### PR TITLE
Fix user search outputting bad data.

### DIFF
--- a/app/javascript/src/components/search.vue
+++ b/app/javascript/src/components/search.vue
@@ -195,8 +195,9 @@ export default {
           return true;
         }
         betterSearchResults[key].map(result => {
-          // Use the username in the URL if it's a user.
-          let url_key = result.searchable_type === 'User' ? result.content : result.searchable_id;
+          // Use the id in the URL if it's a user because the id is sluggified
+          // and 'friendly' (aka not a number).
+          let url_key = result.searchable_type === 'User' ? result.id : result.searchable_id;
           result.url = `/${this.plurals[result.searchable_type]}/${url_key}`;
           return result;
         });

--- a/app/javascript/src/components/search.vue
+++ b/app/javascript/src/components/search.vue
@@ -195,9 +195,8 @@ export default {
           return true;
         }
         betterSearchResults[key].map(result => {
-          // Use the id in the URL if it's a user because the id is sluggified
-          // and 'friendly' (aka not a number).
-          let url_key = result.searchable_type === 'User' ? result.id : result.searchable_id;
+          // Use the slug in the URL if it's a user.
+          let url_key = result.searchable_type === 'User' ? result.slug : result.searchable_id;
           result.url = `/${this.plurals[result.searchable_type]}/${url_key}`;
           return result;
         });

--- a/app/views/search/index.json.jbuilder
+++ b/app/views/search/index.json.jbuilder
@@ -13,7 +13,8 @@ complex_types = ['Game', 'User'].freeze
     results_of_type = @search_results.select { |result| result[:searchable_type] == type }
     if complex_types.include?(type)
       json.array!(results_of_type) do |pg_search|
-        json.id pg_search.searchable.id
+        # Use friendly_id if it's a user so the link is correct.
+        json.id type == 'User' ? pg_search.searchable.friendly_id : pg_search.searchable.id
         json.content pg_search.content
         json.searchable_type pg_search.searchable_type
         json.searchable_id pg_search.searchable_id

--- a/app/views/search/index.json.jbuilder
+++ b/app/views/search/index.json.jbuilder
@@ -13,8 +13,7 @@ complex_types = ['Game', 'User'].freeze
     results_of_type = @search_results.select { |result| result[:searchable_type] == type }
     if complex_types.include?(type)
       json.array!(results_of_type) do |pg_search|
-        # Use friendly_id if it's a user so the link is correct.
-        json.id type == 'User' ? pg_search.searchable.friendly_id : pg_search.searchable.id
+        json.id pg_search.searchable.id
         json.content pg_search.content
         json.searchable_type pg_search.searchable_type
         json.searchable_id pg_search.searchable_id
@@ -33,6 +32,8 @@ complex_types = ['Game', 'User'].freeze
           else
             json.image_url asset_path('default-avatar.png')
           end
+          # Provide the slug if it's a user so the link is correct.
+          json.slug pg_search.searchable.friendly_id
         end
       end
     else

--- a/spec/support/search_test_helper.rb
+++ b/spec/support/search_test_helper.rb
@@ -28,13 +28,14 @@
 #
 # @param [String] searchables The JSON string representing the search results. See format above.
 # @param [String] type The type of returned searchable to filter to, one of ['Game', 'Series', 'Company', 'Platform', 'Engine', 'Genre, 'User']
-# @return [Array<Hash>] A hash with `searchable_id`, `content`, and `searchable_type` keys.
-def searchable_helper(searchables, type)
+# @param [Array<Symbol>] keys The keys to return from the searchable objects, by default `searchable_id`, `content`, and `searchable_type`.
+# @return [Array<Hash>] A hash with whatever keys are determined by `keys`.
+def searchable_helper(searchables, type, keys = [:searchable_id, :content, :searchable_type])
   return JSON.parse(searchables)[type].map do |searchable|
-    {
-      searchable_id: searchable['searchable_id'],
-      content: searchable['content'],
-      searchable_type: searchable['searchable_type']
-    }
+    hash = {}
+    keys.each do |key|
+      hash[key] = searchable[key.to_s]
+    end
+    hash
   end
 end


### PR DESCRIPTION
Previously usernames with `.` or capital letters lead to invalid pages because the URL was being created incorrectly.

Fixes #1775.