### PR TITLE
Add database constraints to events.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,6 +11,7 @@ class Event < ApplicationRecord
 
   validates :event_category, presence: true
 
+  # Make sure to update database constraints if a new event type is added.
   enum event_category: {
     add_to_library: 0,
     change_completion_status: 1,

--- a/db/migrate/20210227204700_add_constraints_to_events.rb
+++ b/db/migrate/20210227204700_add_constraints_to_events.rb
@@ -1,0 +1,19 @@
+# typed: false
+class AddConstraintsToEvents < ActiveRecord::Migration[6.1]
+  # Event categories and corresponding eventable types:
+  # add_to_library: 0 => GamePurchase
+  # change_completion_status: 1 => GamePurchase
+  # favorite_game: 2 => FavoriteGame
+  # new_user: 3 => User
+  # following: 4 => Relationship
+  CONSTRAINT = <<~SQL.squish
+    (event_category IN (0, 1) AND eventable_type = 'GamePurchase')
+    OR (event_category = 2 AND eventable_type = 'FavoriteGame')
+    OR (event_category = 3 AND eventable_type = 'User')
+    OR (event_category = 4 AND eventable_type = 'Relationship')
+  SQL
+
+  def change
+    add_check_constraint :events, CONSTRAINT, name: "event_category_type_check"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_24_204720) do
+ActiveRecord::Schema.define(version: 2021_02_27_204700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 2021_01_24_204720) do
     t.index ["eventable_id", "eventable_type", "user_id"], name: "index_events_on_id_type_and_user_id"
     t.index ["eventable_id"], name: "index_events_on_eventable_id"
     t.index ["user_id"], name: "index_events_on_user_id"
+    t.check_constraint "((event_category = ANY (ARRAY[0, 1])) AND ((eventable_type)::text = 'GamePurchase'::text)) OR ((event_category = 2) AND ((eventable_type)::text = 'FavoriteGame'::text)) OR ((event_category = 3) AND ((eventable_type)::text = 'User'::text)) OR ((event_category = 4) AND ((eventable_type)::text = 'Relationship'::text))", name: "event_category_type_check"
   end
 
   create_table "external_accounts", force: :cascade do |t|
@@ -218,6 +219,7 @@ ActiveRecord::Schema.define(version: 2021_01_24_204720) do
     t.index ["game_id", "user_id"], name: "index_game_purchases_on_game_id_and_user_id", unique: true
     t.index ["game_id"], name: "index_game_purchases_on_game_id"
     t.index ["user_id"], name: "index_game_purchases_on_user_id"
+    t.check_constraint "replay_count >= 0", name: "game_purchases_replay_count_not_negative"
   end
 
   create_table "game_versions", force: :cascade do |t|

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -2,52 +2,39 @@
 FactoryBot.define do
   factory :event do
     user
-    for_game_purchase
-
-    trait :for_game_purchase do
-      association(:eventable, factory: :game_purchase)
-
-      # One of these needs to be included by default for the factory to be valid.
-      # They can be overridden by explicitly using the traits for each event_type.
-      event_category { [:add_to_library, :change_completion_status].sample }
-      eventable_type { 'GamePurchase' }
-    end
+    add_to_library
 
     trait :for_favorite_game do
       association(:eventable, factory: :favorite_game)
       event_category { :favorite_game }
-      eventable_type { 'FavoriteGame' }
     end
 
     trait :for_new_user do
       association(:eventable, factory: :user)
       event_category { :new_user }
-      eventable_type { 'User' }
     end
 
     trait :for_following do
       association(:eventable, factory: :relationship)
       event_category { :following }
-      eventable_type { 'Relationship' }
     end
 
     trait :add_to_library do
+      association(:eventable, factory: :game_purchase)
       event_category { :add_to_library }
-      eventable_type { 'GamePurchase' }
     end
 
     trait :change_completion_status do
+      association(:eventable, factory: :game_purchase)
       event_category { :change_completion_status }
       differences do
         # Pick two random values
         { completion_status: GamePurchase.completion_statuses.values.sample(2) }
       end
-      eventable_type { 'GamePurchase' }
     end
 
-    factory :game_purchase_event,            traits: [:for_game_purchase]
-    factory :game_purchase_library_event,    traits: [:for_game_purchase, :add_to_library]
-    factory :game_purchase_completion_event, traits: [:for_game_purchase, :change_completion_status]
+    factory :game_purchase_library_event,    traits: [:add_to_library]
+    factory :game_purchase_completion_event, traits: [:change_completion_status]
     factory :favorite_game_event,            traits: [:for_favorite_game]
     factory :new_user_event,                 traits: [:for_new_user]
     factory :following_event,                traits: [:for_following]

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -10,25 +10,30 @@ FactoryBot.define do
       # One of these needs to be included by default for the factory to be valid.
       # They can be overridden by explicitly using the traits for each event_type.
       event_category { [:add_to_library, :change_completion_status].sample }
+      eventable_type { 'GamePurchase' }
     end
 
     trait :for_favorite_game do
       association(:eventable, factory: :favorite_game)
       event_category { :favorite_game }
+      eventable_type { 'FavoriteGame' }
     end
 
     trait :for_new_user do
       association(:eventable, factory: :user)
       event_category { :new_user }
+      eventable_type { 'User' }
     end
 
     trait :for_following do
       association(:eventable, factory: :relationship)
       event_category { :following }
+      eventable_type { 'Relationship' }
     end
 
     trait :add_to_library do
       event_category { :add_to_library }
+      eventable_type { 'GamePurchase' }
     end
 
     trait :change_completion_status do
@@ -37,6 +42,7 @@ FactoryBot.define do
         # Pick two random values
         { completion_status: GamePurchase.completion_statuses.values.sample(2) }
       end
+      eventable_type { 'GamePurchase' }
     end
 
     factory :game_purchase_event,            traits: [:for_game_purchase]

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,42 +1,36 @@
 # typed: false
 FactoryBot.define do
-  factory :event do
+  factory :game_purchase_library_event, class: 'Event', aliases: [:event] do
     user
-    add_to_library
+    association(:eventable, factory: :game_purchase)
+    event_category { :add_to_library }
+  end
 
-    trait :for_favorite_game do
-      association(:eventable, factory: :favorite_game)
-      event_category { :favorite_game }
+  factory :game_purchase_completion_event, class: 'Event' do
+    user
+    association(:eventable, factory: :game_purchase)
+    event_category { :change_completion_status }
+    differences do
+      # Pick two random values
+      { completion_status: GamePurchase.completion_statuses.values.sample(2) }
     end
+  end
 
-    trait :for_new_user do
-      association(:eventable, factory: :user)
-      event_category { :new_user }
-    end
+  factory :favorite_game_event, class: 'Event' do
+    user
+    association(:eventable, factory: :favorite_game)
+    event_category { :favorite_game }
+  end
 
-    trait :for_following do
-      association(:eventable, factory: :relationship)
-      event_category { :following }
-    end
+  factory :new_user_event, class: 'Event' do
+    user
+    association(:eventable, factory: :user)
+    event_category { :new_user }
+  end
 
-    trait :add_to_library do
-      association(:eventable, factory: :game_purchase)
-      event_category { :add_to_library }
-    end
-
-    trait :change_completion_status do
-      association(:eventable, factory: :game_purchase)
-      event_category { :change_completion_status }
-      differences do
-        # Pick two random values
-        { completion_status: GamePurchase.completion_statuses.values.sample(2) }
-      end
-    end
-
-    factory :game_purchase_library_event,    traits: [:add_to_library]
-    factory :game_purchase_completion_event, traits: [:change_completion_status]
-    factory :favorite_game_event,            traits: [:for_favorite_game]
-    factory :new_user_event,                 traits: [:for_new_user]
-    factory :following_event,                traits: [:for_following]
+  factory :following_event, class: 'Event' do
+    user
+    association(:eventable, factory: :relationship)
+    event_category { :following }
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Event, type: :model do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
     let(:game_purchase) { create(:game_purchase, game: game) }
-    let(:game_purchase_event) { create(:game_purchase_event, user: user, eventable: game_purchase) }
+    let(:game_purchase_event) { create(:add_to_library_event, user: user, eventable: game_purchase) }
 
     it 'GamePurchase should not be deleted when Event is deleted' do
       game_purchase_event

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Event, type: :model do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
     let(:game_purchase) { create(:game_purchase, game: game) }
-    let(:game_purchase_event) { create(:add_to_library_event, user: user, eventable: game_purchase) }
+    let(:game_purchase_event) { create(:game_purchase_library_event, user: user, eventable: game_purchase) }
 
     it 'GamePurchase should not be deleted when Event is deleted' do
       game_purchase_event

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe "Events", type: :request do
   describe "DELETE event_path" do
     let(:user) { create(:confirmed_user) }
-    let!(:event) { create(:add_to_library_event, user: user) }
+    let!(:event) { create(:event, user: user) }
 
     it "deletes an event" do
       sign_in(user)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe "Events", type: :request do
   describe "DELETE event_path" do
     let(:user) { create(:confirmed_user) }
-    let!(:event) { create(:game_purchase_event, user: user) }
+    let!(:event) { create(:add_to_library_event, user: user) }
 
     it "deletes an event" do
       sign_in(user)


### PR DESCRIPTION
Some users have somehow managed to create invalid events, so that's fun.

This constraint will prevent the such issues from occurring in the future.

Fixes #1892.