### PR TITLE
Fix the "Display columns" dropdown working inconsistently

### DIFF
--- a/app/javascript/src/components/library.vue
+++ b/app/javascript/src/components/library.vue
@@ -98,9 +98,21 @@ export default {
         .then(purchasedGames => {
           this.games = purchasedGames;
           this.isLoading = false;
-          // Emit a bulma init event to make sure that the filter dropdown is initialized.
-          let event = new Event('bulma:init');
-          document.body.dispatchEvent(event);
+
+          // Make sure to trigger bulma:init, even if the load event has already fired.
+          // This can theoretically trigger a race condtion because readyState
+          // will be set to complete right before the load event is fired, but yolo.
+          if (document.readyState === 'complete') {
+            // Emit a bulma init event to make sure that the filter dropdown is initialized.
+            let event = new Event('bulma:init');
+            document.body.dispatchEvent(event);
+          } else {
+            window.addEventListener('load', (_loadEvent) => {
+              // Emit a bulma init event to make sure that the filter dropdown is initialized.
+              let event = new Event('bulma:init');
+              document.body.dispatchEvent(event);
+            });
+          }
         });
     },
     refreshLibrary() {


### PR DESCRIPTION
This fixes a race condition in our Vue components by calling `bulma:init` more consistently if other elements (e.g. images) take a long time to load.

Previously, if something took too long to load - such as the user's profile picture - bulma:init would be called when the user's game library loaded, which could happen when the page wasn't quite done loading.

I simulated this case by randomizing the profile picture's dimensions so it'd take rails a good 5-10 seconds to generate the user's profile picture.

With this solution, bulma:init is now called either immediately (if the page load has completed) or as soon as the rest of the page loads. This introduces a new problem in that the dropdowns aren't usable until everything has loaded, but I'm not sure how to work around that issue.

I'm not entirely sure why calling `bulma:init` while the page is still loading is problematic, that might be worth investigating in the future. Theoretically it shouldn't cause any problems, but I'm probably missing something about how the DOM event lifecycle works.

In conclusion, race conditions suck.

See also:
- #400, where `bulma:init` was first introduced

EDIT:

Ok apparently I do this for some reason:

```js
window.addEventListener('load', function() {
  document.body.addEventListener('bulma:init', initBulma);
});
```

I'm not entirely sure why I wait for the load event to add the event listener.