### PR TITLE
Fix some errors caused by ActiveStorage.

### DIFF
--- a/config/initializers/activestorage.rb
+++ b/config/initializers/activestorage.rb
@@ -1,0 +1,14 @@
+# typed: false
+
+# Only attempt to create variants of PNG and JPEG images, don't try to
+# generate webp variants. This can be changed in the future if we switch to
+# vips or update ImageMagick to support webp.
+#
+# The default for this value includes various other content types as well, but
+# we don't use any of them.
+Rails.application.config.active_storage.variable_content_types = %w(image/png image/jpg image/jpeg)
+
+# An array of content types in which variants can be processed without being
+# converted to the fallback PNG format. This is set here explicitly to prevent
+# the usage of gifs or any other formats from future Rails versions.
+Rails.application.config.active_storage.web_image_content_types = %w(image/png image/jpg image/jpeg)

--- a/config/initializers/activestorage.rb
+++ b/config/initializers/activestorage.rb
@@ -6,9 +6,9 @@
 #
 # The default for this value includes various other content types as well, but
 # we don't use any of them.
-Rails.application.config.active_storage.variable_content_types = %w(image/png image/jpg image/jpeg)
+Rails.application.config.active_storage.variable_content_types = ['image/png', 'image/jpg', 'image/jpeg']
 
 # An array of content types in which variants can be processed without being
 # converted to the fallback PNG format. This is set here explicitly to prevent
 # the usage of gifs or any other formats from future Rails versions.
-Rails.application.config.active_storage.web_image_content_types = %w(image/png image/jpg image/jpeg)
+Rails.application.config.active_storage.web_image_content_types = ['image/png', 'image/jpg', 'image/jpeg']

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -1,12 +1,14 @@
 # typed: false
-namespace 'active_storage:vglist' do
+namespace 'active_storage:vglist:clean' do
   desc "Remove any attachments where the blob has a content type other than PNG or JPG."
-  task clean: :environment do
+  task bad_content_types: :environment do
     # Get blobs where the content type is an invalid type (e.g. webp) and
     # they're associated with an attachment somehow.
     # Ideally this should never happen, but somehow it occasionally does. Need
     # to investigate this more.
     blobs = ActiveStorage::Blob.joins(:attachments).where.not(content_type: ['image/png', 'image/jpeg', 'image/jpg'])
+
+    puts "Found #{blobs.count} ActiveStorage::Blobs with a bad content type."
 
     blobs.each do |blob|
       # They should only have one each, but do all of them just in case
@@ -21,5 +23,26 @@ namespace 'active_storage:vglist' do
         end
       end
     end
+
+    puts "Purged all ActiveStorage::Blobs with a bad content type."
+  end
+
+  desc "Remove any blobs without an associated attachment."
+  task orphan_blobs: :environment do
+    # Find all orphan blobs so they can be purged.
+    orphan_blobs = ActiveStorage::Blob.where.missing(:attachments)
+
+    puts "Found #{orphan_blobs.count} orphan ActiveStorage::Blobs."
+
+    # Purge all the orphan blobs.
+    orphan_blobs.each(&:purge)
+
+    puts "Purged all orphan ActiveStorage::Blobs."
+  end
+
+  desc "Run all ActiveStorage cleaning tasks."
+  task all: :environment do
+    Rake::Task['active_storage:vglist:clean:bad_content_types'].invoke
+    Rake::Task['active_storage:vglist:clean:orphan_blobs'].invoke
   end
 end

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -32,7 +32,8 @@ namespace 'active_storage:vglist:clean' do
     # Find all orphan blobs so they can be purged.
     orphan_blobs = ActiveStorage::Blob.where.missing(:attachments)
 
-    puts "Found #{orphan_blobs.count} orphan ActiveStorage::Blobs."
+    total_size_in_mb = orphan_blobs.sum(&:byte_size).to_f.fdiv(1024).round(2)
+    puts "Found #{orphan_blobs.count} orphan ActiveStorage::Blobs, total size #{total_size_in_mb} MB."
 
     # Purge all the orphan blobs.
     orphan_blobs.each(&:purge)

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -1,0 +1,25 @@
+# typed: false
+namespace 'active_storage:vglist' do
+  desc "Remove any attachments where the blob has a content type other than PNG or JPG."
+  task clean: :environment do
+    # Get blobs where the content type is an invalid type (e.g. webp) and
+    # they're associated with an attachment somehow.
+    # Ideally this should never happen, but somehow it occasionally does. Need
+    # to investigate this more.
+    blobs = ActiveStorage::Blob.joins(:attachments).where.not(content_type: ['image/png', 'image/jpeg', 'image/jpg'])
+
+    blobs.each do |blob|
+      # They should only have one each, but do all of them just in case
+      blob.attachments.each do |attachment|
+        case attachment.record_type
+        when 'Game'
+          Game.find(attachment.record_id).cover.purge
+        when 'User'
+          User.find(attachment.record_id).avatar.purge
+        else
+          raise StandardError, "Invalid record type for attachment: #{attachment.record_type}."
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It attempts to create variants of webp images but ImageMagick can't handle them, so it errors.

This removes webp from the list of valid variants (it was added in Rails 6.1) and creates a Rake task for removing any attachments that shouldn't exist due to their invalid content type.