### PR TITLE
Improve the search input style

### DIFF
--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -665,13 +665,30 @@ nav.navbar {
 
 // Styling for the navbar search field, mostly the icon.
 .navbar-search-input {
+  background-color: rgba(255, 255, 255, 0.25);
+  border: 0;
+  transition: background-color 250ms;
+
+  &::placeholder {
+    color: #fff;
+    transition: color 250ms;
+  }
+
   + span.icon {
-    fill: $grey-light;
+    fill: rgba(255, 255, 255, 0.5);
     transition: fill 250ms;
   }
-  
-  &:focus + span.icon {
-    fill: darken($grey-light, 30%);
+
+  &:focus {
+    background-color: rgba(255, 255, 255, 1);
+
+    + span.icon {
+      fill: darken($grey-light, 30%);
+    }
+
+    &::placeholder {
+      color: #333;
+    }
   }
 }
 


### PR DESCRIPTION
Before:

<img width="714" alt="Screen Shot 2020-08-23 at 4 32 38 PM" src="https://user-images.githubusercontent.com/2977353/90990388-4d9c5900-e55e-11ea-96a3-58bd5d3d0bf8.png">

After:

<img width="678" alt="Screen Shot 2020-08-23 at 4 30 38 PM" src="https://user-images.githubusercontent.com/2977353/90990369-29d91300-e55e-11ea-8733-f6fe188921c6.png">

When it gets focus now, it looks pretty much the same as the Before image.
