### PR TITLE
Add GraphQL spec helpers

### DIFF
--- a/spec/requests/api/activity_spec.rb
+++ b/spec/requests/api/activity_spec.rb
@@ -32,25 +32,25 @@ RSpec.describe "Activity API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result["data"]["activity"]["nodes"]).to include(
+      expect(result.graphql_dig(:activity, :nodes)).to include(
         {
-          "user" => {
-            "username" => user.username
+          user: {
+            username: user.username
           },
-          "eventable" => {
-            "__typename" => "GamePurchase"
+          eventable: {
+            __typename: "GamePurchase"
           }
         },
         {
-          "user" => {
-            "username" => user.username
+          user: {
+            username: user.username
           },
-          "eventable" => {
-            "__typename" => "User"
+          eventable: {
+            __typename: "User"
           }
         }
       )
-      expect(result["data"]["activity"]["nodes"].length).to eq(2)
+      expect(result.graphql_dig(:activity, :nodes).length).to eq(2)
     end
 
     it "returns data for various types of activity events" do
@@ -88,50 +88,50 @@ RSpec.describe "Activity API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result["data"]["activity"]["nodes"]).to include(
+      expect(result.graphql_dig(:activity, :nodes)).to include(
         {
-          "user" => {
-            "username" => user.username
+          user: {
+            username: user.username
           },
-          "eventable" => {
-            "__typename" => "FavoriteGame",
-            "id" => favorite_game.id.to_s
+          eventable: {
+            __typename: "FavoriteGame",
+            id: favorite_game.id.to_s
           }
         },
         {
-          "user" => {
-            "username" => user.username
+          user: {
+            username: user.username
           },
-          "eventable" => {
-            "__typename" => "Relationship",
-            "id" => relationship.id.to_s
+          eventable: {
+            __typename: "Relationship",
+            id: relationship.id.to_s
           }
         },
         {
-          "user" => {
-            "username" => user2.username
+          user: {
+            username: user2.username
           },
-          "eventable" => {
-            "__typename" => "User",
-            "id" => user2.id.to_s
+          eventable: {
+            __typename: "User",
+            id: user2.id.to_s
           }
         },
         {
-          "user" => {
-            "username" => user.username
+          user: {
+            username: user.username
           },
-          "eventable" => {
-            "__typename" => "GamePurchase",
-            "id" => game_purchase.id.to_s
+          eventable: {
+            __typename: "GamePurchase",
+            id: game_purchase.id.to_s
           }
         },
         {
-          "user" => {
-            "username" => user.username
+          user: {
+            username: user.username
           },
-          "eventable" => {
-            "__typename" => "User",
-            "id" => user.id.to_s
+          eventable: {
+            __typename: "User",
+            id: user.id.to_s
           }
         }
       )
@@ -160,30 +160,30 @@ RSpec.describe "Activity API", type: :request do
       result = api_request(query_string, token: access_token)
 
       # Doesn't include user3 because user isn't following them.
-      expect(result["data"]["activity"]["nodes"]).to eq(
+      expect(result.graphql_dig(:activity, :nodes)).to eq(
         [
           {
-            "user" => {
-              "username" => user.username
+            user: {
+              username: user.username
             },
-            "eventable" => {
-              "__typename" => "Relationship"
+            eventable: {
+              __typename: "Relationship"
             }
           },
           {
-            "user" => {
-              "username" => user2.username
+            user: {
+              username: user2.username
             },
-            "eventable" => {
-              "__typename" => "User"
+            eventable: {
+              __typename: "User"
             }
           },
           {
-            "user" => {
-              "username" => user.username
+            user: {
+              username: user.username
             },
-            "eventable" => {
-              "__typename" => "User"
+            eventable: {
+              __typename: "User"
             }
           }
         ]

--- a/spec/requests/api/companies_spec.rb
+++ b/spec/requests/api/companies_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe "Companies API", type: :request do
 
       result = api_request(query_string, variables: { id: company.id }, token: access_token)
 
-      expect(result["data"]["company"]).to eq(
+      expect(result.graphql_dig(:company)).to eq(
         {
-          "id" => company.id.to_s,
-          "name" => company.name
+          id: company.id.to_s,
+          name: company.name
         }
       )
     end
@@ -45,10 +45,10 @@ RSpec.describe "Companies API", type: :request do
 
       result = api_request(query_string, variables: { query: company.name }, token: access_token)
 
-      expect(result["data"]["companySearch"]["nodes"]).to eq(
+      expect(result.graphql_dig(:companySearch, :nodes)).to eq(
         [{
-          "id" => company.id.to_s,
-          "name" => company.name
+          id: company.id.to_s,
+          name: company.name
         }]
       )
     end
@@ -69,15 +69,15 @@ RSpec.describe "Companies API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result["data"]["companies"]["nodes"]).to eq(
+      expect(result.graphql_dig(:companies, :nodes)).to eq(
         [
           {
-            "id" => company.id.to_s,
-            "name" => company.name
+            id: company.id.to_s,
+            name: company.name
           },
           {
-            "id" => company2.id.to_s,
-            "name" => company2.name
+            id: company2.id.to_s,
+            name: company2.name
           }
         ]
       )

--- a/spec/requests/api/companies_spec.rb
+++ b/spec/requests/api/companies_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Companies API", type: :request do
 
       result = api_request(query_string, variables: { query: company.name }, token: access_token)
 
-      expect(result.graphql_dig(:companySearch, :nodes)).to eq(
+      expect(result.graphql_dig(:company_search, :nodes)).to eq(
         [{
           id: company.id.to_s,
           name: company.name

--- a/spec/requests/api/engines_spec.rb
+++ b/spec/requests/api/engines_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Engines API", type: :request do
 
       result = api_request(query_string, variables: { query: engine.name }, token: access_token)
 
-      expect(result.graphql_dig(:engineSearch, :nodes)).to eq(
+      expect(result.graphql_dig(:engine_search, :nodes)).to eq(
         [{
           id: engine.id.to_s,
           name: engine.name

--- a/spec/requests/api/engines_spec.rb
+++ b/spec/requests/api/engines_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe "Engines API", type: :request do
 
       result = api_request(query_string, variables: { id: engine.id }, token: access_token)
 
-      expect(result["data"]["engine"]).to eq(
+      expect(result.graphql_dig(:engine)).to eq(
         {
-          "id" => engine.id.to_s,
-          "name" => engine.name
+          id: engine.id.to_s,
+          name: engine.name
         }
       )
     end
@@ -45,10 +45,10 @@ RSpec.describe "Engines API", type: :request do
 
       result = api_request(query_string, variables: { query: engine.name }, token: access_token)
 
-      expect(result["data"]["engineSearch"]["nodes"]).to eq(
+      expect(result.graphql_dig(:engineSearch, :nodes)).to eq(
         [{
-          "id" => engine.id.to_s,
-          "name" => engine.name
+          id: engine.id.to_s,
+          name: engine.name
         }]
       )
     end
@@ -69,15 +69,15 @@ RSpec.describe "Engines API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result.to_h["data"]["engines"]["nodes"]).to eq(
+      expect(result.graphql_dig(:engines, :nodes)).to eq(
         [
           {
-            "id" => engine.id.to_s,
-            "name" => engine.name
+            id: engine.id.to_s,
+            name: engine.name
           },
           {
-            "id" => engine2.id.to_s,
-            "name" => engine2.name
+            id: engine2.id.to_s,
+            name: engine2.name
           }
         ]
       )

--- a/spec/requests/api/game_purchases_spec.rb
+++ b/spec/requests/api/game_purchases_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe "GamePurchase API", type: :request do
 
       result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
 
-      expect(result["data"]["gamePurchase"]).to eq(
+      expect(result.graphql_dig(:gamePurchase)).to eq(
         {
-          "id" => game_purchase.id.to_s,
-          "rating" => game_purchase.rating,
-          "comments" => game_purchase.comments
+          id: game_purchase.id.to_s,
+          rating: game_purchase.rating,
+          comments: game_purchase.comments
         }
       )
     end
@@ -53,7 +53,7 @@ RSpec.describe "GamePurchase API", type: :request do
 
       result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
 
-      expect(result["data"]["gamePurchase"]).to eq(nil)
+      expect(result.graphql_dig(:gamePurchase)).to eq(nil)
     end
   end
 end

--- a/spec/requests/api/game_purchases_spec.rb
+++ b/spec/requests/api/game_purchases_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "GamePurchase API", type: :request do
 
       result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
 
-      expect(result.graphql_dig(:gamePurchase)).to eq(
+      expect(result.graphql_dig(:game_purchase)).to eq(
         {
           id: game_purchase.id.to_s,
           rating: game_purchase.rating,
@@ -53,7 +53,7 @@ RSpec.describe "GamePurchase API", type: :request do
 
       result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
 
-      expect(result.graphql_dig(:gamePurchase)).to eq(nil)
+      expect(result.graphql_dig(:game_purchase)).to eq(nil)
     end
   end
 end

--- a/spec/requests/api/games_spec.rb
+++ b/spec/requests/api/games_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe "Games API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result["data"]["game"]).to eq(
+      expect(result.graphql_dig(:game)).to eq(
         {
-          "id" => game.id.to_s,
-          "name" => game.name
+          id: game.id.to_s,
+          name: game.name
         }
       )
     end
@@ -48,12 +48,10 @@ RSpec.describe "Games API", type: :request do
 
       result = api_request(query_string, variables: { id: game_with_steam_app_ids.id }, token: access_token)
 
-      expect(result["data"]["game"]).to eq(
-        {
-          "id" => game_with_steam_app_ids.id.to_s,
-          "name" => game_with_steam_app_ids.name,
-          "steamAppIds" => game_with_steam_app_ids.steam_app_ids.map(&:app_id)
-        }
+      expect(result.graphql_dig(:game)).to include(
+        id: game_with_steam_app_ids.id.to_s,
+        name: game_with_steam_app_ids.name,
+        steamAppIds: game_with_steam_app_ids.steam_app_ids.map(&:app_id)
       )
     end
 
@@ -73,11 +71,11 @@ RSpec.describe "Games API", type: :request do
 
       cover_variant = game_with_cover.sized_cover(:small)
 
-      expect(result["data"]["game"]).to eq(
+      expect(result.graphql_dig(:game)).to eq(
         {
-          "id" => game_with_cover.id.to_s,
-          "name" => game_with_cover.name,
-          "coverUrl" => Rails.application.routes.url_helpers.rails_representation_url(cover_variant)
+          id: game_with_cover.id.to_s,
+          name: game_with_cover.name,
+          coverUrl: Rails.application.routes.url_helpers.rails_representation_url(cover_variant)
         }
       )
     end
@@ -96,11 +94,11 @@ RSpec.describe "Games API", type: :request do
 
       result = api_request(query_string, variables: { id: game_with_release_date.id }, token: access_token)
 
-      expect(result["data"]["game"]).to eq(
+      expect(result.graphql_dig(:game)).to eq(
         {
-          "id" => game_with_release_date.id.to_s,
-          "name" => game_with_release_date.name,
-          "releaseDate" => game_with_release_date.release_date.strftime("%F")
+          id: game_with_release_date.id.to_s,
+          name: game_with_release_date.name,
+          releaseDate: game_with_release_date.release_date.strftime("%F")
         }
       )
     end
@@ -117,10 +115,10 @@ RSpec.describe "Games API", type: :request do
 
       result = api_request(query_string, variables: { giantbomb_id: game_with_giantbomb_id.giantbomb_id }, token: access_token)
 
-      expect(result["data"]["game"]).to eq(
+      expect(result.graphql_dig(:game)).to eq(
         {
-          "id" => game_with_giantbomb_id.id.to_s,
-          "name" => game_with_giantbomb_id.name
+          id: game_with_giantbomb_id.id.to_s,
+          name: game_with_giantbomb_id.name
         }
       )
     end
@@ -137,8 +135,8 @@ RSpec.describe "Games API", type: :request do
 
       result = api_request(query_string, variables: { id: game_with_giantbomb_id.id, giantbomb_id: game_with_giantbomb_id.giantbomb_id }, token: access_token)
 
-      expect(result["data"]["game"]).to be_nil
-      expect(result["errors"].first['message']).to eq('Cannot provide more than one argument to game at a time.')
+      expect(result.graphql_dig(:game)).to be_nil
+      expect(result.to_h["errors"].first['message']).to eq('Cannot provide more than one argument to game at a time.')
     end
 
     it "returns data for a game when searching" do
@@ -156,11 +154,9 @@ RSpec.describe "Games API", type: :request do
 
       result = api_request(query_string, variables: { query: game.name }, token: access_token)
 
-      expect(result["data"]["gameSearch"]["nodes"]).to eq(
-        [{
-          "id" => game.id.to_s,
-          "name" => game.name
-        }]
+      expect(result.graphql_dig(:game_search, :nodes)).to include_hash_matching(
+        id: game.id.to_s,
+        name: game.name
       )
     end
 
@@ -179,15 +175,15 @@ RSpec.describe "Games API", type: :request do
       GRAPHQL
 
       result = api_request(query_string, token: access_token)
-      expect(result["data"]["games"]["nodes"]).to eq(
+      expect(result.graphql_dig(:games, :nodes)).to eq(
         [
           {
-            "id" => game.id.to_s,
-            "name" => game.name
+            id: game.id.to_s,
+            name: game.name
           },
           {
-            "id" => game2.id.to_s,
-            "name" => game2.name
+            id: game2.id.to_s,
+            name: game2.name
           }
         ]
       )

--- a/spec/requests/api/generic_spec.rb
+++ b/spec/requests/api/generic_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe "API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result.graphql_dig(:games, :pageInfo, :hasNextPage)).to eq(true)
-      expect(result.graphql_dig(:games, :pageInfo, :pageSize)).to eq(30)
+      expect(result.graphql_dig(:games, :page_info, :has_next_page)).to eq(true)
+      expect(result.graphql_dig(:games, :page_info, :page_size)).to eq(30)
     end
   end
 end

--- a/spec/requests/api/generic_spec.rb
+++ b/spec/requests/api/generic_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe "API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result["data"]["games"]["pageInfo"]["hasNextPage"]).to eq(true)
-      expect(result["data"]["games"]["pageInfo"]["pageSize"]).to eq(30)
+      expect(result.graphql_dig(:games, :pageInfo, :hasNextPage)).to eq(true)
+      expect(result.graphql_dig(:games, :pageInfo, :pageSize)).to eq(30)
     end
   end
 end

--- a/spec/requests/api/genres_spec.rb
+++ b/spec/requests/api/genres_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe "Genres API", type: :request do
 
       result = api_request(query_string, variables: { id: genre.id }, token: access_token)
 
-      expect(result["data"]["genre"]).to eq(
+      expect(result.graphql_dig(:genre)).to eq(
         {
-          "id" => genre.id.to_s,
-          "name" => genre.name
+          id: genre.id.to_s,
+          name: genre.name
         }
       )
     end
@@ -45,10 +45,10 @@ RSpec.describe "Genres API", type: :request do
 
       result = api_request(query_string, variables: { query: genre.name }, token: access_token)
 
-      expect(result["data"]["genreSearch"]["nodes"]).to eq(
+      expect(result.graphql_dig(:genreSearch, :nodes)).to eq(
         [{
-          "id" => genre.id.to_s,
-          "name" => genre.name
+          id: genre.id.to_s,
+          name: genre.name
         }]
       )
     end
@@ -69,15 +69,15 @@ RSpec.describe "Genres API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result["data"]["genres"]["nodes"]).to eq(
+      expect(result.graphql_dig(:genres, :nodes)).to eq(
         [
           {
-            "id" => genre.id.to_s,
-            "name" => genre.name
+            id: genre.id.to_s,
+            name: genre.name
           },
           {
-            "id" => genre2.id.to_s,
-            "name" => genre2.name
+            id: genre2.id.to_s,
+            name: genre2.name
           }
         ]
       )

--- a/spec/requests/api/genres_spec.rb
+++ b/spec/requests/api/genres_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Genres API", type: :request do
 
       result = api_request(query_string, variables: { query: genre.name }, token: access_token)
 
-      expect(result.graphql_dig(:genreSearch, :nodes)).to eq(
+      expect(result.graphql_dig(:genre_search, :nodes)).to eq(
         [{
           id: genre.id.to_s,
           name: genre.name

--- a/spec/requests/api/mutations/add_game_to_library_spec.rb
+++ b/spec/requests/api/mutations/add_game_to_library_spec.rb
@@ -41,18 +41,18 @@ RSpec.describe "AddGameToLibrary Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result["data"]["addGameToLibrary"]["gamePurchase"]).to eq(
+      expect(result.graphql_dig(:addGameToLibrary, :gamePurchase)).to eq(
         {
-          "user" => {
-            "id" => user.id.to_s
+          user: {
+            id: user.id.to_s
           },
-          "game" => {
-            "name" => game.name
+          game: {
+            name: game.name
           },
-          "hoursPlayed" => nil,
-          "comments" => "",
-          "completionStatus" => nil,
-          "rating" => nil
+          hoursPlayed: nil,
+          comments: "",
+          completionStatus: nil,
+          rating: nil
         }
       )
     end
@@ -107,20 +107,20 @@ RSpec.describe "AddGameToLibrary Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result["data"]["addGameToLibrary"]["gamePurchase"]).to eq(
+      expect(result.graphql_dig(:addGameToLibrary, :gamePurchase)).to eq(
         {
-          "user" => {
-            "id" => user.id.to_s
+          user: {
+            id: user.id.to_s
           },
-          "game" => {
-            "name" => game.name
+          game: {
+            name: game.name
           },
-          "hoursPlayed" => 10,
-          "comments" => "Pretty good",
-          "completionStatus" => "NOT_APPLICABLE",
-          "rating" => 100,
-          "startDate" => "2019-10-10",
-          "completionDate" => "2019-10-11"
+          hoursPlayed: 10,
+          comments: "Pretty good",
+          completionStatus: "NOT_APPLICABLE",
+          rating: 100,
+          startDate: "2019-10-10",
+          completionDate: "2019-10-11"
         }
       )
     end

--- a/spec/requests/api/mutations/add_game_to_library_spec.rb
+++ b/spec/requests/api/mutations/add_game_to_library_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "AddGameToLibrary Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.graphql_dig(:addGameToLibrary, :gamePurchase)).to eq(
+      expect(result.graphql_dig(:add_game_to_library, :game_purchase)).to eq(
         {
           user: {
             id: user.id.to_s
@@ -107,7 +107,7 @@ RSpec.describe "AddGameToLibrary Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.graphql_dig(:addGameToLibrary, :gamePurchase)).to eq(
+      expect(result.graphql_dig(:add_game_to_library, :game_purchase)).to eq(
         {
           user: {
             id: user.id.to_s

--- a/spec/requests/api/mutations/favorite_game_spec.rb
+++ b/spec/requests/api/mutations/favorite_game_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe "FavoriteGame Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result["data"]["favoriteGame"]["game"]).to eq(
+      expect(result.graphql_dig(:favoriteGame, :game)).to eq(
         {
-          "id" => game.id.to_s,
-          "name" => game.name
+          id: game.id.to_s,
+          name: game.name
         }
       )
     end

--- a/spec/requests/api/mutations/favorite_game_spec.rb
+++ b/spec/requests/api/mutations/favorite_game_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "FavoriteGame Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.graphql_dig(:favoriteGame, :game)).to eq(
+      expect(result.graphql_dig(:favorite_game, :game)).to eq(
         {
           id: game.id.to_s,
           name: game.name

--- a/spec/requests/api/mutations/follow_user_spec.rb
+++ b/spec/requests/api/mutations/follow_user_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "FollowUser Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: user2.id }, token: access_token)
 
-      expect(result.graphql_dig(:followUser, :user)).to eq(
+      expect(result.graphql_dig(:follow_user, :user)).to eq(
         {
           id: user2.id.to_s,
           username: user2.username

--- a/spec/requests/api/mutations/follow_user_spec.rb
+++ b/spec/requests/api/mutations/follow_user_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe "FollowUser Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: user2.id }, token: access_token)
 
-      expect(result["data"]["followUser"]["user"]).to eq(
+      expect(result.graphql_dig(:followUser, :user)).to eq(
         {
-          "id" => user2.id.to_s,
-          "username" => user2.username
+          id: user2.id.to_s,
+          username: user2.username
         }
       )
     end

--- a/spec/requests/api/mutations/remove_game_from_library_spec.rb
+++ b/spec/requests/api/mutations/remove_game_from_library_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.graphql_dig(:removeGameFromLibrary, :game)).to eq(
+      expect(result.graphql_dig(:remove_game_from_library, :game)).to eq(
         {
           id: game.id.to_s,
           name: game.name
@@ -61,7 +61,7 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
 
       result = api_request(query_string2, variables: { id: game_purchase.id }, token: access_token)
 
-      expect(result.graphql_dig(:removeGameFromLibrary, :game)).to eq(
+      expect(result.graphql_dig(:remove_game_from_library, :game)).to eq(
         {
           id: game_purchase.game.id.to_s,
           name: game_purchase.game.name

--- a/spec/requests/api/mutations/remove_game_from_library_spec.rb
+++ b/spec/requests/api/mutations/remove_game_from_library_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result["data"]["removeGameFromLibrary"]["game"]).to eq(
+      expect(result.graphql_dig(:removeGameFromLibrary, :game)).to eq(
         {
-          "id" => game.id.to_s,
-          "name" => game.name
+          id: game.id.to_s,
+          name: game.name
         }
       )
     end
@@ -61,10 +61,10 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
 
       result = api_request(query_string2, variables: { id: game_purchase.id }, token: access_token)
 
-      expect(result["data"]["removeGameFromLibrary"]["game"]).to eq(
+      expect(result.graphql_dig(:removeGameFromLibrary, :game)).to eq(
         {
-          "id" => game_purchase.game.id.to_s,
-          "name" => game_purchase.game.name
+          id: game_purchase.game.id.to_s,
+          name: game_purchase.game.name
         }
       )
     end
@@ -74,7 +74,7 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
 
       expect do
         response = api_request(query_string2, variables: { id: game_purchase_for_other_user.id }, token: access_token)
-        expect(response['errors'].first['message']).to eq("You aren't allowed to delete this game purchase.")
+        expect(response.to_h['errors'].first['message']).to eq("You aren't allowed to delete this game purchase.")
       end.to change(GamePurchase, :count).by(0)
     end
   end

--- a/spec/requests/api/mutations/unfavorite_game_spec.rb
+++ b/spec/requests/api/mutations/unfavorite_game_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe "UnfavoriteGame Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result["data"]["unfavoriteGame"]["game"]).to eq(
+      expect(result.graphql_dig(:unfavoriteGame, :game)).to eq(
         {
-          "id" => game.id.to_s,
-          "name" => game.name
+          id: game.id.to_s,
+          name: game.name
         }
       )
     end

--- a/spec/requests/api/mutations/unfavorite_game_spec.rb
+++ b/spec/requests/api/mutations/unfavorite_game_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "UnfavoriteGame Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.graphql_dig(:unfavoriteGame, :game)).to eq(
+      expect(result.graphql_dig(:unfavorite_game, :game)).to eq(
         {
           id: game.id.to_s,
           name: game.name

--- a/spec/requests/api/mutations/unfollow_user_spec.rb
+++ b/spec/requests/api/mutations/unfollow_user_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe "UnfollowUser Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: user2.id }, token: access_token)
 
-      expect(result["data"]["unfollowUser"]["user"]).to eq(
+      expect(result.graphql_dig(:unfollowUser, :user)).to eq(
         {
-          "id" => user2.id.to_s,
-          "username" => user2.username
+          id: user2.id.to_s,
+          username: user2.username
         }
       )
     end

--- a/spec/requests/api/mutations/unfollow_user_spec.rb
+++ b/spec/requests/api/mutations/unfollow_user_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "UnfollowUser Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: user2.id }, token: access_token)
 
-      expect(result.graphql_dig(:unfollowUser, :user)).to eq(
+      expect(result.graphql_dig(:unfollow_user, :user)).to eq(
         {
           id: user2.id.to_s,
           username: user2.username

--- a/spec/requests/api/mutations/update_game_in_library_spec.rb
+++ b/spec/requests/api/mutations/update_game_in_library_spec.rb
@@ -33,15 +33,15 @@ RSpec.describe "UpdateGameInLibrary Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
 
-      expect(result["data"]["updateGameInLibrary"]["gamePurchase"]).to eq(
+      expect(result.graphql_dig(:updateGameInLibrary, :gamePurchase)).to eq(
         {
-          "user" => {
-            "id" => user.id.to_s
+          user: {
+            id: user.id.to_s
           },
-          "game" => {
-            "name" => game.name
+          game: {
+            name: game.name
           },
-          "hoursPlayed" => 5
+          hoursPlayed: 5
         }
       )
     end
@@ -51,7 +51,7 @@ RSpec.describe "UpdateGameInLibrary Mutation API", type: :request do
 
       expect do
         response = api_request(query_string, variables: { id: game_purchase_for_other_user.id }, token: access_token)
-        expect(response['errors'].first['message']).to eq("You aren't allowed to update this game purchase.")
+        expect(response.to_h['errors'].first['message']).to eq("You aren't allowed to update this game purchase.")
       end.to change(GamePurchase, :count).by(0)
     end
   end
@@ -121,20 +121,20 @@ RSpec.describe "UpdateGameInLibrary Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
 
-      expect(result["data"]["updateGameInLibrary"]["gamePurchase"]).to eq(
+      expect(result.graphql_dig(:updateGameInLibrary, :gamePurchase)).to eq(
         {
-          "user" => {
-            "id" => user.id.to_s
+          user: {
+            id: user.id.to_s
           },
-          "game" => {
-            "name" => game.name
+          game: {
+            name: game.name
           },
-          "hoursPlayed" => 5,
-          "completionStatus" => "UNPLAYED",
-          "comments" => "Pretty good",
-          "rating" => 100,
-          "startDate" => "2019-10-10",
-          "completionDate" => "2019-10-11"
+          hoursPlayed: 5,
+          completionStatus: "UNPLAYED",
+          comments: "Pretty good",
+          rating: 100,
+          startDate: "2019-10-10",
+          completionDate: "2019-10-11"
         }
       )
     end
@@ -144,16 +144,16 @@ RSpec.describe "UpdateGameInLibrary Mutation API", type: :request do
 
       result = api_request(query_string2, variables: { id: game_purchase2.id }, token: access_token)
 
-      expect(result["data"]["updateGameInLibrary"]["gamePurchase"]).to eq(
+      expect(result.graphql_dig(:updateGameInLibrary, :gamePurchase)).to eq(
         {
-          "user" => {
-            "id" => user.id.to_s
+          user: {
+            id: user.id.to_s
           },
-          "game" => {
-            "name" => game.name
+          game: {
+            name: game.name
           },
-          "hoursPlayed" => nil,
-          "rating" => 100
+          hoursPlayed: nil,
+          rating: 100
         }
       )
     end

--- a/spec/requests/api/mutations/update_game_in_library_spec.rb
+++ b/spec/requests/api/mutations/update_game_in_library_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "UpdateGameInLibrary Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
 
-      expect(result.graphql_dig(:updateGameInLibrary, :gamePurchase)).to eq(
+      expect(result.graphql_dig(:update_game_in_library, :game_purchase)).to eq(
         {
           user: {
             id: user.id.to_s
@@ -121,7 +121,7 @@ RSpec.describe "UpdateGameInLibrary Mutation API", type: :request do
 
       result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
 
-      expect(result.graphql_dig(:updateGameInLibrary, :gamePurchase)).to eq(
+      expect(result.graphql_dig(:update_game_in_library, :game_purchase)).to eq(
         {
           user: {
             id: user.id.to_s
@@ -144,7 +144,7 @@ RSpec.describe "UpdateGameInLibrary Mutation API", type: :request do
 
       result = api_request(query_string2, variables: { id: game_purchase2.id }, token: access_token)
 
-      expect(result.graphql_dig(:updateGameInLibrary, :gamePurchase)).to eq(
+      expect(result.graphql_dig(:update_game_in_library, :game_purchase)).to eq(
         {
           user: {
             id: user.id.to_s

--- a/spec/requests/api/platforms_spec.rb
+++ b/spec/requests/api/platforms_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Platforms API", type: :request do
 
       result = api_request(query_string, variables: { query: platform.name }, token: access_token)
 
-      expect(result.graphql_dig(:platformSearch, :nodes)).to eq(
+      expect(result.graphql_dig(:platform_search, :nodes)).to eq(
         [{
           id: platform.id.to_s,
           name: platform.name

--- a/spec/requests/api/platforms_spec.rb
+++ b/spec/requests/api/platforms_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe "Platforms API", type: :request do
 
       result = api_request(query_string, variables: { id: platform.id }, token: access_token)
 
-      expect(result["data"]["platform"]).to eq(
+      expect(result.graphql_dig(:platform)).to eq(
         {
-          "id" => platform.id.to_s,
-          "name" => platform.name
+          id: platform.id.to_s,
+          name: platform.name
         }
       )
     end
@@ -45,10 +45,10 @@ RSpec.describe "Platforms API", type: :request do
 
       result = api_request(query_string, variables: { query: platform.name }, token: access_token)
 
-      expect(result["data"]["platformSearch"]["nodes"]).to eq(
+      expect(result.graphql_dig(:platformSearch, :nodes)).to eq(
         [{
-          "id" => platform.id.to_s,
-          "name" => platform.name
+          id: platform.id.to_s,
+          name: platform.name
         }]
       )
     end
@@ -69,15 +69,15 @@ RSpec.describe "Platforms API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result["data"]["platforms"]["nodes"]).to eq(
+      expect(result.graphql_dig(:platforms, :nodes)).to eq(
         [
           {
-            "id" => platform.id.to_s,
-            "name" => platform.name
+            id: platform.id.to_s,
+            name: platform.name
           },
           {
-            "id" => platform2.id.to_s,
-            "name" => platform2.name
+            id: platform2.id.to_s,
+            name: platform2.name
           }
         ]
       )

--- a/spec/requests/api/series_spec.rb
+++ b/spec/requests/api/series_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe "Series API", type: :request do
 
       result = api_request(query_string, variables: { id: series.id }, token: access_token)
 
-      expect(result["data"]["series"]).to eq(
+      expect(result.graphql_dig(:series)).to eq(
         {
-          "id" => series.id.to_s,
-          "name" => series.name
+          id: series.id.to_s,
+          name: series.name
         }
       )
     end
@@ -45,10 +45,10 @@ RSpec.describe "Series API", type: :request do
 
       result = api_request(query_string, variables: { query: series.name }, token: access_token)
 
-      expect(result["data"]["seriesSearch"]["nodes"]).to eq(
+      expect(result.graphql_dig(:seriesSearch, :nodes)).to eq(
         [{
-          "id" => series.id.to_s,
-          "name" => series.name
+          id: series.id.to_s,
+          name: series.name
         }]
       )
     end
@@ -69,15 +69,15 @@ RSpec.describe "Series API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result["data"]["seriesList"]["nodes"]).to eq(
+      expect(result.graphql_dig(:seriesList, :nodes)).to eq(
         [
           {
-            "id" => series.id.to_s,
-            "name" => series.name
+            id: series.id.to_s,
+            name: series.name
           },
           {
-            "id" => series2.id.to_s,
-            "name" => series2.name
+            id: series2.id.to_s,
+            name: series2.name
           }
         ]
       )

--- a/spec/requests/api/series_spec.rb
+++ b/spec/requests/api/series_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Series API", type: :request do
 
       result = api_request(query_string, variables: { query: series.name }, token: access_token)
 
-      expect(result.graphql_dig(:seriesSearch, :nodes)).to eq(
+      expect(result.graphql_dig(:series_search, :nodes)).to eq(
         [{
           id: series.id.to_s,
           name: series.name
@@ -69,7 +69,7 @@ RSpec.describe "Series API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result.graphql_dig(:seriesList, :nodes)).to eq(
+      expect(result.graphql_dig(:series_list, :nodes)).to eq(
         [
           {
             id: series.id.to_s,

--- a/spec/requests/api/stores_spec.rb
+++ b/spec/requests/api/stores_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe "Stores API", type: :request do
 
       result = api_request(query_string, variables: { id: store.id }, token: access_token)
 
-      expect(result["data"]["store"]).to eq(
+      expect(result.graphql_dig(:store)).to eq(
         {
-          "id" => store.id.to_s,
-          "name" => store.name
+          id: store.id.to_s,
+          name: store.name
         }
       )
     end
@@ -45,10 +45,10 @@ RSpec.describe "Stores API", type: :request do
 
       result = api_request(query_string, variables: { query: store.name }, token: access_token)
 
-      expect(result["data"]["storeSearch"]["nodes"]).to eq(
+      expect(result.graphql_dig(:storeSearch, :nodes)).to eq(
         [{
-          "id" => store.id.to_s,
-          "name" => store.name
+          id: store.id.to_s,
+          name: store.name
         }]
       )
     end
@@ -69,15 +69,15 @@ RSpec.describe "Stores API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result["data"]["stores"]["nodes"]).to eq(
+      expect(result.graphql_dig(:stores, :nodes)).to eq(
         [
           {
-            "id" => store.id.to_s,
-            "name" => store.name
+            id: store.id.to_s,
+            name: store.name
           },
           {
-            "id" => store2.id.to_s,
-            "name" => store2.name
+            id: store2.id.to_s,
+            name: store2.name
           }
         ]
       )

--- a/spec/requests/api/stores_spec.rb
+++ b/spec/requests/api/stores_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Stores API", type: :request do
 
       result = api_request(query_string, variables: { query: store.name }, token: access_token)
 
-      expect(result.graphql_dig(:storeSearch, :nodes)).to eq(
+      expect(result.graphql_dig(:store_search, :nodes)).to eq(
         [{
           id: store.id.to_s,
           name: store.name

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe "Users API", type: :request do
 
       result = api_request(query_string, variables: { query: user.username }, token: access_token)
 
-      expect(result.graphql_dig(:userSearch, :nodes)).to eq(
+      expect(result.graphql_dig(:user_search, :nodes)).to eq(
         [{
           id: user.id.to_s,
           username: user.username
@@ -254,7 +254,7 @@ RSpec.describe "Users API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result.graphql_dig(:currentUser)).to eq(
+      expect(result.graphql_dig(:current_user)).to eq(
         {
           id: user.id.to_s,
           username: user.username

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe "Users API", type: :request do
 
       result = api_request(query_string, variables: { id: user.id }, token: access_token)
 
-      expect(result["data"]["user"]).to eq(
+      expect(result.graphql_dig(:user)).to eq(
         {
-          "id" => user.id.to_s,
-          "username" => user.username,
-          "role" => user.role.upcase,
-          "privacy" => user.privacy.upcase,
-          "avatarUrl" => nil
+          id: user.id.to_s,
+          username: user.username,
+          role: user.role.upcase,
+          privacy: user.privacy.upcase,
+          avatarUrl: nil
         }
       )
     end
@@ -53,13 +53,13 @@ RSpec.describe "Users API", type: :request do
 
       result = api_request(query_string, variables: { username: user.username }, token: access_token)
 
-      expect(result["data"]["user"]).to eq(
+      expect(result.graphql_dig(:user)).to eq(
         {
-          "id" => user.id.to_s,
-          "username" => user.username,
-          "role" => user.role.upcase,
-          "privacy" => user.privacy.upcase,
-          "avatarUrl" => nil
+          id: user.id.to_s,
+          username: user.username,
+          role: user.role.upcase,
+          privacy: user.privacy.upcase,
+          avatarUrl: nil
         }
       )
     end
@@ -76,8 +76,8 @@ RSpec.describe "Users API", type: :request do
 
       result = api_request(query_string, variables: { id: user.id, username: user.username }, token: access_token)
 
-      expect(result["data"]["user"]).to be_nil
-      expect(result["errors"].first['message']).to eq('Cannot provide more than one argument to user at a time.')
+      expect(result.graphql_dig(:user)).to be_nil
+      expect(result.to_h["errors"].first['message']).to eq('Cannot provide more than one argument to user at a time.')
     end
 
     it "returns avatar for user" do
@@ -96,11 +96,11 @@ RSpec.describe "Users API", type: :request do
 
       avatar_variant = user_with_avatar.sized_avatar(:small)
 
-      expect(result["data"]["user"]).to eq(
+      expect(result.graphql_dig(:user)).to eq(
         {
-          "id" => user_with_avatar.id.to_s,
-          "username" => user_with_avatar.username,
-          "avatarUrl" => Rails.application.routes.url_helpers.rails_representation_url(avatar_variant)
+          id: user_with_avatar.id.to_s,
+          username: user_with_avatar.username,
+          avatarUrl: Rails.application.routes.url_helpers.rails_representation_url(avatar_variant)
         }
       )
     end
@@ -128,13 +128,13 @@ RSpec.describe "Users API", type: :request do
 
       result = api_request(query_string, variables: { id: private_user.id }, token: access_token)
 
-      expect(result["data"]["user"]).to eq(
+      expect(result.graphql_dig(:user)).to eq(
         {
-          "id" => private_user.id.to_s,
-          "username" => private_user.username,
-          "bio" => nil,
-          "gamePurchases" => nil,
-          "activity" => nil
+          id: private_user.id.to_s,
+          username: private_user.username,
+          bio: nil,
+          gamePurchases: nil,
+          activity: nil
         }
       )
     end
@@ -171,17 +171,17 @@ RSpec.describe "Users API", type: :request do
 
       result = api_request(query_string, variables: { id: user.id }, token: access_token)
 
-      expect(result["data"]["user"]).to eq(
+      expect(result.graphql_dig(:user)).to eq(
         {
-          "id" => user.id.to_s,
-          "username" => user.username,
-          "activity" => {
-            "nodes" => [
+          id: user.id.to_s,
+          username: user.username,
+          activity: {
+            nodes: [
               {
-                "id" => user.events.first.id,
-                "eventable" => {
-                  "id" => user.id.to_s,
-                  "__typename" => "User"
+                id: user.events.first.id,
+                eventable: {
+                  id: user.id.to_s,
+                  __typename: "User"
                 }
               }
             ]
@@ -206,14 +206,14 @@ RSpec.describe "Users API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result["data"]["users"]["nodes"]).to include(
+      expect(result.graphql_dig(:users, :nodes)).to include(
         {
-          "id" => user.id.to_s,
-          "username" => user.username
+          id: user.id.to_s,
+          username: user.username
         },
         {
-          "id" => user2.id.to_s,
-          "username" => user2.username
+          id: user2.id.to_s,
+          username: user2.username
         }
       )
     end
@@ -233,10 +233,10 @@ RSpec.describe "Users API", type: :request do
 
       result = api_request(query_string, variables: { query: user.username }, token: access_token)
 
-      expect(result["data"]["userSearch"]["nodes"]).to eq(
+      expect(result.graphql_dig(:userSearch, :nodes)).to eq(
         [{
-          "id" => user.id.to_s,
-          "username" => user.username
+          id: user.id.to_s,
+          username: user.username
         }]
       )
     end
@@ -254,10 +254,10 @@ RSpec.describe "Users API", type: :request do
 
       result = api_request(query_string, token: access_token)
 
-      expect(result["data"]["currentUser"]).to eq(
+      expect(result.graphql_dig(:currentUser)).to eq(
         {
-          "id" => user.id.to_s,
-          "username" => user.username
+          id: user.id.to_s,
+          username: user.username
         }
       )
     end

--- a/spec/support/api_request_test_helper.rb
+++ b/spec/support/api_request_test_helper.rb
@@ -1,5 +1,9 @@
 # typed: false
 module ApiRequestTestHelper
+  # @param query_string [String]
+  # @param variables [Hash]
+  # @param token [Doorkeeper::AccessToken]
+  # @return [VglistApiRequestResponse]
   def api_request(query_string, variables: nil, token:)
     # Allow variables to be sent as snake case, e.g. "giantbomb_id" by
     # transforming them into "giantbombId" before passing them to GraphQL.
@@ -15,11 +19,14 @@ module ApiRequestTestHelper
       }
 
     response_body = VglistApiRequestResponse.new(JSON.parse(response.body))
-    puts "ERRORS: #{response_body['errors'].inspect}" if ENV['DEBUG'] && response_body['errors']&.any?
+    puts "ERRORS: #{response_body.to_h['errors'].inspect}" if ENV['DEBUG'] && response_body.to_h['errors']&.any?
     return response_body
   end
 
   # Return an array of error messages from the GraphQL result object.
+  #
+  # @param result [VglistApiRequestResponse]
+  # @return [Hash]
   def api_result_errors(result)
     return result.to_h['errors'].map { |item| item['message'] }
   end
@@ -33,6 +40,9 @@ class VglistApiRequestResponse
     @body = body
   end
 
+  # Returns the body as a hash.
+  #
+  # @return [Hash]
   def to_h
     body
   end
@@ -44,6 +54,7 @@ class VglistApiRequestResponse
   # It digs into `data` automatically.
   #
   # @param args [Symbol] The keys to go through for digging into nested objects.
+  # @return [Array<any>|Hash<any>] Returns a hash or an array by digging into the GraphQL response.
   def graphql_dig(*args)
     formatted_args = args.map { |arg| arg.to_s.camelize(:lower) }
     data = body.dig('data', *formatted_args)

--- a/spec/support/api_request_test_helper.rb
+++ b/spec/support/api_request_test_helper.rb
@@ -14,13 +14,41 @@ module ApiRequestTestHelper
         'Authorization': "Bearer #{token.token}"
       }
 
-    response_body = JSON.parse(response.body)
+    response_body = VglistApiRequestResponse.new(JSON.parse(response.body))
     puts "ERRORS: #{response_body['errors'].inspect}" if ENV['DEBUG'] && response_body['errors']&.any?
     return response_body
   end
 
   # Return an array of error messages from the GraphQL result object.
   def api_result_errors(result)
-    return result['errors'].map { |item| item['message'] }
+    return result.to_h['errors'].map { |item| item['message'] }
+  end
+end
+
+class VglistApiRequestResponse
+  attr_reader :body
+
+  # @param body [Hash] The response body of the GraphQL query.
+  def initialize(body)
+    @body = body
+  end
+
+  def to_h
+    body
+  end
+
+  # This will dig into the body, which is returned by `ApiRequestTestHelper`
+  # above. It takes symbol keys and will stringify and camelize them. So it
+  # will accept `:foo_bar` and transform it into `'fooBar'`.
+  #
+  # It digs into `data` automatically.
+  #
+  # @param args [Symbol] The keys to go through for digging into nested objects.
+  def graphql_dig(*args)
+    formatted_args = args.map { |arg| arg.to_s.camelize(:lower) }
+    data = body.dig('data', *formatted_args)
+    data.deep_symbolize_keys! if data.is_a?(Hash)
+    data.map!(&:deep_symbolize_keys) if data.is_a?(Array)
+    data
   end
 end


### PR DESCRIPTION
Make writing specs for the GraphQL API a bit less bad.