### PR TITLE
Add a currentUser query to the GraphQL API

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -110,6 +110,10 @@ module Types
       argument :username, String, required: false, description: "Find a user by their username."
     end
 
+    field :current_user, UserType, null: true do
+      description "Get the currently authenticated user."
+    end
+
     field :users, UserType.connection_type, null: true do
       description "List all users."
     end
@@ -249,6 +253,11 @@ module Types
       else
         raise GraphQL::ExecutionError, "Field 'user' is missing a required argument: 'id' or 'username'"
       end
+    end
+
+    sig { returns(T.nilable(User)) }
+    def current_user
+      context[:current_user]
     end
 
     sig { returns(User::RelationType) }

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -222,5 +222,26 @@ RSpec.describe "Users API", type: :request do
         }]
       )
     end
+
+    it "returns data for current user when requesting currentUser" do
+      user
+      query_string = <<-GRAPHQL
+        query {
+          currentUser {
+            id
+            username
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, token: access_token)
+
+      expect(result["data"]["currentUser"]).to eq(
+        {
+          "id" => user.id.to_s,
+          "username" => user.username
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
Now you can make a GraphQL query like this and get back information about the current user:

```graphql
query {
  currentUser {
    id
    username
  }
}
```

Resolves #1666.