### PR TITLE
Add game merging

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -248,9 +248,9 @@ class GamesController < ApplicationController
 
     respond_to do |format|
       if GameMergeService.new(@game_a, @game_b).merge!
-        format.html { redirect_to @game_a, success: "#{@game_b.name} successfully merged into #{@game_a.name}." }
+        format.json { redirect_to game_path(@game_a), success: "#{@game_b.name} successfully merged into #{@game_a.name}." }
       else
-        format.html { redirect_to @game_a, error: "#{@game_b.name} couldn't be merged into #{@game_a.name} due to an error." }
+        format.json { render json: { errors: ["#{@game_b.name} couldn't be merged into #{@game_a.name} due to an error."] }, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -239,13 +239,18 @@ class GamesController < ApplicationController
     end
   end
 
+  # Merge one game into another and update any associated records as necessary.
   def merge
     @game_a = Game.find(params[:game_a_id])
     @game_b = Game.find(params[:game_b_id])
 
-    if GameMergeService.new(@game_a, @game_b).merge!
-      format.html { redirect_to @game_a, success: "#{@game_b.name} successfully merged into #{@game_a.name}." }
-    else
+    respond_to do |format|
+      if GameMergeService.new(@game_a, @game_b).merge!
+        format.html { redirect_to @game_a, success: "#{@game_b.name} successfully merged into #{@game_a.name}." }
+      else
+        format.html { redirect_to @game_a, error: "#{@game_b.name} couldn't be merged into #{@game_a.name} due to an error." }
+      end
+    end
   end
 
   private

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -241,8 +241,10 @@ class GamesController < ApplicationController
 
   # Merge one game into another and update any associated records as necessary.
   def merge
-    @game_a = Game.find(params[:game_a_id])
+    @game_a = Game.find(params[:id])
     @game_b = Game.find(params[:game_b_id])
+
+    authorize @game_a
 
     respond_to do |format|
       if GameMergeService.new(@game_a, @game_b).merge!

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -239,6 +239,15 @@ class GamesController < ApplicationController
     end
   end
 
+  def merge
+    @game_a = Game.find(params[:game_a_id])
+    @game_b = Game.find(params[:game_b_id])
+
+    if GameMergeService.new(@game_a, @game_b).merge!
+      format.html { redirect_to @game_a, success: "#{@game_b.name} successfully merged into #{@game_a.name}." }
+    else
+  end
+
   private
 
   def game_params

--- a/app/javascript/src/components/merge-games-button.vue
+++ b/app/javascript/src/components/merge-games-button.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <a
+      v-on:click="activateModal"
+      class="dropdown-item has-text-danger js-merge-games-button"
+      data-game-id="gameId">
+      Merge
+    </a>
+
+    <merge-games-modal
+      v-if="isModalActive"
+      :isActive="isModalActive"
+      :game="game"
+      v-on:close="deactivateModal"
+      v-on:closeAndRefresh="closeAndRefresh"
+      v-on:create="onSubmit"
+    ></merge-games-modal>
+  </div>
+</template>
+
+<script lang="ts">
+import MergeGamesModal from './merge-games-modal.vue';
+import Rails from '@rails/ujs';
+import Turbolinks from 'turbolinks';
+
+export default {
+  name: 'merge-games-button',
+  components: {
+    MergeGamesModal
+  },
+  props: {
+    game: {
+      type: Object,
+      required: true,
+      default: function() {
+        return {};
+      }
+    }
+  },
+  data: function() {
+    return {
+      isModalActive: false
+    };
+  },
+  methods: {
+    activateModal(game = {}) {
+      let html = document.querySelector('html');
+      html.classList.add('is-clipped');
+
+      this.isModalActive = true;
+    },
+    deactivateModal() {
+      let html = document.querySelector('html');
+      html.classList.remove('is-clipped');
+
+      this.isModalActive = false;
+    },
+    closeAndRefresh() {
+      this.deactivateModal();
+    },
+    onSubmit() {
+      Turbolinks.visit(window.location.href);
+    }
+  }
+};
+</script>

--- a/app/javascript/src/components/merge-games-modal.vue
+++ b/app/javascript/src/components/merge-games-modal.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="modal" :class="{ 'is-active': isActive }">
+    <div @click="onClose" class="modal-background"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">{{ `Merge ${game.name} into another game` }}</p>
+        <button @click="onClose" class="delete" aria-label="close"></button>
+      </header>
+      <section class="modal-card-body modal-card-body-allow-overflow">
+        <!-- Display errors if there are any. -->
+        <div class="notification errors-notification is-danger" v-if="errors.length > 0">
+          <p>
+            {{ errors.length > 1 ? 'Errors' : 'An error' }} prevented this game from
+            being merged:
+          </p>
+          <ul>
+            <li v-for="error in errors" :key="error">{{ error }}</li>
+          </ul>
+        </div>
+        <div>
+          <single-select
+            :label="'Game'"
+            v-model="gameA"
+            :search-path-identifier="'games'"
+            :max-height="'150px'"
+            @input="selectGame"
+          ></single-select>
+        </div>
+      </section>
+      <footer class="modal-card-foot">
+        <button @click="onSave" class="button is-primary js-submit-button" :disabled="!this.gameSelected">Submit</button>
+        <button @click="onClose" class="button">Cancel</button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import SingleSelect from './fields/single-select.vue';
+import VglistUtils from '../utils';
+import Turbolinks from 'turbolinks';
+
+export default {
+  name: 'merge-games-modal',
+  components: {
+    SingleSelect
+  },
+  props: {
+    game: {
+      type: Object,
+      required: true,
+      default: function() {
+        return {};
+      }
+    },
+    isActive: {
+      type: Boolean,
+      required: true
+    }
+  },
+  data() {
+    return {
+      errors: [],
+      gameSelected: false,
+      gameA: null
+    };
+  },
+  methods: {
+    onClose() {
+      this.$emit('close');
+    },
+    onSave() {
+      let gameAId = this.gameA.id;
+      let gameBId = this.game.id;
+      let mergePath = `/games/${gameAId}/merge/${gameBId}.json`;
+      VglistUtils.rawAuthenticatedFetch(
+        mergePath,
+        'POST'
+      ).then(response => {
+        // HTTP 301 response
+        if (response.redirected) {
+          Turbolinks.clearCache();
+          Turbolinks.visit(response.url);
+        // If it's not a redirect, check it for errors and display them.
+        } else {
+          response.json().then(json => {
+            this.errors = json.errors
+          });
+          let submitButton = document.querySelector('.js-submit-button');
+          submitButton.classList.add('js-submit-button-error');
+          setTimeout(() => {
+            submitButton.classList.remove('js-submit-button-error');
+          }, 2000);
+        }
+      });
+    },
+    selectGame() {
+      this.gameSelected = true;
+    }
+  }
+};
+</script>

--- a/app/policies/game_policy.rb
+++ b/app/policies/game_policy.rb
@@ -65,4 +65,9 @@ class GamePolicy < ApplicationPolicy
   def add_to_wikidata_blocklist?
     user&.admin?
   end
+
+  sig { returns(T.nilable(T::Boolean)) }
+  def merge?
+    user&.admin?
+  end
 end

--- a/app/services/game_merge_service.rb
+++ b/app/services/game_merge_service.rb
@@ -18,6 +18,9 @@ class GameMergeService
   # Merge the two games together.
   sig { returns(T::Boolean) }
   def merge!
+    # Cannot merge a game into itself, return early.
+    return false if @game_a.id == @game_b.id
+
     # Update all relevant game purchases and favorites, delete game purchases
     # and favorites if a user has both of these games owned/favorited.
     handle_purchases

--- a/app/services/game_merge_service.rb
+++ b/app/services/game_merge_service.rb
@@ -1,0 +1,35 @@
+# typed: true
+
+# A service for merging two games together.
+class GameMergeService
+  extend T::Sig
+
+  attr_accessor :game_a
+  attr_accessor :game_b
+
+  def initialize(game_a, game_b)
+    @game_a = game_a
+    @game_b = game_b
+  end
+
+  # Merge the two games together.
+  def merge!
+    # Update all the game purchase records
+    # TODO: Handle the case where a user has both games in their library.
+    @game_b_purchases = GamePurchase.where(game_id: @game_b.id)
+    @game_b_purchases.each do |purchase|
+      purchase.update(game_id: @game_a.id)
+    end
+
+    # Update all the favorites
+    # TODO: Handle the case where a user has both games favorited.
+    @game_b_favorites = FavoriteGame.where(game_id: @game_b.id)
+    @game_b_favorites.each do |favorite|
+      favorite.update(game_id: @game_a.id)
+    end
+
+    # Delete Game B.
+    @game_b.destroy!
+    return true
+  end
+end

--- a/app/services/game_merge_service.rb
+++ b/app/services/game_merge_service.rb
@@ -18,12 +18,10 @@ class GameMergeService
   # Merge the two games together.
   sig { returns(T::Boolean) }
   def merge!
-    # Update all the game purchase records
-    # TODO: Handle the case where a user has both games in their library.
-    @game_b.game_purchases.update_all(game_id: @game_a.id)
-    # Update all the game favorite records
-    # TODO: Handle the case where a user has both games in their library.
-    @game_b.favorites.update_all(game_id: @game_a.id)
+    # Update all relevant game purchases and favorites, delete game purchases
+    # and favorites if a user has both of these games owned/favorited.
+    handle_purchases
+    handle_favorites
 
     # Reload to make sure that destroying game_b doesn't attempt to destroy
     # favorites or game purchases that are no longer associated with it.
@@ -31,6 +29,37 @@ class GameMergeService
 
     # Delete Game B.
     @game_b.destroy!
+
     return true
+  end
+
+  private
+
+  sig { void }
+  def handle_purchases
+    game_a_purchasers = @game_a.game_purchases.pluck(:user_id)
+    game_b_purchasers = @game_b.game_purchases.pluck(:user_id)
+    users_who_own_both_games = game_a_purchasers & game_b_purchasers
+
+    users_who_own_both_games.each do |user_id|
+      GamePurchase.find_by(game_id: @game_b.id, user_id: user_id)&.destroy!
+    end
+
+    # Update all the game purchase records
+    @game_b.game_purchases.update_all(game_id: @game_a.id) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  sig { void }
+  def handle_favorites
+    game_a_favoriters = @game_a.favorites.pluck(:user_id)
+    game_b_favoriters = @game_b.favorites.pluck(:user_id)
+    users_who_favorited_both_games = game_a_favoriters & game_b_favoriters
+
+    users_who_favorited_both_games.each do |user_id|
+      FavoriteGame.find_by(game_id: @game_b.id, user_id: user_id)&.destroy!
+    end
+
+    # Update all the game favorite records
+    @game_b.favorites.update_all(game_id: @game_a.id) # rubocop:disable Rails/SkipsModelValidations
   end
 end

--- a/app/services/game_merge_service.rb
+++ b/app/services/game_merge_service.rb
@@ -4,29 +4,30 @@
 class GameMergeService
   extend T::Sig
 
+  sig { returns(Game) }
   attr_accessor :game_a
+  sig { returns(Game) }
   attr_accessor :game_b
 
+  sig { params(game_a: Game, game_b: Game).void }
   def initialize(game_a, game_b)
     @game_a = game_a
     @game_b = game_b
   end
 
   # Merge the two games together.
+  sig { returns(T::Boolean) }
   def merge!
     # Update all the game purchase records
     # TODO: Handle the case where a user has both games in their library.
-    @game_b_purchases = GamePurchase.where(game_id: @game_b.id)
-    @game_b_purchases.each do |purchase|
-      purchase.update(game_id: @game_a.id)
-    end
+    @game_b.game_purchases.update_all(game_id: @game_a.id)
+    # Update all the game favorite records
+    # TODO: Handle the case where a user has both games in their library.
+    @game_b.favorites.update_all(game_id: @game_a.id)
 
-    # Update all the favorites
-    # TODO: Handle the case where a user has both games favorited.
-    @game_b_favorites = FavoriteGame.where(game_id: @game_b.id)
-    @game_b_favorites.each do |favorite|
-      favorite.update(game_id: @game_a.id)
-    end
+    # Reload to make sure that destroying game_b doesn't attempt to destroy
+    # favorites or game purchases that are no longer associated with it.
+    @game_b.reload
 
     # Delete Game B.
     @game_b.destroy!

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -52,7 +52,7 @@
   <% end %>
 
   <% if policy(@game).update? || policy(@game).destroy? %>
-    <div id="actions-dropdown" class="dropdown is-right is-fullwidth-mobile mr-5 mr-0-mobile">
+    <div id="actions-dropdown" class="dropdown is-right is-fullwidth-mobile mr-5 mr-0-mobile js-no-close-on-click">
       <div class="dropdown-trigger is-fullwidth-mobile">
         <button class="button is-fullwidth-mobile" aria-haspopup="true" aria-controls="dropdown-menu">
           <span>Actions</span>
@@ -73,7 +73,15 @@
             <%= link_to "Add to Wikidata Blocklist", add_to_wikidata_blocklist_game_path(@game.id), method: :post, data: { confirm: "You sure?" }, class: "dropdown-item has-text-danger" %>
           <% end %>
           <% if policy(@game).merge? %>
-            <%= link_to "Merge", merge_game_path(id: @game.id, game_b_id: @game.id), method: :post, data: { confirm: "You sure?" }, class: "dropdown-item has-text-danger" %>
+            <div data-vue-component="merge-games-button"
+              data-vue-props="<%=
+                {
+                  game: {
+                    id: @game.id,
+                    name: @game.name
+                  }
+                }.to_json
+              %>"></div>
           <% end %>
           <% if policy(@game).destroy? %>
             <%= link_to "Delete", game_path(@game.id), method: :delete, data: { confirm: "You sure?" }, class: "dropdown-item has-text-danger" %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -69,8 +69,11 @@
           <% if @game.cover.attached? && policy(@game).remove_cover? %>
             <%= link_to "Remove cover", remove_cover_game_path(@game.id), method: :delete, data: { confirm: "You sure?" }, class: "dropdown-item has-text-danger" %>
           <% end %>
-          <% if policy(@game).add_to_wikidata_blocklist? && !@game.wikidata_id.nil?%>
+          <% if policy(@game).add_to_wikidata_blocklist? && !@game.wikidata_id.nil? %>
             <%= link_to "Add to Wikidata Blocklist", add_to_wikidata_blocklist_game_path(@game.id), method: :post, data: { confirm: "You sure?" }, class: "dropdown-item has-text-danger" %>
+          <% end %>
+          <% if policy(@game).merge? %>
+            <%= link_to "Merge", merge_game_path(id: @game.id, game_b_id: @game.id), method: :post, data: { confirm: "You sure?" }, class: "dropdown-item has-text-danger" %>
           <% end %>
           <% if policy(@game).destroy? %>
             <%= link_to "Delete", game_path(@game.id), method: :delete, data: { confirm: "You sure?" }, class: "dropdown-item has-text-danger" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
     post :favorite, on: :member
     delete :unfavorite, on: :member
     get :favorited, on: :member
+    # Path like `/games/:id/merge/:game_b_id`
+    post :merge, on: :member, path: 'merge/:game_b_id'
 
     post :add_to_wikidata_blocklist, on: :member
   end

--- a/spec/policies/game_policy_spec.rb
+++ b/spec/policies/game_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GamePolicy, type: :policy do
     let(:user) { create(:user) }
     let(:game) { create(:game) }
 
-    it 'can do everything except delete games and covers' do
+    it 'can do most things' do
       expect(game_policy).to permit_actions(
         [
           :index,
@@ -25,11 +25,12 @@ RSpec.describe GamePolicy, type: :policy do
       )
     end
 
-    it 'cannot delete games or remove covers' do
+    it 'cannot delete games, remove covers, or merge games' do
       expect(game_policy).to forbid_actions(
         [
           :destroy,
-          :remove_cover
+          :remove_cover,
+          :merge
         ]
       )
     end
@@ -39,7 +40,7 @@ RSpec.describe GamePolicy, type: :policy do
     let(:user) { create(:moderator) }
     let(:game) { create(:game) }
 
-    it "can do everything" do
+    it "can do almost everything" do
       expect(game_policy).to permit_actions(
         [
           :index,
@@ -56,6 +57,10 @@ RSpec.describe GamePolicy, type: :policy do
           :favorited
         ]
       )
+    end
+
+    it 'cannot merge games' do
+      expect(game_policy).to forbid_actions([:merge])
     end
   end
 
@@ -77,7 +82,8 @@ RSpec.describe GamePolicy, type: :policy do
           :remove_cover,
           :favorite,
           :unfavorite,
-          :favorited
+          :favorited,
+          :merge
         ]
       )
     end
@@ -101,7 +107,8 @@ RSpec.describe GamePolicy, type: :policy do
           :remove_cover,
           :favorite,
           :unfavorite,
-          :favorited
+          :favorited,
+          :merge
         ]
       )
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -371,8 +371,7 @@ RSpec.describe "Users", type: :request do
 
     it "removes the avatar from the current user" do
       sign_in(user)
-      delete remove_avatar_user_path(user.id),
-        params: { id: user.id }
+      delete remove_avatar_user_path(user.id)
       expect(response).to redirect_to(user_url(user))
       # Need to follow redirect for the flash message to show up.
       follow_redirect!
@@ -381,8 +380,7 @@ RSpec.describe "Users", type: :request do
 
     it "doesn't let a user remove the avatar from a different user" do
       sign_in(another_user)
-      delete remove_avatar_user_path(user.id),
-        params: { id: user.id }
+      delete remove_avatar_user_path(user.id)
       expect(response).to redirect_to(root_path)
       expect(user.reload.avatar).to be_attached
     end
@@ -394,8 +392,7 @@ RSpec.describe "Users", type: :request do
 
     it "removes the Steam account from the current user" do
       sign_in(user_with_external_account)
-      delete disconnect_steam_user_path(user_with_external_account.id),
-        params: { id: user_with_external_account.id }
+      delete disconnect_steam_user_path(user_with_external_account.id)
       expect(response).to redirect_to(settings_import_path)
       # Need to follow redirect for the flash message to show up.
       follow_redirect!
@@ -404,8 +401,7 @@ RSpec.describe "Users", type: :request do
 
     it "does not remove the Steam account from the current user if they have no Steam account connected" do
       sign_in(user)
-      delete disconnect_steam_user_path(user.id),
-        params: { id: user.id }
+      delete disconnect_steam_user_path(user.id)
       expect(response).to redirect_to(settings_import_path)
       # Need to follow redirect for the flash message to show up.
       follow_redirect!
@@ -419,8 +415,7 @@ RSpec.describe "Users", type: :request do
 
     it "removes game purchases from the current user" do
       sign_in(user_with_game_purchase)
-      delete reset_game_library_user_path(user_with_game_purchase.id),
-        params: { id: user_with_game_purchase.id }
+      delete reset_game_library_user_path(user_with_game_purchase.id)
       expect(response).to redirect_to(user_path(user_with_game_purchase))
       # Need to follow redirect for the flash message to show up.
       follow_redirect!
@@ -430,8 +425,7 @@ RSpec.describe "Users", type: :request do
     it "removes all game purchases from the current user" do
       sign_in(user_with_game_purchase)
       expect do
-        delete reset_game_library_user_path(user_with_game_purchase.id),
-          params: { id: user_with_game_purchase.id }
+        delete reset_game_library_user_path(user_with_game_purchase.id)
       end.to change(GamePurchase, :count).by(-1)
 
       expect(GamePurchase.find_by(user_id: user_with_game_purchase.id)).to be(nil)
@@ -439,8 +433,7 @@ RSpec.describe "Users", type: :request do
 
     it "removes game purchases from the current user even if they don't have any game purchases" do
       sign_in(user)
-      delete reset_game_library_user_path(user.id),
-        params: { id: user.id }
+      delete reset_game_library_user_path(user.id)
       expect(response).to redirect_to(user_path(user))
       # Need to follow redirect for the flash message to show up.
       follow_redirect!

--- a/spec/services/game_merge_service_spec.rb
+++ b/spec/services/game_merge_service_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe GameMergeService, type: :service do
     let!(:game_a) { create(:game) }
     let!(:game_b) { create(:game) }
     let(:user) { create(:user) }
+    let(:game_a_purchase) { create(:game_purchase, game: game_a, user: user) }
+    let(:game_a_favorite) { create(:favorite_game, game: game_a, user: user) }
     let(:game_b_purchase) { create(:game_purchase, game: game_b, user: user) }
     let(:game_b_favorite) { create(:favorite_game, game: game_b, user: user) }
 
@@ -27,6 +29,22 @@ RSpec.describe GameMergeService, type: :service do
       game_b_favorite
       GameMergeService.new(game_a, game_b).merge!
       expect(game_b_favorite.reload.game_id).to eq(game_a.id)
+    end
+
+    it 'when the user owns both games results in purchase of game_b being deleted' do
+      game_a_purchase
+      game_b_purchase
+      GameMergeService.new(game_a, game_b).merge!
+      # For whatever reason, be_destroyed doesn't work here.
+      expect(GamePurchase.exists?(game_b_purchase.id)).to eq(false)
+    end
+
+    it 'when the user favorites both games results in favorite of game_b being deleted' do
+      game_a_favorite
+      game_b_favorite
+      GameMergeService.new(game_a, game_b).merge!
+      # For whatever reason, be_destroyed doesn't work here.
+      expect(FavoriteGame.exists?(game_b_favorite.id)).to eq(false)
     end
   end
 end

--- a/spec/services/game_merge_service_spec.rb
+++ b/spec/services/game_merge_service_spec.rb
@@ -46,5 +46,13 @@ RSpec.describe GameMergeService, type: :service do
       # For whatever reason, be_destroyed doesn't work here.
       expect(FavoriteGame.exists?(game_b_favorite.id)).to eq(false)
     end
+
+    it 'returns false when merging a game into itself' do
+      expect(GameMergeService.new(game_a, game_a).merge!).to eq(false)
+    end
+
+    it 'does not delete the game when merging into itself' do
+      expect { GameMergeService.new(game_a, game_a).merge! }.to change(Game, :count).by(0)
+    end
   end
 end

--- a/spec/services/game_merge_service_spec.rb
+++ b/spec/services/game_merge_service_spec.rb
@@ -1,0 +1,32 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe GameMergeService, type: :service do
+  describe "merging two games" do
+    let!(:game_a) { create(:game) }
+    let!(:game_b) { create(:game) }
+    let(:user) { create(:user) }
+    let(:game_b_purchase) { create(:game_purchase, game: game_b, user: user) }
+    let(:game_b_favorite) { create(:favorite_game, game: game_b, user: user) }
+
+    it 'results in game_b being deleted' do
+      GameMergeService.new(game_a, game_b).merge!
+      expect(game_a).not_to be_destroyed
+      expect(game_b).to be_destroyed
+    end
+
+    it 'results in purchases of game_b being updated' do
+      user
+      game_b_purchase
+      GameMergeService.new(game_a, game_b).merge!
+      expect(game_b_purchase.reload.game_id).to eq(game_a.id)
+    end
+
+    it 'results in favorites of game_b being updated' do
+      user
+      game_b_favorite
+      GameMergeService.new(game_a, game_b).merge!
+      expect(game_b_favorite.reload.game_id).to eq(game_a.id)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #171.

This adds the ability for admins to merge two game records together, and handles updating all associated game purchases and favorites. It also adds tests for all this new functionality.

For admins, it adds a merge button to the actions dropdown:

<img width="440" alt="Screen Shot 2020-07-13 at 4 38 43 PM" src="https://user-images.githubusercontent.com/2977353/87360450-61987800-c527-11ea-8553-ff547379bb71.png">

The merge button opens a dialog where the user can pick what game to merge the current game into:

![image](https://user-images.githubusercontent.com/2977353/87360452-62c9a500-c527-11ea-9335-54702c271064.png)

This doesn't add anything for redirecting the game record to the newly-merged record, but that should probably be added at some point.