### PR TITLE
Add GraphQL mutation for deleting an event.

### DIFF
--- a/app/graphql/mutations/delete_event.rb
+++ b/app/graphql/mutations/delete_event.rb
@@ -1,0 +1,30 @@
+# typed: true
+class Mutations::DeleteEvent < Mutations::BaseMutation
+  description "Delete an event from the Activity Feed. You must be the owner of the event to delete it."
+
+  argument :event_id, ID, required: true, description: "ID of event to delete, will be a UUID."
+
+  field :deleted, Boolean, null: false, description: "Whether the event was deleted successfully or not."
+
+  sig { params(event_id: String).returns(T::Hash[Symbol, T::Boolean]) }
+  def resolve(event_id:)
+    event = Event.find_by(id: event_id)
+
+    raise GraphQL::ExecutionError, "Event does not exist or could not be deleted." unless event&.destroy
+
+    {
+      deleted: true
+    }
+  end
+
+  sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
+  def authorized?(object)
+    event = Event.find_by(id: object[:event_id])
+
+    return false if event.nil?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this event." unless EventPolicy.new(@context[:current_user], event).destroy?
+
+    return true
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -12,5 +12,7 @@ module Types
     field :add_game_to_library, mutation: Mutations::AddGameToLibrary
     field :update_game_in_library, mutation: Mutations::UpdateGameInLibrary
     field :remove_game_from_library, mutation: Mutations::RemoveGameFromLibrary
+
+    field :delete_event, mutation: Mutations::DeleteEvent
   end
 end

--- a/spec/requests/api/mutations/delete_event_spec.rb
+++ b/spec/requests/api/mutations/delete_event_spec.rb
@@ -1,0 +1,47 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "DeleteEvent Mutation API", type: :request do
+  describe "Mutation deletes event" do
+    let!(:user) { create(:confirmed_user) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:user2) { create(:confirmed_user) }
+    let(:event) { create(:event, user: user) }
+    let(:other_event) { create(:event, user: user2) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          deleteEvent(eventId: $id) {
+            deleted
+          }
+        }
+      GRAPHQL
+    end
+
+    it "deletes an event" do
+      event
+
+      expect do
+        api_request(query_string, variables: { id: event.id }, token: access_token)
+      end.to change(Event, :count).by(-1)
+    end
+
+    it "does not delete an event we do not own" do
+      other_event
+
+      expect do
+        result = api_request(query_string, variables: { id: other_event.id }, token: access_token)
+        expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this event.")
+      end.to change(Event, :count).by(0)
+    end
+
+    it "returns a deleted boolean after deleting the event" do
+      event
+
+      result = api_request(query_string, variables: { id: event.id }, token: access_token)
+
+      expect(result.graphql_dig(:delete_event, :deleted)).to eq(true)
+    end
+  end
+end

--- a/spec/requests/api/mutations/remove_game_from_library_spec.rb
+++ b/spec/requests/api/mutations/remove_game_from_library_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
       game_purchase_for_other_user
 
       expect do
-        response = api_request(query_string2, variables: { id: game_purchase_for_other_user.id }, token: access_token)
-        expect(response.to_h['errors'].first['message']).to eq("You aren't allowed to delete this game purchase.")
+        result = api_request(query_string2, variables: { id: game_purchase_for_other_user.id }, token: access_token)
+        expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this game purchase.")
       end.to change(GamePurchase, :count).by(0)
     end
   end


### PR DESCRIPTION
Pretty self-explanatory. This is necessary for the GraphQL-powered frontend and it doesn't seem like restricting it to first-party OAuth apps (once we have those) is really necessary.