### PR TITLE
Add "More..." button to search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,8 @@
 # typed: true
 class SearchController < ApplicationController
+  # Skip bullet on activity to avoid errors.
+  around_action :skip_bullet, if: -> { defined?(Bullet) }
+
   def index
     skip_policy_scope
 
@@ -23,5 +26,15 @@ class SearchController < ApplicationController
     # Flatten search results so it returns the search results as one array
     # rather than as separate arrays.
     @search_results.flatten!
+  end
+
+  private
+
+  def skip_bullet
+    previous_value = Bullet.enable?
+    Bullet.enable = false
+    yield
+  ensure
+    Bullet.enable = previous_value
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,11 +2,26 @@
 class SearchController < ApplicationController
   def index
     skip_policy_scope
-    @search_results = PgSearch.multisearch(params[:query]).limit(15)
+
     # A list of the types of records which can be returned in the multisearch.
     # Intentionally ordered so the most important types come first.
     @searchable_types = %w[
       Game Series Company Platform Engine Genre User
     ]
+    # Return only games if the `only_games` parameter is true.
+    @searchable_types = ['Game'] if params[:only_games]
+
+    @search_results = []
+    # Return up to 15 records for each type of record and paginate if
+    # necessary.
+    @searchable_types.each do |searchable_type|
+      @search_results << PgSearch.multisearch(params[:query])
+                                 .where(searchable_type: searchable_type)
+                                 .page(helpers.page_param)
+                                 .per(15)
+    end
+    # Flatten search results so it returns the search results as one array
+    # rather than as separate arrays.
+    @search_results.flatten!
   end
 end

--- a/app/javascript/src/components/search.vue
+++ b/app/javascript/src/components/search.vue
@@ -53,7 +53,6 @@
         </a>
         <!-- If there are a multiple of 15 games, we can potentially load another page of them. -->
         <a class="navbar-item"
-           :class="{'is-active': activeSearchResult !== -1}"
            v-if="type === 'Game' && betterSearchResults[type].length % 15 === 0"
            @click="onMoreGames"
         >

--- a/app/javascript/src/components/search.vue
+++ b/app/javascript/src/components/search.vue
@@ -51,6 +51,18 @@
             </div>
           </div>
         </a>
+        <!-- If there are a multiple of 15 games, we can potentially load another page of them. -->
+        <a class="navbar-item"
+           :class="{'is-active': activeSearchResult !== -1}"
+           v-if="type === 'Game' && betterSearchResults[type].length % 15 === 0"
+           @click="onMoreGames"
+        >
+          <div class="media">
+            <div class="media-content">
+              <p>More...</p>
+            </div>
+          </div>
+        </a>
       </div>
     </div>
   </div>
@@ -81,7 +93,8 @@ export default {
         Genre: 'genres',
         User: 'users'
       },
-      activeSearchResult: -1
+      activeSearchResult: -1,
+      currentPage: 1
     };
   },
   methods: {
@@ -133,6 +146,18 @@ export default {
         searchDropdown.scrollTop =
           activeItem.offsetTop - searchDropdown.offsetTop;
       }
+    },
+    // Load more games if the user selects "More...".
+    onMoreGames() {
+      this.currentPage += 1;
+      fetch(`${this.searchUrl}?query=${this.query}&page=${this.currentPage}&only_games=true`)
+          .then(response => {
+            return response.json();
+          })
+          .then(searchResults => {
+            this.searchResults['Game'] = this.searchResults['Game'].concat(searchResults['Game']);
+            this.activeSearchResult = -1;
+          });
     }
   },
   computed: {
@@ -162,6 +187,8 @@ export default {
           delete betterSearchResults[key];
           return true;
         }
+        console.log(`key: ${key}`);
+        console.log(betterSearchResults);
         betterSearchResults[key].map(result => {
           // Use the username in the URL if it's a user.
           let url_key = result.searchable_type === 'User' ? result.content : result.searchable_id;

--- a/app/javascript/src/components/search.vue
+++ b/app/javascript/src/components/search.vue
@@ -53,7 +53,7 @@
         </a>
         <!-- If there are a multiple of 15 games, we can potentially load another page of them. -->
         <a class="navbar-item"
-           v-if="type === 'Game' && betterSearchResults[type].length % 15 === 0"
+           v-if="type === 'Game' && betterSearchResults[type].length % 15 === 0 && !moreAlreadyLoaded"
            @click="onMoreGames"
         >
           <div class="media">
@@ -93,7 +93,8 @@ export default {
         User: 'users'
       },
       activeSearchResult: -1,
-      currentPage: 1
+      currentPage: 1,
+      moreAlreadyLoaded: false
     };
   },
   methods: {
@@ -156,6 +157,13 @@ export default {
           .then(searchResults => {
             this.searchResults['Game'] = this.searchResults['Game'].concat(searchResults['Game']);
             this.activeSearchResult = -1;
+            // If there are a multiple of 15 results and no new games are
+            // added, the component will still show a "More..." button. This
+            // sets 'moreAlreadyLoaded' to true to make sure the 'More...'
+            // button is hidden and handle this edge case.
+            if (searchResults['Game'].length === 0) {
+              this.moreAlreadyLoaded = true;
+            }
           });
     }
   },
@@ -186,8 +194,6 @@ export default {
           delete betterSearchResults[key];
           return true;
         }
-        console.log(`key: ${key}`);
-        console.log(betterSearchResults);
         betterSearchResults[key].map(result => {
           // Use the username in the URL if it's a user.
           let url_key = result.searchable_type === 'User' ? result.content : result.searchable_id;

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -69,6 +69,11 @@ FactoryBot.define do
       avg_rating { rand(0..100) }
     end
 
+    # Used for games where we want the names to be unique but sequential.
+    trait :sequential_name do
+      sequence(:name) { |n| "Game Name #{n}" }
+    end
+
     factory :game_with_cover, traits: [:cover]
     factory :game_with_release_date, traits: [:release_date]
     factory :game_with_everything,

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -4,11 +4,14 @@ require 'rails_helper'
 RSpec.describe "Search", type: :request do
   describe "GET search_path" do
     let(:series) { create(:series) }
+    let(:game) { create(:game) }
+    let(:sequential_games) { create_list(:game, 15, :sequential_name) }
+    let(:more_sequential_games) { create_list(:game, 20, :sequential_name) }
 
     it "returns the given series" do
       get search_path(query: series.name, format: :json)
-      expected_response = { searchable_id: series.id, content: series.name, searchable_type: 'Series' }.stringify_keys
-      expect(JSON.parse(response.body)['Series'].first).to include(expected_response)
+      expected_response = { searchable_id: series.id, content: series.name, searchable_type: 'Series' }
+      expect(searchable_helper(response.body, 'Series')).to include(expected_response)
     end
 
     it "returns no item when given a random string" do
@@ -27,6 +30,32 @@ RSpec.describe "Search", type: :request do
         expected_response[type] = []
       end
       expect(response.body).to eq(expected_response.to_json)
+    end
+
+    it "returns game when a query is given" do
+      get search_path(query: game.name, format: :json)
+      expected_response = { searchable_id: game.id, content: game.name, searchable_type: 'Game' }
+      expect(searchable_helper(response.body, 'Game')).to include(expected_response)
+    end
+
+    it "returns games when a query is given and multiple games with similar names exist" do
+      sequential_games
+      get search_path(query: "Game Name", format: :json)
+      expected_response = { searchable_id: sequential_games.first.id, content: sequential_games.first.name, searchable_type: 'Game' }
+      expect(searchable_helper(response.body, 'Game')).to include(expected_response)
+    end
+
+    it "returns games when using only games parameter and paginating" do
+      more_sequential_games
+      get search_path(query: "Game Name", only_games: true, page: 2, format: :json)
+      expected_response = { searchable_id: more_sequential_games[15].id, content: more_sequential_games[15].name, searchable_type: 'Game' }
+      not_expected_response = { searchable_id: more_sequential_games.first.id, content: more_sequential_games.first.name, searchable_type: 'Game' }
+      # Include the 16th game in the sequential list but not the first, since
+      # we're on page 2.
+      expect(searchable_helper(response.body, 'Game')).to include(expected_response)
+      expect(searchable_helper(response.body, 'Game')).not_to include(not_expected_response)
+      # Only return games when only_games parameter is used.
+      expect(JSON.parse(response.body).keys).not_to include(['Series', 'Platform', 'Company', 'User', 'Genre', 'Engine'])
     end
   end
 end

--- a/spec/support/search_test_helper.rb
+++ b/spec/support/search_test_helper.rb
@@ -1,0 +1,41 @@
+# typed: false
+
+# Given a response body, parse the JSON, access the specific type of search
+# result we want, and return just the attributes we want.
+#
+# `searchables` is in this format:
+#
+# ```json
+# {
+#   "Game": [
+#     {
+#       "id": 1932,
+#       "content": "Half-Life 2",
+#       "searchable_type": "Game",
+#       "searchable_id": 1932,
+#       "image_url": null,
+#       "developer": null,
+#       "release_date": null
+#     }
+#   ],
+#   "Series": [],
+#   "Company": [],
+#   "Platform": [],
+#   "Engine": [],
+#   "Genre": [],
+#   "User": []
+# }
+# ```
+#
+# @param [String] searchables The JSON string representing the search results. See format above.
+# @param [String] type The type of returned searchable to filter to, one of ['Game', 'Series', 'Company', 'Platform', 'Engine', 'Genre, 'User']
+# @return [Array<Hash>] A hash with `searchable_id`, `content`, and `searchable_type` keys.
+def searchable_helper(searchables, type)
+  return JSON.parse(searchables)[type].map do |searchable|
+    {
+      searchable_id: searchable['searchable_id'],
+      content: searchable['content'],
+      searchable_type: searchable['searchable_type']
+    }
+  end
+end


### PR DESCRIPTION
Resolves #1247.

It implements pagination on the search endpoint and updates the Search Vue component to support loading a second page for the games if the user requests it. Currently this only works for games since that's the main use case users want this for. This also changes things a bit so there are up to 15 results _per type of item_, rather than 15 items total amongst all the types of items returned.

<img width="309" alt="Screen Shot 2020-07-03 at 10 02 14 AM" src="https://user-images.githubusercontent.com/2977353/86484869-6df52780-bd14-11ea-814e-8e46c452c44e.png">

TODO:

- [x] Make the up/down keys work correctly with this.
