### PR TITLE
Fix sorting by average rating

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -38,11 +38,11 @@ class Game < ApplicationRecord
   scope :least_recently_updated, -> { order("updated_at asc") }
   # Sort by average rating.
   # Must have at least 5 owners w/ ratings to be included.
+  # Also check that the avg_rating column isn't nil to preven[t weirdness in
+  # certain cases where the game record becomes invalid.
   scope :highest_avg_rating, -> {
     joins(:game_purchases)
       .where.not('game_purchases.rating': nil)
-      # Check that the avg_rating column isn't nil to prevent weirdness in
-      # certain cases where the game record becomes invalid.
       .where.not('games.avg_rating': nil)
       .group('games.id')
       .having("count(game_purchases.id) >= ?", 5)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -41,6 +41,9 @@ class Game < ApplicationRecord
   scope :highest_avg_rating, -> {
     joins(:game_purchases)
       .where.not('game_purchases.rating': nil)
+      # Check that the avg_rating column isn't nil to prevent weirdness in
+      # certain cases where the game record becomes invalid.
+      .where.not('games.avg_rating': nil)
       .group('games.id')
       .having("count(game_purchases.id) >= ?", 5)
       .order("avg_rating desc")

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -37,7 +37,7 @@ class Game < ApplicationRecord
   scope :recently_updated, -> { order("updated_at desc") }
   scope :least_recently_updated, -> { order("updated_at asc") }
   # Sort by average rating.
-  # Must have at least 5 owners to be included.
+  # Must have at least 5 owners w/ ratings to be included.
   scope :highest_avg_rating, -> {
     joins(:game_purchases)
       .where.not('game_purchases.rating': nil)

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -300,6 +300,23 @@ RSpec.describe Game, type: :model do
       end
     end
 
+    context 'when sorting by average rating with three games where one has no ratings' do
+      let!(:game1) { create(:game) }
+      let!(:game2) { create(:game) }
+      let!(:game3) { create(:game) }
+      # rubocop:disable RSpec/LetSetup
+      # These are necessary because the average rating scope depends on there
+      # being at least 5 owners of the game with an actual rating.
+      let!(:game_purchases1) { create_list(:game_purchase, 5, game: game1, rating: 30) }
+      let!(:game_purchases2) { create_list(:game_purchase, 5, game: game2, rating: 60) }
+      let!(:game_purchases3) { create_list(:game_purchase, 5, game: game3, rating: nil) }
+      # rubocop:enable RSpec/LetSetup
+
+      it "return the two non-nil games in proper order" do
+        expect(Game.highest_avg_rating).to eq([game2, game1])
+      end
+    end
+
     context 'with three games where two have platforms and one does not' do
       let(:platform1) { create(:platform) }
       let(:platform2) { create(:platform) }


### PR DESCRIPTION
Kingdom Hearts HD 1.5 reMIX has a NULL average rating but it's sorted at the top of the average rating sort because nulls get sorted first, and it has multiple game_purchases associated with it that have ratings so the scope doesn't exclude it.

So I _think_ what's happening here is that someone somehow added an invalid cover (maybe it's a webp or >5MB or something, idk how the hell it got added without failing validation but whatever). The game can be added to your library, which causes it to attempt to update the average rating, but that fails because the cover is invalid, which is why it has a few people who have rated it but a null average rating.