### PR TITLE
Split out all GraphQL query definitions into their own files.

### DIFF
--- a/app/graphql/resolvers/activity_resolver.rb
+++ b/app/graphql/resolvers/activity_resolver.rb
@@ -1,0 +1,27 @@
+# typed: true
+module Resolvers
+  class ActivityResolver < Resolvers::BaseResolver
+    type Types::EventType.connection_type, null: true
+
+    description "View recent activity."
+
+    argument :feed_type, Types::ActivityFeedType, required: false
+
+    sig { params(feed_type: String).returns(T.nilable(Event::RelationType)) }
+    def resolve(feed_type: 'following')
+      case feed_type
+      when 'global'
+        Event.recently_created
+             .joins(:user)
+             .where(users: { privacy: :public_account })
+      when 'following'
+        user_ids = @context[:current_user]&.following&.map { |u| u.id }
+        # Include the user's own activity in the feed.
+        user_ids << @context[:current_user].id
+        Event.recently_created
+             .joins(:user)
+             .where(user_id: user_ids)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -1,0 +1,8 @@
+# typed: true
+module Resolvers
+  class BaseResolver < GraphQL::Schema::Resolver
+    extend T::Sig
+
+    argument_class Types::BaseArgument
+  end
+end

--- a/app/graphql/resolvers/company_resolvers/company_resolver.rb
+++ b/app/graphql/resolvers/company_resolvers/company_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module CompanyResolvers
+    class CompanyResolver < Resolvers::BaseResolver
+      type Types::CompanyType, null: true
+
+      description "Find a company by ID."
+
+      argument :id, ID, required: true
+
+      sig { params(id: T.any(String, Integer)).returns(Company) }
+      def resolve(id:)
+        Company.find(id)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/company_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/company_resolvers/list_resolver.rb
@@ -1,0 +1,15 @@
+# typed: true
+module Resolvers
+  module CompanyResolvers
+    class ListResolver < Resolvers::BaseResolver
+      type Types::CompanyType.connection_type, null: true
+
+      description "List all companies."
+
+      sig { returns(Company::RelationType) }
+      def resolve
+        Company.all
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/company_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/company_resolvers/search_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module CompanyResolvers
+    class SearchResolver < Resolvers::BaseResolver
+      type Types::CompanyType.connection_type, null: true
+
+      description "Find a company by searching based on its name."
+
+      argument :query, String, required: true, description: "Name to search by."
+
+      sig { params(query: String).returns(Company::RelationType) }
+      def resolve(query:)
+        Company.search(query)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/engine_resolvers/engine_resolver.rb
+++ b/app/graphql/resolvers/engine_resolvers/engine_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module EngineResolvers
+    class EngineResolver < Resolvers::BaseResolver
+      type Types::EngineType, null: true
+
+      description "Find a game engine by ID."
+
+      argument :id, ID, required: true
+
+      sig { params(id: T.any(String, Integer)).returns(Engine) }
+      def resolve(id:)
+        Engine.find(id)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/engine_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/engine_resolvers/list_resolver.rb
@@ -1,0 +1,15 @@
+# typed: true
+module Resolvers
+  module EngineResolvers
+    class ListResolver < Resolvers::BaseResolver
+      type Types::EngineType.connection_type, null: true
+
+      description "List all game engines."
+
+      sig { returns(Engine::RelationType) }
+      def resolve
+        Engine.all
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/engine_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/engine_resolvers/search_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module EngineResolvers
+    class SearchResolver < Resolvers::BaseResolver
+      type Types::EngineType.connection_type, null: true
+
+      description "Find a game engine by searching based on its name."
+
+      argument :query, String, required: true, description: "Name to search by."
+
+      sig { params(query: String).returns(Engine::RelationType) }
+      def resolve(query:)
+        Engine.search(query)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/game_purchase_resolver.rb
+++ b/app/graphql/resolvers/game_purchase_resolver.rb
@@ -1,0 +1,15 @@
+# typed: true
+module Resolvers
+  class GamePurchaseResolver < Resolvers::BaseResolver
+    type Types::GamePurchaseType, null: true
+
+    description "Find a game purchase by ID."
+
+    argument :id, ID, required: true
+
+    sig { params(id: T.any(String, Integer)).returns(GamePurchase) }
+    def resolve(id:)
+      GamePurchase.find(id)
+    end
+  end
+end

--- a/app/graphql/resolvers/game_resolvers/game_resolver.rb
+++ b/app/graphql/resolvers/game_resolvers/game_resolver.rb
@@ -1,0 +1,33 @@
+# typed: true
+module Resolvers
+  module GameResolvers
+    class GameResolver < Resolvers::BaseResolver
+      type Types::GameType, null: true
+
+      description "Find a game by ID or GiantBomb ID. May only use one of the filters at a time."
+
+      argument :id, ID, required: false, description: "Find a game by its unique ID."
+      argument :giantbomb_id, String, required: false, description: "Find a game by its GiantBomb ID, e.g. `'3030-23708'`."
+
+      # Use validator to validate that one of the arguments is being used.
+      validates required: {
+        one_of: [:id, :giantbomb_id],
+        message: 'Cannot provide more than one argument to game at a time.'
+      }
+
+      sig do
+        params(
+          id: T.nilable(T.any(String, Integer)),
+          giantbomb_id: T.nilable(String)
+        ).returns(T.nilable(Game))
+      end
+      def resolve(id: nil, giantbomb_id: nil)
+        if !id.nil?
+          Game.find(id)
+        elsif !giantbomb_id.nil?
+          Game.find_by(giantbomb_id: giantbomb_id)
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/game_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/game_resolvers/list_resolver.rb
@@ -1,0 +1,15 @@
+# typed: true
+module Resolvers
+  module GameResolvers
+    class ListResolver < Resolvers::BaseResolver
+      type Types::GameType.connection_type, null: true
+
+      description "List all games."
+
+      sig { returns(Game::RelationType) }
+      def resolve
+        Game.all
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/game_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/game_resolvers/search_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module GameResolvers
+    class SearchResolver < Resolvers::BaseResolver
+      type Types::GameType.connection_type, null: true
+
+      description "Find a game by searching based on its name."
+
+      argument :query, String, required: true, description: "Name to search by."
+
+      sig { params(query: String).returns(Game::RelationType) }
+      def resolve(query:)
+        Game.search(query)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/genre_resolvers/genre_resolver.rb
+++ b/app/graphql/resolvers/genre_resolvers/genre_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module GenreResolvers
+    class GenreResolver < Resolvers::BaseResolver
+      type Types::GenreType, null: true
+
+      description "Find a genre by ID."
+
+      argument :id, ID, required: true
+
+      sig { params(id: T.any(String, Integer)).returns(Genre) }
+      def resolve(id:)
+        Genre.find(id)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/genre_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/genre_resolvers/list_resolver.rb
@@ -1,0 +1,15 @@
+# typed: true
+module Resolvers
+  module GenreResolvers
+    class ListResolver < Resolvers::BaseResolver
+      type Types::GenreType.connection_type, null: true
+
+      description "List all genres."
+
+      sig { returns(Genre::RelationType) }
+      def resolve
+        Genre.all
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/genre_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/genre_resolvers/search_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module GenreResolvers
+    class SearchResolver < Resolvers::BaseResolver
+      type Types::GenreType.connection_type, null: true
+
+      description "Find a genre by searching based on its name."
+
+      argument :query, String, required: true, description: "Name to search by."
+
+      sig { params(query: String).returns(Genre::RelationType) }
+      def resolve(query:)
+        Genre.search(query)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/platform_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/platform_resolvers/list_resolver.rb
@@ -1,0 +1,15 @@
+# typed: true
+module Resolvers
+  module PlatformResolvers
+    class ListResolver < Resolvers::BaseResolver
+      type Types::PlatformType.connection_type, null: true
+
+      description "List all platforms."
+
+      sig { returns(Platform::RelationType) }
+      def resolve
+        Platform.all
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/platform_resolvers/platform_resolver.rb
+++ b/app/graphql/resolvers/platform_resolvers/platform_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module PlatformResolvers
+    class PlatformResolver < Resolvers::BaseResolver
+      type Types::PlatformType, null: true
+
+      description "Find a platform by ID."
+
+      argument :id, ID, required: true
+
+      sig { params(id: T.any(String, Integer)).returns(Platform) }
+      def resolve(id:)
+        Platform.find(id)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/platform_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/platform_resolvers/search_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module PlatformResolvers
+    class SearchResolver < Resolvers::BaseResolver
+      type Types::PlatformType.connection_type, null: true
+
+      description "Find a platform by searching based on its name."
+
+      argument :query, String, required: true, description: "Name to search by."
+
+      sig { params(query: String).returns(Platform::RelationType) }
+      def resolve(query:)
+        Platform.search(query)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/series_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/series_resolvers/list_resolver.rb
@@ -1,0 +1,15 @@
+# typed: true
+module Resolvers
+  module SeriesResolvers
+    class ListResolver < Resolvers::BaseResolver
+      type Types::SeriesType.connection_type, null: true
+
+      description "List all series'. This is different from the other list queries because series is the plural of series. :("
+
+      sig { returns(Series::RelationType) }
+      def resolve
+        Series.all
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/series_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/series_resolvers/search_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module SeriesResolvers
+    class SearchResolver < Resolvers::BaseResolver
+      type Types::SeriesType.connection_type, null: true
+
+      description "Find a series by searching based on its name."
+
+      argument :query, String, required: true, description: "Name to search by."
+
+      sig { params(query: String).returns(Series::RelationType) }
+      def resolve(query:)
+        Series.search(query)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/series_resolvers/series_resolver.rb
+++ b/app/graphql/resolvers/series_resolvers/series_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module SeriesResolvers
+    class SeriesResolver < Resolvers::BaseResolver
+      type Types::SeriesType, null: true
+
+      description "Find a series by ID."
+
+      argument :id, ID, required: true
+
+      sig { params(id: T.any(String, Integer)).returns(Series) }
+      def resolve(id:)
+        Series.find(id)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/store_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/store_resolvers/list_resolver.rb
@@ -1,0 +1,15 @@
+# typed: true
+module Resolvers
+  module StoreResolvers
+    class ListResolver < Resolvers::BaseResolver
+      type Types::StoreType.connection_type, null: true
+
+      description "List all stores."
+
+      sig { returns(Store::RelationType) }
+      def resolve
+        Store.all
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/store_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/store_resolvers/search_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module StoreResolvers
+    class SearchResolver < Resolvers::BaseResolver
+      type Types::StoreType.connection_type, null: true
+
+      description "Find a store by searching based on its name."
+
+      argument :query, String, required: true, description: "Name to search by."
+
+      sig { params(query: String).returns(Store::RelationType) }
+      def resolve(query:)
+        Store.search(query)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/store_resolvers/store_resolver.rb
+++ b/app/graphql/resolvers/store_resolvers/store_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module StoreResolvers
+    class StoreResolver < Resolvers::BaseResolver
+      type Types::StoreType, null: true
+
+      description "Find a store by ID."
+
+      argument :id, ID, required: true
+
+      sig { params(id: T.any(String, Integer)).returns(Store) }
+      def resolve(id:)
+        Store.find(id)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/user_resolvers/current_user_resolver.rb
+++ b/app/graphql/resolvers/user_resolvers/current_user_resolver.rb
@@ -1,0 +1,15 @@
+# typed: true
+module Resolvers
+  module UserResolvers
+    class CurrentUserResolver < Resolvers::BaseResolver
+      type Types::UserType, null: true
+
+      description "Get the currently authenticated user."
+
+      sig { returns(T.nilable(User)) }
+      def resolve
+        context[:current_user]
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/user_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/user_resolvers/list_resolver.rb
@@ -1,0 +1,16 @@
+# typed: true
+module Resolvers
+  module UserResolvers
+    class ListResolver < Resolvers::BaseResolver
+      type Types::UserType.connection_type, null: true
+
+      description "List all users."
+
+      sig { returns(User::RelationType) }
+      def resolve
+        # Exclude banned users from the results.
+        User.all.where(banned: false)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/user_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/user_resolvers/search_resolver.rb
@@ -1,0 +1,17 @@
+# typed: true
+module Resolvers
+  module UserResolvers
+    class SearchResolver < Resolvers::BaseResolver
+      type Types::UserType.connection_type, null: true
+
+      description "Find a user by searching based on its username."
+
+      argument :query, String, required: true, description: "Username to search by."
+
+      sig { params(query: String).returns(User::RelationType) }
+      def resolve(query:)
+        User.search(query)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/user_resolvers/user_resolver.rb
+++ b/app/graphql/resolvers/user_resolvers/user_resolver.rb
@@ -1,0 +1,28 @@
+# typed: true
+module Resolvers
+  module UserResolvers
+    class UserResolver < Resolvers::BaseResolver
+      type Types::UserType, null: true
+
+      description "Find a user. May only use one or the other."
+
+      argument :id, ID, required: false, description: "Find a user by their ID."
+      argument :username, String, required: false, description: "Find a user by their username."
+
+      # Use validator to validate that one of the arguments is being used.
+      validates required: {
+        one_of: [:id, :username],
+        message: 'Cannot provide more than one argument to user at a time.'
+      }
+
+      sig { params(id: T.nilable(T.any(String, Integer)), username: T.nilable(String)).returns(T.nilable(User)) }
+      def resolve(id: nil, username: nil)
+        if !id.nil?
+          User.find(id)
+        elsif !username.nil?
+          User.find_by(username: username)
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -5,300 +5,41 @@ module Types
 
     description "Queries are GraphQL requests that can be used to request data from vglist's database."
 
-    field :game, GameType, null: true do
-      description "Find a game by ID or GiantBomb ID. May only use one of the filters at a time."
-      argument :id, ID, required: false, description: "Find a game by its unique ID."
-      argument :giantbomb_id, String, required: false, description: "Find a game by its GiantBomb ID, e.g. `'3030-23708'`."
+    field :game, resolver: Resolvers::GameResolvers::GameResolver
+    field :games, resolver: Resolvers::GameResolvers::ListResolver
+    field :game_search, resolver: Resolvers::GameResolvers::SearchResolver
 
-      # Use validator to validate that one of the arguments is being used.
-      validates required: {
-        one_of: [:id, :giantbomb_id],
-        message: 'Cannot provide more than one argument to game at a time.'
-      }
-    end
+    field :series, resolver: Resolvers::SeriesResolvers::SeriesResolver
+    field :series_list, resolver: Resolvers::SeriesResolvers::ListResolver
+    field :series_search, resolver: Resolvers::SeriesResolvers::SearchResolver
 
-    field :games, GameType.connection_type, null: true do
-      description "List all games."
-    end
+    field :company, resolver: Resolvers::CompanyResolvers::CompanyResolver
+    field :companies, resolver: Resolvers::CompanyResolvers::ListResolver
+    field :company_search, resolver: Resolvers::CompanyResolvers::SearchResolver
 
-    field :game_search, GameType.connection_type, null: true do
-      description "Find a game by searching based on its name."
-      argument :query, String, required: true, description: "Name to search by."
-    end
+    field :platform, resolver: Resolvers::PlatformResolvers::PlatformResolver
+    field :platforms, resolver: Resolvers::PlatformResolvers::ListResolver
+    field :platform_search, resolver: Resolvers::PlatformResolvers::SearchResolver
 
-    field :series, SeriesType, null: true do
-      description "Find a series by ID."
-      argument :id, ID, required: true
-    end
+    field :engine, resolver: Resolvers::EngineResolvers::EngineResolver
+    field :engines, resolver: Resolvers::EngineResolvers::ListResolver
+    field :engine_search, resolver: Resolvers::EngineResolvers::SearchResolver
 
-    field :series_list, SeriesType.connection_type, null: true do
-      description "List all series'. This is different from the other list queries because series is the plural of series. :("
-    end
+    field :genre, resolver: Resolvers::GenreResolvers::GenreResolver
+    field :genres, resolver: Resolvers::GenreResolvers::ListResolver
+    field :genre_search, resolver: Resolvers::GenreResolvers::SearchResolver
 
-    field :series_search, SeriesType.connection_type, null: true do
-      description "Find a series by searching based on its name."
-      argument :query, String, required: true, description: "Name to search by."
-    end
+    field :store, resolver: Resolvers::StoreResolvers::StoreResolver
+    field :stores, resolver: Resolvers::StoreResolvers::ListResolver
+    field :store_search, resolver: Resolvers::StoreResolvers::SearchResolver
 
-    field :company, CompanyType, null: true do
-      description "Find a company by ID."
-      argument :id, ID, required: true
-    end
+    field :user, resolver: Resolvers::UserResolvers::UserResolver
+    field :users, resolver: Resolvers::UserResolvers::ListResolver
+    field :user_search, resolver: Resolvers::UserResolvers::SearchResolver
+    field :current_user, resolver: Resolvers::UserResolvers::CurrentUserResolver
 
-    field :companies, CompanyType.connection_type, null: true do
-      description "List all companies."
-    end
+    field :game_purchase, resolver: Resolvers::GamePurchaseResolver
 
-    field :company_search, CompanyType.connection_type, null: true do
-      description "Find a company by searching based on its name."
-      argument :query, String, required: true, description: "Name to search by."
-    end
-
-    field :platform, PlatformType, null: true do
-      description "Find a platform by ID."
-      argument :id, ID, required: true
-    end
-
-    field :platforms, PlatformType.connection_type, null: true do
-      description "List all platforms."
-    end
-
-    field :platform_search, PlatformType.connection_type, null: true do
-      description "Find a platform by searching based on its name."
-      argument :query, String, required: true, description: "Name to search by."
-    end
-
-    field :engine, EngineType, null: true do
-      description "Find a game engine by ID."
-      argument :id, ID, required: true
-    end
-
-    field :engines, EngineType.connection_type, null: true do
-      description "List all game engines."
-    end
-
-    field :engine_search, EngineType.connection_type, null: true do
-      description "Find a game engine by searching based on its name."
-      argument :query, String, required: true, description: "Name to search by."
-    end
-
-    field :genre, GenreType, null: true do
-      description "Find a genre by ID."
-      argument :id, ID, required: true
-    end
-
-    field :genres, GenreType.connection_type, null: true do
-      description "List all genres."
-    end
-
-    field :genre_search, GenreType.connection_type, null: true do
-      description "Find a genre by searching based on its name."
-      argument :query, String, required: true, description: "Name to search by."
-    end
-
-    field :store, StoreType, null: true do
-      description "Find a store by ID."
-      argument :id, ID, required: true
-    end
-
-    field :stores, StoreType.connection_type, null: true do
-      description "List all stores."
-    end
-
-    field :store_search, StoreType.connection_type, null: true do
-      description "Find a store by searching based on its name."
-      argument :query, String, required: true, description: "Name to search by."
-    end
-
-    field :user, UserType, null: true do
-      description "Find a user. May only use one or the other."
-      argument :id, ID, required: false, description: "Find a user by their ID."
-      argument :username, String, required: false, description: "Find a user by their username."
-
-      # Use validator to validate that one of the arguments is being used.
-      validates required: {
-        one_of: [:id, :username],
-        message: 'Cannot provide more than one argument to user at a time.'
-      }
-    end
-
-    field :current_user, UserType, null: true do
-      description "Get the currently authenticated user."
-    end
-
-    field :users, UserType.connection_type, null: true do
-      description "List all users."
-    end
-
-    field :user_search, UserType.connection_type, null: true do
-      description "Find a user by searching based on its username."
-      argument :query, String, required: true, description: "Username to search by."
-    end
-
-    field :game_purchase, GamePurchaseType, null: true do
-      description "Find a game purchase by ID."
-      argument :id, ID, required: true
-    end
-
-    field :activity, EventType.connection_type, null: true do
-      description "View recent activity."
-      argument :feed_type, ActivityFeedType, required: false
-    end
-
-    sig { params(id: T.nilable(T.any(String, Integer)), giantbomb_id: T.nilable(String)).returns(T.nilable(Game)) }
-    def game(id: nil, giantbomb_id: nil)
-      if !id.nil?
-        Game.find(id)
-      elsif !giantbomb_id.nil?
-        Game.find_by(giantbomb_id: giantbomb_id)
-      end
-    end
-
-    sig { returns(Game::RelationType) }
-    def games
-      Game.all
-    end
-
-    sig { params(query: String).returns(Game::RelationType) }
-    def game_search(query:)
-      Game.search(query)
-    end
-
-    sig { params(id: T.any(String, Integer)).returns(Series) }
-    def series(id:)
-      Series.find(id)
-    end
-
-    sig { returns(Series::RelationType) }
-    def series_list
-      Series.all
-    end
-
-    sig { params(query: String).returns(Series::RelationType) }
-    def series_search(query:)
-      Series.search(query)
-    end
-
-    sig { params(id: T.any(String, Integer)).returns(Company) }
-    def company(id:)
-      Company.find(id)
-    end
-
-    sig { returns(Company::RelationType) }
-    def companies
-      Company.all
-    end
-
-    sig { params(query: String).returns(Company::RelationType) }
-    def company_search(query:)
-      Company.search(query)
-    end
-
-    sig { params(id: T.any(String, Integer)).returns(Platform) }
-    def platform(id:)
-      Platform.find(id)
-    end
-
-    sig { returns(Platform::RelationType) }
-    def platforms
-      Platform.all
-    end
-
-    sig { params(query: String).returns(Platform::RelationType) }
-    def platform_search(query:)
-      Platform.search(query)
-    end
-
-    sig { params(id: T.any(String, Integer)).returns(Engine) }
-    def engine(id:)
-      Engine.find(id)
-    end
-
-    sig { returns(Engine::RelationType) }
-    def engines
-      Engine.all
-    end
-
-    sig { params(query: String).returns(Engine::RelationType) }
-    def engine_search(query:)
-      Engine.search(query)
-    end
-
-    sig { params(id: T.any(String, Integer)).returns(Genre) }
-    def genre(id:)
-      Genre.find(id)
-    end
-
-    sig { returns(Genre::RelationType) }
-    def genres
-      Genre.all
-    end
-
-    sig { params(query: String).returns(Genre::RelationType) }
-    def genre_search(query:)
-      Genre.search(query)
-    end
-
-    sig { params(id: T.any(String, Integer)).returns(Store) }
-    def store(id:)
-      Store.find(id)
-    end
-
-    sig { returns(Store::RelationType) }
-    def stores
-      Store.all
-    end
-
-    sig { params(query: String).returns(Store::RelationType) }
-    def store_search(query:)
-      Store.search(query)
-    end
-
-    sig { params(id: T.nilable(T.any(String, Integer)), username: T.nilable(String)).returns(T.nilable(User)) }
-    def user(id: nil, username: nil)
-      if !id.nil?
-        User.find(id)
-      elsif !username.nil?
-        User.find_by(username: username)
-      end
-    end
-
-    sig { returns(T.nilable(User)) }
-    def current_user
-      context[:current_user]
-    end
-
-    sig { returns(User::RelationType) }
-    def users
-      # Exclude banned users from the results.
-      User.all.where(banned: false)
-    end
-
-    sig { params(query: String).returns(User::RelationType) }
-    def user_search(query:)
-      User.search(query)
-    end
-
-    sig { params(id: T.any(String, Integer)).returns(GamePurchase) }
-    def game_purchase(id:)
-      GamePurchase.find(id)
-    end
-
-    sig { params(feed_type: String).returns(T.nilable(Event::RelationType)) }
-    def activity(feed_type: 'following')
-      case feed_type
-      when 'global'
-        Event.recently_created
-             .joins(:user)
-             .where(users: { privacy: :public_account })
-      when 'following'
-        user_ids = @context[:current_user]&.following&.map { |u| u.id }
-        # Include the user's own activity in the feed.
-        user_ids << @context[:current_user].id
-        Event.recently_created
-             .joins(:user)
-             .where(user_id: user_ids)
-      end
-    end
+    field :activity, resolver: Resolvers::ActivityResolver
   end
 end


### PR DESCRIPTION
This is much better in terms of maintainability, no more massive `query_type.rb` file to maintain :)

This shouldn't functionally change anything with what the GraphQL API outputs (and didn't require any changes to tests!)