### PR TITLE
Update Sentry configuration.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
 
   # Send user ID, params, and request URL to Sentry on-error.
   def set_raven_context
-    Raven.user_context(id: current_user&.username)
+    Raven.user_context(id: current_user&.id, username: current_user&.username)
     Raven.extra_context(params: params.to_unsafe_h, url: request.url)
   end
 end

--- a/app/javascript/packs/application.ts
+++ b/app/javascript/packs/application.ts
@@ -14,7 +14,8 @@ import VTooltip from 'v-tooltip';
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import * as Sentry from '@sentry/browser';
-import * as _ from "lodash";
+import { Vue as VueIntegration } from '@sentry/integrations';
+import _ from "lodash";
 import '../src/vue-loader';
 import '../src/toggleable-buttons';
 import '../src/bulma';
@@ -25,7 +26,13 @@ import '../src/settings';
 require.context('../icons', true);
 
 if (process.env.NODE_ENV === 'production') {
-  Sentry.init({ dsn: process.env.SENTRY_DSN_JS });
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN_JS,
+    integrations: [
+      new VueIntegration({ Vue })
+    ],
+    environment: process.env.NODE_ENV
+  });
 }
 
 Vue.use(TurbolinksAdapter);

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -7,6 +7,12 @@ namespace :deploy do
       puts
       puts "Pulling down the latest code from master..."
       system('git pull')
+      # Create Sentry release
+      puts
+      puts "Creating Sentry release..."
+      version = `sentry-cli releases propose-version`.strip
+      system("sentry-cli releases new -p vglist-backend -p vglist-frontend #{version}")
+      system("sentry-cli releases set-commits --auto #{version}")
       # Install dependencies with Bundler.
       puts
       puts "Installing Ruby dependencies..."
@@ -23,6 +29,10 @@ namespace :deploy do
       puts
       puts "Precompiling assets..."
       system('bundle exec rails assets:precompile')
+      # Finalize Sentry release
+      puts
+      puts "Finalizing Sentry release..."
+      system("sentry-cli releases finalize #{version}")
 
       puts
       puts "Deploy successful!"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/ujs": "^6.0.2",
     "@rails/webpacker": "5.2.1",
     "@sentry/browser": "5.26.0",
+    "@sentry/integrations": "^5.26.0",
     "@types/node": "^14.0.0",
     "babel-preset-typescript-vue": "^1.1.1",
     "bulma": "https://github.com/connorshea/bulma#css-variables-with-fallback",

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,6 +956,16 @@
     "@sentry/utils" "5.26.0"
     tslib "^1.9.3"
 
+"@sentry/integrations@^5.26.0":
+  version "5.26.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-5.26.0.tgz#cf90005359862c5b1df4df0f1ce8be5e56c9e1ad"
+  integrity sha512-XBMPm3wWW+3EJvWFHdVcl0PSWjjNEzmQxjjWeMv9vLWAC1zhS8gcpk/LyDIFWojJBzhASD8f1mLv2ZdKZtA1ZQ==
+  dependencies:
+    "@sentry/types" "5.26.0"
+    "@sentry/utils" "5.26.0"
+    localforage "1.8.1"
+    tslib "^1.9.3"
+
 "@sentry/minimal@5.26.0":
   version "5.26.0"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.26.0.tgz#851dea3644153ed3ac4837fa8ed5661d94e7a313"
@@ -4068,6 +4078,11 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -4651,6 +4666,13 @@ last-call-webpack-plugin@^3.0.0:
     lodash "^4.17.5"
     webpack-sources "^1.1.0"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -4705,6 +4727,13 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+localforage@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.8.1.tgz#f6c0a24b41ab33b10e4dc84342dd696f6f3e3433"
+  integrity sha512-azSSJJfc7h4bVpi0PGi+SmLQKJl2/8NErI+LhJsrORNikMZnhaQ7rv9fHj+ofwgSHrKRlsDCL/639a6nECIKuQ==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Use a distinct DSN for Rails and JS since we're splitting it into two separate projects, use Sentry's Vue integration, and add creating Sentry releases to the deploy task.

Resolves #1566