### PR TITLE
Add a dark mode

### DIFF
--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -22,6 +22,8 @@
 
   --dropdown-icon-fill: $dropdown-content-arrow;
 
+  --text-muted: var(--grey, #7a7a7a);
+
   --vglist-default-fill: #585858;
 }
 
@@ -53,6 +55,8 @@
     --input-disabled-border-color: transparent;
     --input-background-color: #445168;
     --input-disabled-background-color: #445168;
+
+    --text-muted: var(--grey-lighter, #dbdbdb);
 
     --vglist-default-fill: var(--white);
     --dropdown-icon-fill: var(--vglist-default-fill);
@@ -857,6 +861,7 @@ nav.navbar {
   border: 0px;
 }
 
+// Custom vue-select styles.
 .v-select {
   border: 1px solid var(--input-border-color);
   border-radius: var(--input-radius);
@@ -881,20 +886,20 @@ nav.navbar {
 
   .vs__dropdown-menu {
     background-color: var(--scheme-alt);
-    color: var(--text-color);
+    color: var(--text);
   }
 
   .vs__selected {
-    color: var(--text-color);
+    color: var(--text);
   }
 
   &:not(.vs--single) .vs__selected-options .vs__selected {
-    color: var(--text-color);
+    color: var(--text);
     background-color: var(--scheme-alt);
   }
 
   .vs__dropdown-option {
-    color: var(--text-color);
+    color: var(--text);
   }
 
   // Set the fill of the icons in v-select inputs.
@@ -918,4 +923,10 @@ nav.navbar {
     color: var(--input-disabled-color);
     background-color: transparent;
   }
+}
+
+// For text that should have a more muted color, e.g. extra information in
+// a card.
+.has-text-muted {
+  color: var(--text-muted);
 }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -173,6 +173,8 @@ html {
 }
 
 nav.navbar {
+  --navbar-menu-background-color: var(--vglist-theme);
+
   background: var(--vglist-theme);
   // Subtle box-shadow for nav bar.
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.3);
@@ -404,7 +406,7 @@ nav.navbar {
 }
 
 .custom-card {
-  --card-radius: var(--radius-large);
+  --card-radius: var(--radius);
 
   background-color: var(--card-background-color, #fff);
   box-shadow: var(--vglist-shadow);
@@ -876,18 +878,7 @@ nav.navbar {
 
 // Custom vue-select styles.
 .v-select {
-  border: 1px solid var(--input-border-color);
-  border-radius: var(--input-radius);
   background-color: var(--input-background-color);
-
-  &:hover {
-    border: 1px solid var(--input-hover-border-color);
-  }
-
-  &:focus,
-  &.vs--open {
-    border: 1px solid var(--input-focus-border-color);
-  }
 
   .vs__search {
     color: var(--input-color);
@@ -902,6 +893,20 @@ nav.navbar {
     color: var(--text);
   }
 
+  .vs__dropdown-toggle {
+    border: 1px solid var(--input-border-color);
+    border-radius: var(--input-radius);
+
+    &:hover {
+      border: 1px solid var(--input-hover-border-color);
+    }
+
+    &:focus,
+    &.vs--open {
+      border: 1px solid var(--input-focus-border-color);
+    }
+  }
+
   .vs__selected {
     color: var(--text);
   }
@@ -913,6 +918,12 @@ nav.navbar {
 
   .vs__dropdown-option {
     color: var(--text);
+
+    // When highlighted, it should have white text since it always has a blue
+    // background.
+    &.vs__dropdown-option--highlight {
+      color: var(--white);
+    }
   }
 
   // Set the fill of the icons in v-select inputs.
@@ -945,9 +956,9 @@ nav.navbar {
 }
 
 .box {
-  --box-radius: var(--radius-large);
+  --box-radius: var(--radius);
 }
 
 .card {
-  --card-radius: var(--radius-large);
+  --card-radius: var(--radius);
 }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -114,6 +114,10 @@
   .modal-close::after {
     background-color: var(--white);
   }
+
+  .modal-background {
+    --modal-background-background-color: rgba(10.2, 10.2, 10.2, 0.86);
+  }
 }
 
 html {

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -19,15 +19,19 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    --white: #fff;
+    --white-rgb: 255, 255, 255;
+
     --card-background-color: #333;
-    --text: #fff;
+    --text: var(--white);
     --scheme-main: #333;
-    --custom-card-drop-shadow-color: #fff;
-    --custom-card-drop-shadow-color-rgb: 255, 255, 255;
-    --dropdown-link-no-highlight: #fff;
+    --scheme-invert-rgb: 255, 255, 255;
+    --custom-card-drop-shadow-color: var(--white);
+    --custom-card-drop-shadow-color-rgb: var(--white-rgb);
+    --dropdown-link-no-highlight: var(--white);
     --home-section-background-color: #333;
     --home-section-background-brightness: 75%;
-    --navbar-dropdown-item-color: #fff;
+    --navbar-dropdown-item-color: var(--white);
     --navbar-item-background-hover: #444;
   }
 
@@ -40,17 +44,18 @@
   }
 
   .table {
-    --table-color: #fff;
+    --table-color: var(--white);
     --table-head-cell-color: var(--table-color);
     --table-foot-cell-color: var(--table-color);
+    --table-striped-row-even-background-color: var(--table-body-background-color);
   }
 
   .box {
-    --box-shadow: 0 2px 3px rgba(255, 255, 255, 0.1), 0 0 0 1px rgba(255, 255, 255, 0.1)
+    --box-shadow: 0 2px 3px rgba(var(--white-rgb), 0.1), 0 0 0 1px rgba(var(--white-rgb), 0.1)
   }
 
   .title {
-    --title-color: #fff;
+    --title-color: var(--white);
   }
 
   body {
@@ -62,7 +67,7 @@
   }
 
   .label {
-    --label-color: #fff;
+    --label-color: var(--white);
   }
 
   .notification {
@@ -70,16 +75,17 @@
   }
 
   a:hover {
-    color: #fff;
+    color: var(--white);
   }
 
   .button {
     background-color: #444;
-    color: #fff;
+    color: var(--white);
+    border-color: #afafaf;
 
     &:hover {
       background-color: #333;
-      color: #fff;
+      color: var(--white);
     }
   }
 
@@ -89,8 +95,24 @@
   }
 
   .tabs {
-    --tabs-link-hover-border-bottom-color: #fff;
-    --tabs-link-hover-color: #fff;
+    --tabs-link-hover-border-bottom-color: var(--white);
+    --tabs-link-hover-color: var(--white);
+  }
+
+  .menu {
+    --menu-item-hover-background-color: rgba(var(--white-rgb), 90%)
+  }
+
+  .modal {
+    --modal-card-head-background-color: #333;
+    --modal-card-title-color: var(--white);
+  }
+
+  .delete::before,
+  .modal-close::before,
+  .delete::after,
+  .modal-close::after {
+    background-color: var(--white);
   }
 }
 

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -138,7 +138,8 @@
   }
 
   .menu {
-    --menu-item-hover-background-color: rgba(var(--white-rgb), 90%);
+    --menu-item-hover-background-color: var(--scheme-secondary);
+    --menu-item-hover-color: var(--white);
     --menu-label-color: var(--white);
   }
 

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -15,6 +15,7 @@
   --dropdown-link-no-highlight: #000;
   --navbar-dropdown-item-color: #333;
   --navbar-item-background-hover: #eeeded;
+  --library-edit-bar-border: #fff;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -35,6 +36,7 @@
     --navbar-dropdown-item-color: var(--white);
     --navbar-item-background-hover: var(--scheme-secondary);
     --vglist-shadow: 0 2px 3px rgba(12, 12, 12, 0.1), 0 0 0 1px rgba(12, 12, 12, 0.1);
+    --library-edit-bar-border: #435169;
   }
 
   .navbar {
@@ -719,8 +721,8 @@ nav.navbar {
   position: sticky;
   top: 0;
   width: 100%;
-  background-color: #fff;
-  border: 1px solid #dcdfe6;
+  background-color: var(--scheme-main, #fff);
+  border: 1px solid var(--library-edit-bar-border);
   margin-bottom: 5px;
   // Modal overlay is 40, make sure to stay below it.
   z-index: 39;

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -37,6 +37,7 @@
     --navbar-item-background-hover: var(--scheme-secondary);
     --vglist-shadow: 0 2px 3px rgba(12, 12, 12, 0.1), 0 0 0 1px rgba(12, 12, 12, 0.1);
     --library-edit-bar-border: #435169;
+    --input-color: var(--white);
   }
 
   .navbar {
@@ -93,21 +94,12 @@
   }
 
   .button {
-    background-color: var(--scheme-alt);
-    color: var(--white);
-    border-color: transparent;
-    
-    &:hover {
-      background-color: var(--scheme-secondary);
-      color: var(--white);
-      border-color: transparent;
-    }
-  }
-
-  .button[disabled],
-  fieldset[disabled] .button {
-    background-color: var(--scheme-alt);
-    border-color: transparent;
+    --button-color: var(--white);
+    --button-hover-color: var(--white);
+    --button-active-color: var(--white);
+    --button-focus-color: var(--white);
+    --button-active-border-color: var(--white);
+    --button-focus-border-color: var(--white);
   }
 
   .tabs {

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -962,3 +962,10 @@ nav.navbar {
 .card {
   --card-radius: var(--radius);
 }
+
+// FIXME: A temporary hack until the vue-good-table dark theme styling is
+// fixed. Without this, it'll try to use a light grey background for the
+// headers on the compare library page.
+.vgt-table th.vgt-row-header {
+  background-color: var(--scheme-main) !important;
+}

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -967,5 +967,7 @@ nav.navbar {
 // fixed. Without this, it'll try to use a light grey background for the
 // headers on the compare library page.
 .vgt-table th.vgt-row-header {
-  background-color: var(--scheme-main) !important;
+  @media (prefers-color-scheme: dark) {
+    background-color: var(--scheme-main) !important;
+  }
 }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -4,8 +4,86 @@
 @import './stylesheets/utilities.scss';
 @import './stylesheets/home.scss';
 
+:root {
+  --vglist-theme: #5856d6;
+
+  --home-page-subtitle-text: #fff;
+  --custom-card-drop-shadow-color: #000;
+  --custom-card-drop-shadow-color-rgb: 10, 10, 10;
+  --dropdown-link-no-highlight: #000;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --card-background-color: #333;
+    --text: #fff;
+    --scheme-main: #333;
+    --custom-card-drop-shadow-color: #fff;
+    --custom-card-drop-shadow-color-rgb: 255, 255, 255;
+    --dropdown-link-no-highlight: #fff;
+  }
+
+  .table {
+    --table-color: #fff;
+    --table-head-cell-color: var(--table-color);
+    --table-foot-cell-color: var(--table-color);
+  }
+
+  .box {
+    --box-shadow: 0 2px 3px rgba(255, 255, 255, 0.1), 0 0 0 1px rgba(255, 255, 255, 0.1)
+  }
+
+  .title {
+    --title-color: #fff;
+  }
+
+  body {
+    color: var(--text);
+  }
+
+  code {
+    background-color: #222;
+  }
+
+  .label {
+    --label-color: #fff;
+  }
+
+  .notification {
+    --notification-background-color: #444;
+  }
+
+  a:hover {
+    color: #fff;
+  }
+
+  .button {
+    background-color: #444;
+    color: #fff;
+
+    &:hover {
+      background-color: #333;
+      color: #fff;
+    }
+  }
+
+  .button[disabled],
+  fieldset[disabled] .button {
+    background-color: transparent;
+  }
+
+  .tabs {
+    --tabs-link-hover-border-bottom-color: #fff;
+    --tabs-link-hover-color: #fff;
+  }
+}
+
+html {
+  background-color: var(--scheme-main, #fff);
+}
+
 nav.navbar {
-  background: #5856d6;
+  background: var(--vglist-theme);
   // Subtle box-shadow for nav bar.
   box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.3);
   padding: 0 20px;
@@ -114,7 +192,7 @@ nav.navbar {
   }
 
   .dropdown-item.no-link-highlight a {
-    color: #000;
+    color: var(--dropdown-link-no-highlight);
   }
 }
 
@@ -236,8 +314,8 @@ nav.navbar {
 }
 
 .custom-card {
-  background-color: #fff;
-  box-shadow: 0 2px 3px rgba(#000, 0.1), 0 0 0 1px rgba(#000, 0.1);
+  background-color: var(--card-background-color, #fff);
+  box-shadow: 0 2px 3px rgba(var(--custom-card-drop-shadow-color-rgb), 0.1), 0 0 0 1px rgba(var(--custom-card-drop-shadow-color-rgb), 0.1);
   color: hsl(0, 0%, 21%);
   width: auto;
   position: relative;
@@ -669,11 +747,6 @@ nav.navbar {
   border: 0;
   border-radius: 3px;
   transition: background-color 250ms;
-
-  &::placeholder {
-    color: #fff;
-    transition: color 250ms;
-  }
 
   + span.icon {
     fill: rgba(255, 255, 255, 0.5);

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -10,12 +10,13 @@
   --home-section-background-color: var(--vglist-theme);
   --home-section-background-brightness: 85%;
 
+  --vglist-shadow: 0 2px 3px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.1);
   --custom-card-drop-shadow-color: #000;
   --custom-card-drop-shadow-color-rgb: 10, 10, 10;
   --dropdown-link-no-highlight: #000;
   --navbar-dropdown-item-color: #333;
   --navbar-item-background-hover: #eeeded;
-  --library-edit-bar-border: #fff;
+  --library-edit-bar-border: #dcdfe6;
   --input-radius: 4px;
   --scheme-alt: #fff;
   --input-placeholder-color: #333;
@@ -39,7 +40,7 @@
     --scheme-secondary: #445168;
     --scheme-invert-rgb: 255, 255, 255;
 
-    --card-background-color: var(--scheme-main);
+    --card-background-color: var(--scheme-alt);
     --dropdown-link-no-highlight: var(--white);
     --home-section-background-color: var(--scheme-main);
     --home-section-background-brightness: 75%;
@@ -58,6 +59,7 @@
     --input-disabled-background-color: #445168;
     --code-background: var(--scheme-secondary);
     --code: var(--white);
+    --link: #209ad9;
     --link-hover: var(--white);
 
     --text-muted: var(--grey-lighter, #dbdbdb);
@@ -120,12 +122,16 @@
   }
 
   .button {
+    --button-background-color: var(--scheme-alt);
     --button-color: var(--white);
     --button-hover-color: var(--white);
     --button-active-color: var(--white);
     --button-focus-color: var(--white);
     --button-active-border-color: var(--white);
     --button-focus-border-color: var(--white);
+    --button-border-color: rgba(var(--white-rgb), 0.25);
+
+    box-shadow: var(--vglist-shadow);
   }
 
   .tabs {
@@ -398,8 +404,11 @@ nav.navbar {
 }
 
 .custom-card {
+  --card-radius: var(--radius-large);
+
   background-color: var(--card-background-color, #fff);
   box-shadow: var(--vglist-shadow);
+  border-radius: var(--card-radius);
   color: hsl(0, 0%, 21%);
   width: auto;
   position: relative;
@@ -933,4 +942,12 @@ nav.navbar {
 // a card.
 .has-text-muted {
   color: var(--text-muted);
+}
+
+.box {
+  --box-radius: var(--radius-large);
+}
+
+.card {
+  --card-radius: var(--radius-large);
 }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -60,6 +60,9 @@
 
     --vglist-default-fill: var(--white);
     --dropdown-icon-fill: var(--vglist-default-fill);
+
+    // This is used in code blocks, flash messages, and a few other places.
+    --background: var(--scheme-secondary);
   }
 
   .navbar {
@@ -104,10 +107,6 @@
     color: var(--text);
   }
 
-  code {
-    background-color: #222;
-  }
-
   .label {
     --label-color: var(--white);
   }
@@ -127,6 +126,10 @@
     --button-focus-color: var(--white);
     --button-active-border-color: var(--white);
     --button-focus-border-color: var(--white);
+  }
+
+  code {
+    color: var(--white);
   }
 
   .tabs {

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -187,7 +187,7 @@ nav.navbar {
       border-bottom: 2px solid transparent;
       transition: border-bottom 200ms;
 
-      &:hover {
+      &:hover, &:focus {
         border-bottom: 2px solid rgba(255, 255, 255, 0.8);
       }
     }
@@ -604,7 +604,6 @@ nav.navbar {
   width: 100%;
   border-radius: 4px;
   overflow: hidden;
-  // background-color: #d1cfcf;
 
   .percentage-bar-portion {
     display: inline-block;

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -834,3 +834,7 @@ nav.navbar {
 .is-vertical-align-middle {
   vertical-align: middle;
 }
+
+.is-borderless {
+  border: 0px;
+}

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -766,6 +766,10 @@ nav.navbar {
   border-radius: 3px;
   transition: background-color 250ms, color 250ms;
 
+  &::placeholder {
+    color: #fff;
+  }
+
   + span.icon {
     fill: rgba(255, 255, 255, 0.5);
     transition: fill 250ms;

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -200,7 +200,7 @@ nav.navbar {
         border-bottom: 0;
         color: var(--navbar-dropdown-item-color);
 
-        &:hover {
+        &:hover, &:focus {
           border-bottom: 0;
         }
       }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -22,21 +22,27 @@
     --white: #fff;
     --white-rgb: 255, 255, 255;
 
-    --card-background-color: #333;
     --text: var(--white);
-    --scheme-main: #333;
+    --scheme-main: #2c394f;
+    --scheme-alt: #324057;
+    --scheme-secondary: #445168;
     --scheme-invert-rgb: 255, 255, 255;
-    --custom-card-drop-shadow-color: var(--white);
-    --custom-card-drop-shadow-color-rgb: var(--white-rgb);
+
+    --card-background-color: var(--scheme-main);
     --dropdown-link-no-highlight: var(--white);
-    --home-section-background-color: #333;
+    --home-section-background-color: var(--scheme-main);
     --home-section-background-brightness: 75%;
     --navbar-dropdown-item-color: var(--white);
-    --navbar-item-background-hover: #444;
+    --navbar-item-background-hover: var(--scheme-secondary);
+    --vglist-shadow: 0 2px 3px rgba(12, 12, 12, 0.1), 0 0 0 1px rgba(12, 12, 12, 0.1);
+  }
+
+  .navbar {
+    --navbar-shadow-color: rgba(10.2, 10.2, 10.2, 0.1);
   }
 
   .navbar-dropdown {
-    --navbar-dropdown-background-color: #333;
+    --navbar-dropdown-background-color: var(--scheme-alt);
   }
 
   .navbar-divider {
@@ -51,7 +57,13 @@
   }
 
   .box {
-    --box-shadow: 0 2px 3px rgba(var(--white-rgb), 0.1), 0 0 0 1px rgba(var(--white-rgb), 0.1)
+    --box-background-color: var(--scheme-alt);
+    --box-shadow: var(--vglist-shadow);
+  }
+
+  .card {
+    --card-background-color: var(--scheme-alt);
+    --card-shadow: var(--vglist-shadow);
   }
 
   .title {
@@ -71,7 +83,7 @@
   }
 
   .notification {
-    --notification-background-color: #444;
+    --notification-background-color: var(--scheme-alt);
   }
 
   a:hover {
@@ -79,19 +91,21 @@
   }
 
   .button {
-    background-color: #444;
+    background-color: var(--scheme-alt);
     color: var(--white);
-    border-color: #afafaf;
-
+    border-color: transparent;
+    
     &:hover {
-      background-color: #333;
+      background-color: var(--scheme-secondary);
       color: var(--white);
+      border-color: transparent;
     }
   }
 
   .button[disabled],
   fieldset[disabled] .button {
-    background-color: transparent;
+    background-color: var(--scheme-alt);
+    border-color: transparent;
   }
 
   .tabs {
@@ -100,11 +114,12 @@
   }
 
   .menu {
-    --menu-item-hover-background-color: rgba(var(--white-rgb), 90%)
+    --menu-item-hover-background-color: rgba(var(--white-rgb), 90%);
+    --menu-label-color: var(--white);
   }
 
   .modal {
-    --modal-card-head-background-color: #333;
+    --modal-card-head-background-color: var(--scheme-main);
     --modal-card-title-color: var(--white);
   }
 
@@ -117,6 +132,12 @@
 
   .modal-background {
     --modal-background-background-color: rgba(10.2, 10.2, 10.2, 0.86);
+  }
+
+  .dropdown {
+    --dropdown-content-background-color: var(--scheme-alt);
+    --dropdown-item-hover-background-color: var(--scheme-secondary);
+    --dropdown-item-hover-color: var(--white);
   }
 }
 
@@ -357,7 +378,7 @@ nav.navbar {
 
 .custom-card {
   background-color: var(--card-background-color, #fff);
-  box-shadow: 0 2px 3px rgba(var(--custom-card-drop-shadow-color-rgb), 0.1), 0 0 0 1px rgba(var(--custom-card-drop-shadow-color-rgb), 0.1);
+  box-shadow: var(--vglist-shadow);
   color: hsl(0, 0%, 21%);
   width: auto;
   position: relative;

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -759,10 +759,12 @@ nav.navbar {
 
 // Styling for the navbar search field, mostly the icon.
 .navbar-search-input {
+  --input-color: #fff;
+
   background-color: rgba(255, 255, 255, 0.25);
   border: 0;
   border-radius: 3px;
-  transition: background-color 250ms;
+  transition: background-color 250ms, color 250ms;
 
   + span.icon {
     fill: rgba(255, 255, 255, 0.5);
@@ -770,6 +772,8 @@ nav.navbar {
   }
 
   &:focus {
+    --input-color: #000;
+
     background-color: rgba(255, 255, 255, 1);
 
     + span.icon {

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -16,6 +16,13 @@
   --navbar-dropdown-item-color: #333;
   --navbar-item-background-hover: #eeeded;
   --library-edit-bar-border: #fff;
+  --input-radius: 4px;
+  --scheme-alt: #fff;
+  --input-placeholder-color: #333;
+
+  --dropdown-icon-fill: $dropdown-content-arrow;
+
+  --vglist-default-fill: #585858;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -38,6 +45,17 @@
     --vglist-shadow: 0 2px 3px rgba(12, 12, 12, 0.1), 0 0 0 1px rgba(12, 12, 12, 0.1);
     --library-edit-bar-border: #435169;
     --input-color: var(--white);
+    --input-disabled-color: rgba(255, 255, 255, 0.5);
+    --input-border-color: transparent;
+    --input-placeholder-color: var(--white);
+    --input-hover-border-color: transparent;
+    --input-focus-border-color: #dbdbdb;
+    --input-disabled-border-color: transparent;
+    --input-background-color: #445168;
+    --input-disabled-background-color: #445168;
+
+    --vglist-default-fill: var(--white);
+    --dropdown-icon-fill: var(--vglist-default-fill);
   }
 
   .navbar {
@@ -227,7 +245,7 @@ nav.navbar {
 // Don't apply these styles to vue-select dropdowns.
 .dropdown:not(.v-select) {
   button > .icon {
-    fill: $dropdown-content-arrow;
+    fill: var(--dropdown-icon-fill);
     z-index: 4;
     transition: transform 150ms;
     margin-top: 2px;
@@ -235,7 +253,7 @@ nav.navbar {
 
   &.is-active {
     button > .icon {
-      fill: $dropdown-content-arrow;
+      fill: var(--dropdown-icon-fill);
       transform: rotate(-180deg);
       margin-top: 0;
     }
@@ -476,7 +494,7 @@ nav.navbar {
 
 // Make input placeholder text darker by default.
 .input::placeholder {
-  color: #333;
+  color: var(--input-placeholder-color);
   opacity: 0.5;
 }
 
@@ -837,4 +855,67 @@ nav.navbar {
 
 .is-borderless {
   border: 0px;
+}
+
+.v-select {
+  border: 1px solid var(--input-border-color);
+  border-radius: var(--input-radius);
+  background-color: var(--input-background-color);
+
+  &:hover {
+    border: 1px solid var(--input-hover-border-color);
+  }
+
+  &:focus,
+  &.vs--open {
+    border: 1px solid var(--input-focus-border-color);
+  }
+
+  .vs__search {
+    color: var(--input-color);
+
+    &:focus {
+      color: var(--input-focus-color);
+    }
+  }
+
+  .vs__dropdown-menu {
+    background-color: var(--scheme-alt);
+    color: var(--text-color);
+  }
+
+  .vs__selected {
+    color: var(--text-color);
+  }
+
+  &:not(.vs--single) .vs__selected-options .vs__selected {
+    color: var(--text-color);
+    background-color: var(--scheme-alt);
+  }
+
+  .vs__dropdown-option {
+    color: var(--text-color);
+  }
+
+  // Set the fill of the icons in v-select inputs.
+  .vs__open-indicator,
+  .vs__clear,
+  .vs__spinner,
+  .vs__deselect {
+    fill: var(--vglist-default-fill);
+  }
+
+  &.vs--disabled {
+    background-color: var(--input-disabled-background-color);
+    border-color: var(--input-disabled-border-color);
+  }
+
+  &.vs--disabled .vs__clear,
+  &.vs--disabled .vs__dropdown-toggle,
+  &.vs--disabled .vs__open-indicator,
+  &.vs--disabled .vs__search,
+  &.vs--disabled .vs__selected {
+    color: var(--input-disabled-color);
+    background-color: transparent;
+  }
 }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -64,6 +64,7 @@
 
   .navbar {
     --navbar-shadow-color: rgba(10.2, 10.2, 10.2, 0.1);
+    --navbar-dropdown-item-hover-background-color: #5178bc;
   }
 
   .navbar-dropdown {

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -33,6 +33,7 @@
     --white-rgb: 255, 255, 255;
 
     --text: var(--white);
+    --text-strong: var(--text);
     --scheme-main: #2c394f;
     --scheme-alt: #324057;
     --scheme-secondary: #445168;
@@ -55,13 +56,16 @@
     --input-disabled-border-color: transparent;
     --input-background-color: #445168;
     --input-disabled-background-color: #445168;
+    --code-background: var(--scheme-secondary);
+    --code: var(--white);
+    --link-hover: var(--white);
 
     --text-muted: var(--grey-lighter, #dbdbdb);
 
     --vglist-default-fill: var(--white);
     --dropdown-icon-fill: var(--vglist-default-fill);
 
-    // This is used in code blocks, flash messages, and a few other places.
+    // This is used in flash messages and a few other places.
     --background: var(--scheme-secondary);
   }
 
@@ -115,10 +119,6 @@
     --notification-background-color: var(--scheme-alt);
   }
 
-  a:hover {
-    color: var(--white);
-  }
-
   .button {
     --button-color: var(--white);
     --button-hover-color: var(--white);
@@ -126,10 +126,6 @@
     --button-focus-color: var(--white);
     --button-active-border-color: var(--white);
     --button-focus-border-color: var(--white);
-  }
-
-  code {
-    color: var(--white);
   }
 
   .tabs {

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -95,6 +95,10 @@
     --title-color: var(--white);
   }
 
+  .content {
+    --content-heading-color: var(--white);
+  }
+
   body {
     color: var(--text);
   }

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -6,11 +6,15 @@
 
 :root {
   --vglist-theme: #5856d6;
-
   --home-page-subtitle-text: #fff;
+  --home-section-background-color: var(--vglist-theme);
+  --home-section-background-brightness: 85%;
+
   --custom-card-drop-shadow-color: #000;
   --custom-card-drop-shadow-color-rgb: 10, 10, 10;
   --dropdown-link-no-highlight: #000;
+  --navbar-dropdown-item-color: #333;
+  --navbar-item-background-hover: #eeeded;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -21,6 +25,18 @@
     --custom-card-drop-shadow-color: #fff;
     --custom-card-drop-shadow-color-rgb: 255, 255, 255;
     --dropdown-link-no-highlight: #fff;
+    --home-section-background-color: #333;
+    --home-section-background-brightness: 75%;
+    --navbar-dropdown-item-color: #fff;
+    --navbar-item-background-hover: #444;
+  }
+
+  .navbar-dropdown {
+    --navbar-dropdown-background-color: #333;
+  }
+
+  .navbar-divider {
+    --navbar-divider-background-color: #afafaf;
   }
 
   .table {
@@ -114,7 +130,7 @@ nav.navbar {
         transition: background-color 200ms;
         transition: color 0ms;
         border-bottom: 0;
-        color: #333;
+        color: var(--navbar-dropdown-item-color);
 
         &:hover {
           border-bottom: 0;
@@ -122,7 +138,7 @@ nav.navbar {
       }
 
       a.navbar-item:hover {
-        background-color: #eeeded;
+        background-color: var(--navbar-item-background-hover);
       }
 
       a.navbar-item.is-active {

--- a/app/javascript/src/components/compare-libraries.vue
+++ b/app/javascript/src/components/compare-libraries.vue
@@ -1,5 +1,6 @@
 <template>
   <vue-good-table
+    :theme="theme"
     :columns="columns"
     :rows="rows"
     :sort-options="{
@@ -268,6 +269,9 @@ export default {
     },
     user2Link: function() {
       return `/users/${this.user2.slug}`;
+    },
+    theme: function() {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? "nocturnal" : "default";
     }
   }
 };

--- a/app/javascript/src/components/game-card-dropdown.vue
+++ b/app/javascript/src/components/game-card-dropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="dropdown dropdown-dynamic game-card-dropdown is-right" :class="{ 'is-active': isActive }">
     <div class="dropdown-trigger">
-      <button class="button is-borderless" aria-haspopup="true" aria-controls="dropdown-menu" @click="onClick">
+      <button class="button is-borderless is-shadowless" aria-haspopup="true" aria-controls="dropdown-menu" @click="onClick">
         <span class="icon" v-html="this.chevronDownIcon"></span>
       </button>
     </div>

--- a/app/javascript/src/components/game-card-dropdown.vue
+++ b/app/javascript/src/components/game-card-dropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="dropdown dropdown-dynamic game-card-dropdown is-right" :class="{ 'is-active': isActive }">
     <div class="dropdown-trigger">
-      <button class="button is-white" aria-haspopup="true" aria-controls="dropdown-menu" @click="onClick">
+      <button class="button" aria-haspopup="true" aria-controls="dropdown-menu" @click="onClick">
         <span class="icon" v-html="this.chevronDownIcon"></span>
       </button>
     </div>

--- a/app/javascript/src/components/game-card-dropdown.vue
+++ b/app/javascript/src/components/game-card-dropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="dropdown dropdown-dynamic game-card-dropdown is-right" :class="{ 'is-active': isActive }">
     <div class="dropdown-trigger">
-      <button class="button" aria-haspopup="true" aria-controls="dropdown-menu" @click="onClick">
+      <button class="button is-borderless" aria-haspopup="true" aria-controls="dropdown-menu" @click="onClick">
         <span class="icon" v-html="this.chevronDownIcon"></span>
       </button>
     </div>

--- a/app/javascript/src/components/library-table.vue
+++ b/app/javascript/src/components/library-table.vue
@@ -1,5 +1,6 @@
 <template>
   <vue-good-table
+    :theme="theme"
     ref="game-library-table"
     :columns="columns"
     :rows="rows"
@@ -347,6 +348,11 @@ export default {
           this.$data.columns[index].hidden = !value;
         }
       });
+    }
+  },
+  computed: {
+    theme: function() {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? "nocturnal" : "default";
     }
   }
 };

--- a/app/javascript/src/components/user-statistics.vue
+++ b/app/javascript/src/components/user-statistics.vue
@@ -15,21 +15,21 @@
       <div class="level-item has-text-centered">
         <div>
           <p v-if="completionRateExists" class="title">{{ statistics.percent_completed }}%</p>
-          <p v-else class="title has-text-grey-light">N/A%</p>
+          <p v-else class="title has-text-muted">N/A%</p>
           <p class="heading">Completed</p>
         </div>
       </div>
       <div class="level-item has-text-centered">
         <div>
           <p v-if="averageRatingExists" class="title">{{ statistics.average_rating }}</p>
-          <p v-else class="title has-text-grey-light">N/A</p>
+          <p v-else class="title has-text-muted">N/A</p>
           <p class="heading">Average Rating</p>
         </div>
       </div>
       <div class="level-item has-text-centered">
         <div>
           <p v-if="daysPlayedIsPositive" class="title">{{ statistics.total_days_played }}</p>
-          <p v-else class="title has-text-grey-light">N/A</p>
+          <p v-else class="title has-text-muted">N/A</p>
           <p class="heading">Days Played</p>
         </div>
       </div>

--- a/app/javascript/src/stylesheets/home.scss
+++ b/app/javascript/src/stylesheets/home.scss
@@ -13,10 +13,10 @@
     height: 100%;
     overflow: hidden;
     max-height: 375px;
-    filter: brightness(85%);
+    filter: brightness(var(--home-section-background-brightness));
     display: block;
     // background: no-repeat center center / cover url('../../../assets/images/home-background.jpg') #333;
-    background: no-repeat center center / cover var(--vglist-theme);
+    background: no-repeat center center / cover var(--home-section-background-color);
   }
 
   .subtitle {

--- a/app/javascript/src/stylesheets/home.scss
+++ b/app/javascript/src/stylesheets/home.scss
@@ -16,11 +16,11 @@
     filter: brightness(85%);
     display: block;
     // background: no-repeat center center / cover url('../../../assets/images/home-background.jpg') #333;
-    background: no-repeat center center / cover #5856d6;
+    background: no-repeat center center / cover var(--vglist-theme);
   }
 
   .subtitle {
-    color: #fff;
+    color: var(--home-page-subtitle-text);
   }
 
   .home-logo {

--- a/app/javascript/src/stylesheets/utilities.scss
+++ b/app/javascript/src/stylesheets/utilities.scss
@@ -44,3 +44,7 @@ $extra-colors: (
     }
   }
 }
+
+.has-fill-text-color {
+  fill: var(--text);
+}

--- a/app/javascript/src/stylesheets/utilities.scss
+++ b/app/javascript/src/stylesheets/utilities.scss
@@ -1,46 +1,46 @@
-// /**
-//  * This creates fill classes for use on SVG icons, from Bulma's SCSS colors
-//  * variable.
-//  * 
-//  * .has-fill-danger: Bulma's danger color.
-//  * .has-fill-danger-hoverable: Bulma's danger color, which darkens on hover.
-//  */
-// @each $name, $pair in $colors {
-//   $color: nth($pair, 1);
+/**
+ * This creates fill classes for use on SVG icons, from Bulma's SCSS colors
+ * variable.
+ * 
+ * .has-fill-danger: Bulma's danger color.
+ * .has-fill-danger-hoverable: Bulma's danger color, which darkens on hover.
+ */
+@each $name, $pair in $colors {
+  $color: nth($pair, 1);
 
-//   .has-fill-#{$name} {
-//     fill: $color !important;
-//   }
+  .has-fill-#{$name} {
+    fill: $color !important;
+  }
 
-//   .has-fill-#{$name}-hoverable {
-//     fill: $color !important;
+  .has-fill-#{$name}-hoverable {
+    fill: $color !important;
 
-//     &:hover,
-//     &:focus {
-//       fill: darken($color, 15%) !important;
-//     }
-//   }
-// }
+    &:hover,
+    &:focus {
+      fill: darken($color, 15%) !important;
+    }
+  }
+}
 
-// $extra-colors: (
-//   "dark-grey": $grey-dark,
-//   "grey": $grey,
-//   "light-grey": $grey-light,
-// );
+$extra-colors: (
+  "dark-grey": $grey-dark,
+  "grey": $grey,
+  "light-grey": $grey-light,
+);
 
-// @each $name, $pair in $extra-colors {
-//   $color: nth($pair, 1);
+@each $name, $pair in $extra-colors {
+  $color: nth($pair, 1);
 
-//   .has-fill-#{$name} {
-//     fill: $color !important;
-//   }
+  .has-fill-#{$name} {
+    fill: $color !important;
+  }
 
-//   .has-fill-#{$name}-hoverable {
-//     fill: $color !important;
+  .has-fill-#{$name}-hoverable {
+    fill: $color !important;
 
-//     &:hover,
-//     &:focus {
-//       fill: darken($color, 15%) !important;
-//     }
-//   }
-// }
+    &:hover,
+    &:focus {
+      fill: darken($color, 15%) !important;
+    }
+  }
+}

--- a/app/javascript/src/stylesheets/utilities.scss
+++ b/app/javascript/src/stylesheets/utilities.scss
@@ -1,46 +1,46 @@
-/**
- * This creates fill classes for use on SVG icons, from Bulma's SCSS colors
- * variable.
- * 
- * .has-fill-danger: Bulma's danger color.
- * .has-fill-danger-hoverable: Bulma's danger color, which darkens on hover.
- */
-@each $name, $pair in $colors {
-  $color: nth($pair, 1);
+// /**
+//  * This creates fill classes for use on SVG icons, from Bulma's SCSS colors
+//  * variable.
+//  * 
+//  * .has-fill-danger: Bulma's danger color.
+//  * .has-fill-danger-hoverable: Bulma's danger color, which darkens on hover.
+//  */
+// @each $name, $pair in $colors {
+//   $color: nth($pair, 1);
 
-  .has-fill-#{$name} {
-    fill: $color !important;
-  }
+//   .has-fill-#{$name} {
+//     fill: $color !important;
+//   }
 
-  .has-fill-#{$name}-hoverable {
-    fill: $color !important;
+//   .has-fill-#{$name}-hoverable {
+//     fill: $color !important;
 
-    &:hover,
-    &:focus {
-      fill: darken($color, 15%) !important;
-    }
-  }
-}
+//     &:hover,
+//     &:focus {
+//       fill: darken($color, 15%) !important;
+//     }
+//   }
+// }
 
-$extra-colors: (
-  "dark-grey": $grey-dark,
-  "grey": $grey,
-  "light-grey": $grey-light,
-);
+// $extra-colors: (
+//   "dark-grey": $grey-dark,
+//   "grey": $grey,
+//   "light-grey": $grey-light,
+// );
 
-@each $name, $pair in $extra-colors {
-  $color: nth($pair, 1);
+// @each $name, $pair in $extra-colors {
+//   $color: nth($pair, 1);
 
-  .has-fill-#{$name} {
-    fill: $color !important;
-  }
+//   .has-fill-#{$name} {
+//     fill: $color !important;
+//   }
 
-  .has-fill-#{$name}-hoverable {
-    fill: $color !important;
+//   .has-fill-#{$name}-hoverable {
+//     fill: $color !important;
 
-    &:hover,
-    &:focus {
-      fill: darken($color, 15%) !important;
-    }
-  }
-}
+//     &:hover,
+//     &:focus {
+//       fill: darken($color, 15%) !important;
+//     }
+//   }
+// }

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'pagination--ellipsis' %>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'pagination-ellipsis' %>
 </li>

--- a/app/views/settings/profile.html.erb
+++ b/app/views/settings/profile.html.erb
@@ -37,7 +37,7 @@
           <%= f.radio_button :privacy, "public_account" %>
           <%= f.label :privacy_public_account do %>
             <span>Public Account</span><br>
-            <span class='has-text-grey ml-20'>
+            <span class='has-text-muted ml-20'>
               Your library will be visible to all users and your activity will
               show up in the global activity feed.
             </span>
@@ -47,7 +47,7 @@
           <%= f.radio_button :privacy, "private_account" %>
           <%= f.label :privacy_private_account do %>
             <span>Private Account</span><br>
-            <span class='has-text-grey ml-20'>
+            <span class='has-text-muted ml-20'>
               Your library will be visible to only yourself and admins. Your
               activity will not show up in the global activity feed.
             </span>

--- a/app/views/shared/_event.html.erb
+++ b/app/views/shared/_event.html.erb
@@ -12,7 +12,7 @@
         <p><%= event_text(event) %>
 
         <p>
-          <span class="has-text-grey" title="<%= event.created_at %>">
+          <span class="has-text-muted" title="<%= event.created_at %>">
             <%= "#{distance_of_time_in_words(event.created_at, Time.now)} ago" %>
           </span>
           <% if policy(event).destroy? %>

--- a/app/views/shared/_user_card.html.erb
+++ b/app/views/shared/_user_card.html.erb
@@ -18,7 +18,7 @@
           <span class="tag is-danger has-text-weight-semibold ml-5">Banned</span>
         <% end %>
       </p>
-      <p class="has-text-black"><%= user.games.size %> <%= "Game".pluralize(user.games.size) %></p>
+      <p class="has-text-muted"><%= user.games.size %> <%= "Game".pluralize(user.games.size) %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,7 @@
     <%= link_to compare_users_path(user_id: current_user.slug, other_user_id: @user.slug),
       class: 'button is-fullwidth-mobile mr-5 mr-0-mobile mt-10' do %>
       <span class="icon pl-5 mr-5">
-        <%= svg_icon('balance-scale-left', height: 15, aria: false, css_class: 'has-fill-grey') %>
+        <%= svg_icon('balance-scale-left', height: 15, aria: false, css_class: 'has-fill-text-color') %>
       </span>
       <span>Compare with your library</span>
     <% end %>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@sentry/browser": "5.23.0",
     "@types/node": "^14.0.0",
     "babel-preset-typescript-vue": "^1.1.1",
-    "bulma": "file:../bulma/",
+    "bulma": "https://github.com/connorshea/bulma#css-variables-with-fallback",
     "graphiql": "1.0.4",
     "graphql": "^15.3.0",
     "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@sentry/browser": "5.23.0",
     "@types/node": "^14.0.0",
     "babel-preset-typescript-vue": "^1.1.1",
-    "bulma": "0.9.0",
+    "bulma": "file:../bulma/",
     "graphiql": "1.0.4",
     "graphql": "^15.3.0",
     "lodash": "^4.17.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4526,15 +4526,7 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.14.0, js-yaml@^3.8.1:
+js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.8.1:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,8 +1827,9 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-"bulma@file:../bulma":
+"bulma@https://github.com/connorshea/bulma#css-variables-with-fallback":
   version "0.9.0"
+  resolved "https://github.com/connorshea/bulma#ff889b39fd84f0706b1c007a7b3481b8eb44ccee"
   dependencies:
     metalsmith "^2.3.0"
     metalsmith-filter "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1829,7 +1829,7 @@ builtin-status-codes@^3.0.0:
 
 "bulma@https://github.com/connorshea/bulma#css-variables-with-fallback":
   version "0.9.0"
-  resolved "https://github.com/connorshea/bulma#ff889b39fd84f0706b1c007a7b3481b8eb44ccee"
+  resolved "https://github.com/connorshea/bulma#e5f59ff306c7a2fbdfced5cfff0b06422ec03999"
   dependencies:
     metalsmith "^2.3.0"
     metalsmith-filter "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1213,6 +1213,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+absolute@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/absolute/-/absolute-0.0.1.tgz#c22822f87e1c939f579887504d9c109c4173829d"
+  integrity sha1-wigi+H4ck59XmIdQTZwQnEFzgp0=
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -1285,6 +1290,13 @@ ansi-html@0.0.7:
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
   integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
 
+ansi-red@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-red/-/ansi-red-0.1.1.tgz#8c638f9d1080800a353c9c28c8a81ca4705d946c"
+  integrity sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=
+  dependencies:
+    ansi-wrap "0.1.0"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -1319,6 +1331,11 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+ansi-wrap@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
+  integrity sha1-qCJQ3bABXponyoLoLqYDu/pF768=
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -1376,6 +1393,11 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-differ@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
+  integrity sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -1407,6 +1429,11 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+arrify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
 asn1.js@^5.2.0:
   version "5.4.1"
@@ -1464,6 +1491,11 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
+async@^1.2.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 async@^2.6.2:
   version "2.6.3"
@@ -1795,10 +1827,11 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bulma@0.9.0:
+"bulma@file:../bulma":
   version "0.9.0"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.0.tgz#948c5445a49e9d7546f0826cb3820d17178a814f"
-  integrity sha512-rV75CJkubNUroAt0qCRkjznZLoaXq/ctfMXsMvKSL84UetbSyx5REl96e8GoQ04G4Tkw0XF3STECffTOQrbzOQ==
+  dependencies:
+    metalsmith "^2.3.0"
+    metalsmith-filter "^1.0.2"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -1941,7 +1974,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^1.1.1:
+chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -2066,6 +2099,32 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+co-from-stream@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/co-from-stream/-/co-from-stream-0.0.0.tgz#1a5cd8ced77263946094fa39f2499a63297bcaf9"
+  integrity sha1-GlzYztdyY5RglPo58kmaYyl7yvk=
+  dependencies:
+    co-read "0.0.1"
+
+co-fs-extra@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/co-fs-extra/-/co-fs-extra-1.2.1.tgz#3b6ad77cf2614530f677b1cf62664f5ba756b722"
+  integrity sha1-O2rXfPJhRTD2d7HPYmZPW6dWtyI=
+  dependencies:
+    co-from-stream "~0.0.0"
+    fs-extra "~0.26.5"
+    thunkify-wrap "~1.0.4"
+
+co-read@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/co-read/-/co-read-0.0.1.tgz#f81b3eb8a86675fec51e3d883a7f564e873c9389"
+  integrity sha1-+Bs+uKhmdf7FHj2IOn9WToc8k4k=
+
+co@3.1.0, co@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-3.1.0.tgz#4ea54ea5a08938153185e15210c68d9092bc1b78"
+  integrity sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=
+
 coa@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/coa/-/coa-2.0.2.tgz#43f6c21151b4ef2bf57187db0d73de229e3e7ec3"
@@ -2092,6 +2151,11 @@ codemirror@^5.54.0:
   version "5.57.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.57.0.tgz#d26365b72f909f5d2dbb6b1209349ca1daeb2d50"
   integrity sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg==
+
+coffee-script@^1.12.4:
+  version "1.12.7"
+  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
+  integrity sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -2161,7 +2225,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+commander@^2.20.0, commander@^2.6.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2923,6 +2987,11 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
+enable@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/enable/-/enable-1.3.2.tgz#9eba6837d16d0982b59f87d889bf754443d52931"
+  integrity sha1-nrpoN9FtCYK1n4fYib91REPVKTE=
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -3450,6 +3519,17 @@ fs-extra@^9.0.0:
     jsonfile "^6.0.1"
     universalify "^1.0.0"
 
+fs-extra@~0.26.5:
+  version "0.26.7"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
+  integrity sha1-muH92UiXeY7at20JGM9C0MMYT6k=
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    klaw "^1.0.0"
+    path-is-absolute "^1.0.0"
+    rimraf "^2.2.8"
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -3648,7 +3728,7 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -3711,6 +3791,17 @@ graphql@^15.0.0, graphql@^15.3.0:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
   integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
 
+gray-matter@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-2.1.1.tgz#3042d9adec2a1ded6a7707a9ed2380f8a17a430e"
+  integrity sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=
+  dependencies:
+    ansi-red "^0.1.1"
+    coffee-script "^1.12.4"
+    extend-shallow "^2.0.1"
+    js-yaml "^3.8.1"
+    toml "^2.3.2"
+
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -3745,6 +3836,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-generators@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-generators/-/has-generators-1.0.1.tgz#a6a2e55486011940482e13e2c93791c449acf449"
+  integrity sha1-pqLlVIYBGUBILhPiyTeRxEms9Ek=
 
 has-symbols@^1.0.1:
   version "1.0.1"
@@ -4363,7 +4459,7 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-utf8@^0.2.0:
+is-utf8@^0.2.0, is-utf8@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
@@ -4377,6 +4473,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is@^3.0.1, is@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/is/-/is-3.3.0.tgz#61cff6dd3c4193db94a3d62582072b44e5645d79"
+  integrity sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -4424,7 +4525,15 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^3.14.0:
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.14.0, js-yaml@^3.8.1:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
@@ -4491,6 +4600,13 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonfile@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  integrity sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonfile@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
@@ -4538,6 +4654,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
+  integrity sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
+  optionalDependencies:
+    graceful-fs "^4.1.9"
 
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"
@@ -4869,6 +4992,37 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+metalsmith-filter@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/metalsmith-filter/-/metalsmith-filter-1.0.2.tgz#15f16cac14dec27c074a858a25b725651a0303b8"
+  integrity sha1-FfFsrBTewnwHSoWKJbclZRoDA7g=
+  dependencies:
+    async "^1.2.0"
+    is "^3.0.1"
+    multimatch "^2.0.0"
+
+metalsmith@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/metalsmith/-/metalsmith-2.3.0.tgz#833afbb5a2a6385e2d9ae3d935e39e33eaea5231"
+  integrity sha1-gzr7taKmOF4tmuPZNeOeM+rqUjE=
+  dependencies:
+    absolute "0.0.1"
+    chalk "^1.1.3"
+    clone "^1.0.2"
+    co-fs-extra "^1.2.1"
+    commander "^2.6.0"
+    gray-matter "^2.0.0"
+    has-generators "^1.0.1"
+    is "^3.1.0"
+    is-utf8 "~0.2.0"
+    recursive-readdir "^2.1.0"
+    rimraf "^2.2.8"
+    stat-mode "^0.2.0"
+    thunkify "^2.1.2"
+    unyield "0.0.1"
+    ware "^1.2.0"
+    win-fork "^1.1.1"
+
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
@@ -4943,7 +5097,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.4, minimatch@~3.0.2:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -5066,6 +5220,16 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+multimatch@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
+  integrity sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=
+  dependencies:
+    array-differ "^1.0.0"
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    minimatch "^3.0.0"
 
 nan@^2.12.1, nan@^2.13.2:
   version "2.14.1"
@@ -6629,6 +6793,13 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
+recursive-readdir@^2.1.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
+  integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
+  dependencies:
+    minimatch "3.0.4"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -6855,7 +7026,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.3:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -7334,6 +7505,11 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+stat-mode@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-0.2.2.tgz#e6c80b623123d7d80cf132ce538f346289072502"
+  integrity sha1-5sgLYjEj19gM8TLOU480YokHJQI=
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -7631,6 +7807,18 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
+thunkify-wrap@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/thunkify-wrap/-/thunkify-wrap-1.0.4.tgz#b52be548ddfefda20e00b58c6096762b43dd6880"
+  integrity sha1-tSvlSN3+/aIOALWMYJZ2K0PdaIA=
+  dependencies:
+    enable "1"
+
+thunkify@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
+  integrity sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=
+
 thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
@@ -7699,6 +7887,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+toml@^2.3.2:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.6.tgz#25b0866483a9722474895559088b436fd11f861b"
+  integrity sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==
 
 tough-cookie@~2.5.0:
   version "2.5.0"
@@ -7869,6 +8062,13 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unyield@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/unyield/-/unyield-0.0.1.tgz#150e65da42bf7742445b958a64eb9b85d1d2b180"
+  integrity sha1-FQ5l2kK/d0JEW5WKZOubhdHSsYA=
+  dependencies:
+    co "~3.1.0"
 
 upath@^1.1.1:
   version "1.2.0"
@@ -8062,6 +8262,13 @@ vue@>=2.0.0, vue@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
   integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+
+ware@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ware/-/ware-1.3.0.tgz#d1b14f39d2e2cb4ab8c4098f756fe4b164e473d4"
+  integrity sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=
+  dependencies:
+    wrap-fn "^0.1.0"
 
 watchpack-chokidar2@^2.0.0:
   version "2.0.0"
@@ -8260,6 +8467,11 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+win-fork@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/win-fork/-/win-fork-1.1.1.tgz#8f58e0656fca00adc8c86a2b89e3cd2d6a2d5e5e"
+  integrity sha1-j1jgZW/KAK3IyGoriePNLWotXl4=
+
 worker-farm@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
@@ -8275,6 +8487,13 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
+
+wrap-fn@^0.1.0:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/wrap-fn/-/wrap-fn-0.1.5.tgz#f21b6e41016ff4a7e31720dbc63a09016bdf9845"
+  integrity sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=
+  dependencies:
+    co "3.1.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Currently, this is just implemented depending on the user's color scheme preference, where light/not-set is light, and dark is dark.

It uses Bulma's CSS variables branch, which was incredibly useful for this.

Light mode:
<img width="1440" alt="Screen Shot 2020-09-12 at 5 50 03 PM" src="https://user-images.githubusercontent.com/2977353/93007009-ae490100-f520-11ea-8a2f-c062a3255b15.png">

Dark mode:
<img width="1440" alt="Screen Shot 2020-09-12 at 5 50 23 PM" src="https://user-images.githubusercontent.com/2977353/93007011-b0ab5b00-f520-11ea-9778-dcbd21b261de.png">

Light mode:

<img width="1438" alt="Screen Shot 2020-09-12 at 5 52 38 PM" src="https://user-images.githubusercontent.com/2977353/93007020-d2a4dd80-f520-11ea-85d6-2d663ae5ed40.png">

Dark mode:

<img width="1438" alt="Screen Shot 2020-09-12 at 5 52 51 PM" src="https://user-images.githubusercontent.com/2977353/93007022-d6d0fb00-f520-11ea-83de-636e7292a252.png">
