### PR TITLE
Enable variant tracking and add Rake task to create ActiveStorage Variant records

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,16 +58,16 @@ module ApplicationHelper
         **options
     elsif game.cover&.attached? && !game.cover&.variable?
       image_tag game.cover,
-      width: "#{width}px",
-      height: "#{height}px",
-      alt: "Cover for #{game.name}.",
-      **options
+        width: "#{width}px",
+        height: "#{height}px",
+        alt: "Cover for #{game.name}.",
+        **options
     else
       image_tag 'no-cover.png',
-      width: "#{width}px",
-      height: "#{height}px",
-      alt: "Placeholder cover for #{game.name}.",
-      **options
+        width: "#{width}px",
+        height: "#{height}px",
+        alt: "Placeholder cover for #{game.name}.",
+        **options
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,10 +14,10 @@ module ApplicationHelper
   end
 
   # A helper for displaying user avatars.
-  sig { params(user_id: T.any(Integer, String), size: Symbol, css_class_name: String, options: T.untyped).returns(T.untyped) }
-  def user_avatar(user_id, size:, css_class_name: 'user-avatar', **options)
+  sig { params(user: User, size: Symbol, css_class_name: String, options: T.untyped).returns(T.untyped) }
+  def user_avatar(user, size:, css_class_name: 'user-avatar', **options)
     width, height = User::AVATAR_SIZES[size]
-    user = User.find(user_id)
+
     if user.avatar&.attached? && user.avatar&.variable?
       # Resize the image, center it, and then crop it to a square.
       # This prevents users from having images that aren't either

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -151,7 +151,18 @@ class Game < ApplicationRecord
   global_searchable :name
   searchable :name, tsearch: { normalization: 2 }
 
-  sig { params(size: Symbol).returns(T.nilable(T.any(ActiveStorage::Variant, ActiveStorage::VariantWithRecord))) }
+  # Generate a cover variant with a specific size, size must be a Symbol
+  # matching one of the keys in `Game::COVER_SIZES`.
+  sig do
+    params(size: Symbol).returns(
+      T.nilable(
+        T.any(
+          ActiveStorage::Variant,
+          ActiveStorage::VariantWithRecord
+        )
+      )
+    )
+  end
   def sized_cover(size)
     width, height = COVER_SIZES[size]
     cover&.variant(

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -151,7 +151,7 @@ class Game < ApplicationRecord
   global_searchable :name
   searchable :name, tsearch: { normalization: 2 }
 
-  sig { params(size: Symbol).returns(T.nilable(ActiveStorage::Variant)) }
+  sig { params(size: Symbol).returns(T.nilable(T.any(ActiveStorage::Variant, ActiveStorage::VariantWithRecord))) }
   def sized_cover(size)
     width, height = COVER_SIZES[size]
     cover&.variant(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,7 +179,7 @@ class User < ApplicationRecord
     api_token == token
   end
 
-  sig { params(size: Symbol).returns(T.nilable(ActiveStorage::Variant)) }
+  sig { params(size: Symbol).returns(T.nilable(T.any(ActiveStorage::Variant, ActiveStorage::VariantWithRecord))) }
   def sized_avatar(size)
     width, height = AVATAR_SIZES[size]
     avatar&.variant(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,7 +179,18 @@ class User < ApplicationRecord
     api_token == token
   end
 
-  sig { params(size: Symbol).returns(T.nilable(T.any(ActiveStorage::Variant, ActiveStorage::VariantWithRecord))) }
+  # Generate an avatar variant with a specific size, size must be a Symbol
+  # matching one of the keys in `User::AVATAR_SIZES`.
+  sig do
+    params(size: Symbol).returns(
+      T.nilable(
+        T.any(
+          ActiveStorage::Variant,
+          ActiveStorage::VariantWithRecord
+        )
+      )
+    )
+  end
   def sized_avatar(size)
     width, height = AVATAR_SIZES[size]
     avatar&.variant(

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -101,7 +101,7 @@
         <% @owners.each do |owner| %>
           <li class='avatar-image-grid-item'>
             <%= link_to(user_path(owner), class: 'image') do %>
-              <%= user_avatar(owner.id, size: :small, title: owner.username) %>
+              <%= user_avatar(owner, size: :small, title: owner.username) %>
             <% end %>
           </li>
         <% end %>
@@ -124,7 +124,7 @@
         <% @favoriters.each do |favoriter| %>
           <li class='avatar-image-grid-item'>
             <%= link_to(user_path(favoriter), class: 'image') do %>
-              <%= user_avatar(favoriter.id, size: :small, title: favoriter.username) %>
+              <%= user_avatar(favoriter, size: :small, title: favoriter.username) %>
             <% end %>
           </li>
         <% end %>

--- a/app/views/shared/_event.html.erb
+++ b/app/views/shared/_event.html.erb
@@ -3,7 +3,7 @@
     <div class="media-left">
       <figure class="image is-64x64">
         <%= link_to user_path(event.user) do %>
-          <%= user_avatar(event.user.id, size: :small) %>
+          <%= user_avatar(event.user, size: :small) %>
         <% end %>
       </figure>
     </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -72,7 +72,7 @@
       <% if user_signed_in? %>
         <div class="navbar-item has-dropdown is-hoverable is-hidden-touch">
           <a class="navbar-link">
-            <%= user_avatar(current_user.id, size: :small) %>
+            <%= user_avatar(current_user, size: :small) %>
             <span class='pl-10'><%= current_user.username %></span>
           </a>
 

--- a/app/views/shared/_user_card.html.erb
+++ b/app/views/shared/_user_card.html.erb
@@ -1,7 +1,7 @@
 <div class="user-card custom-card">
   <%= link_to(user_path(user.slug), class: 'card-container') do %>
     <figure class="user-avatar">
-      <%= user_avatar(user.id, size: :small) %>
+      <%= user_avatar(user, size: :small) %>
     </figure>
     <div class="card-content">
       <p class="title is-4 mb-5 is-vertical-align-middle">

--- a/app/views/users/_user_header.html.erb
+++ b/app/views/users/_user_header.html.erb
@@ -1,6 +1,6 @@
 <div class="hero-area">
   <div class="hero-image hero-image-150 user-avatar">
-    <%= user_avatar(user.id, size: :medium) %>
+    <%= user_avatar(user, size: :medium) %>
   </div>
 
   <div class="text-block">

--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -11,7 +11,7 @@
 Rails.application.config.active_record.has_many_inversing = true
 
 # Track Active Storage variants in the database.
-# Rails.application.config.active_storage.track_variants = true
+Rails.application.config.active_storage.track_variants = true
 
 # Apply random variation to the delay when retrying failed jobs.
 Rails.application.config.active_job.retry_jitter = 0.15

--- a/lib/tasks/migrations/variant_creation.rake
+++ b/lib/tasks/migrations/variant_creation.rake
@@ -1,0 +1,47 @@
+# typed: false
+
+# Rails 6.1 changes the way ActiveStorage works so that variants are
+# tracked in the database. The intent of this task is to create the
+# necessary variants for all game covers and user avatars in our database.
+# This way, the user isn't creating dozens of variant records as they
+# browse the site. We want to create them ahead-of-time, when we deploy
+# the change to track variants.
+namespace 'active_storage:vglist:variants' do
+  require 'ruby-progressbar'
+
+  desc "Create all variants for covers and avatars in the database."
+  task create: :environment do
+    games = Game.joins(:cover_attachment)
+    puts 'Creating game cover variants...'
+
+    games_progress_bar = ProgressBar.create(
+      total: games.count,
+      format: "\e[0;32m%c/%C |%b>%i| %e\e[0m"
+    )
+
+    games.each do |game|
+      [:small, :medium, :large].each do |size|
+        game.sized_cover(size).process
+      end
+      games_progress_bar.increment
+    end
+
+    games_progress_bar.finish unless games_progress_bar.finished?
+
+    users = User.joins(:avatar_attachment)
+    puts 'Creating user avatar variants...'
+
+    users_progress_bar = ProgressBar.create(
+      total: users.count,
+      format: "\e[0;32m%c/%C |%b>%i| %e\e[0m"
+    )
+
+    users.each do |user|
+      [:small, :medium, :large].each do |size|
+        user.sized_avatar(size).process
+      end
+      users_progress_bar.increment
+    end
+    users_progress_bar.finish unless users_progress_bar.finished?
+  end
+end


### PR DESCRIPTION
Rails 6.1 adds variant tracking in the database. I tried enabling this a few days after upgrading to Rails 6.1, but found it to be too slow because dozens of variants were being created and saved to the database by users while they browsed the site.

The solution I've come up with is to generate all variants ahead-of-time when enabling the variant_tracking option, via a Rake task.

The site will likely still be slow for a little while after deploying this change, but the Rake task will resolve most of the issue on its own. Will need to run the Rake task ASAP after deployment.