### PR TITLE
Speed up variant creation Rake task

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -80,7 +80,7 @@ test:
 #
 production:
   <<: *default
-  database: vglist_production
+  database: <%= ENV['VGLIST_DATABASE_NAME'] || 'vglist_production' %>
   username: vglist
   password: <%= ENV['VGLIST_DATABASE_PASSWORD'] %>
   host: <%= ENV['VGLIST_DATABASE_HOST'] %>


### PR DESCRIPTION
Uses the Parallel gem to parallelize the variant creation task.

And allow the database name to be configured in production, so we can use connection pooling and safely enable a larger number of database connections at once time.

This doesn't enable track variants yet, I'll do that after I see that the connection pooling works.