### PR TITLE
Add more filters to game query

### DIFF
--- a/app/graphql/resolvers/game_resolvers/game_resolver.rb
+++ b/app/graphql/resolvers/game_resolvers/game_resolver.rb
@@ -4,28 +4,40 @@ module Resolvers
     class GameResolver < Resolvers::BaseResolver
       type Types::GameType, null: true
 
-      description "Find a game by ID or GiantBomb ID. May only use one of the filters at a time."
+      description "Find a game by ID or one of its external IDs. May only use one of the filters at a time."
 
       argument :id, ID, required: false, description: "Find a game by its unique ID."
+      argument :wikidata_id, Integer, required: false, description: "Find a game by its Wikidata ID."
       argument :giantbomb_id, String, required: false, description: "Find a game by its GiantBomb ID, e.g. `'3030-23708'`."
+      argument :igdb_id, String, required: false, description: "Find a game by its IGDB ID."
+      argument :mobygames_id, String, required: false, description: "Find a game by its MobyGames ID."
+      argument :pcgamingwiki_id, String, required: false, description: "Find a game by its PCGamingWiki ID."
+      argument :steam_app_id, Integer, required: false, description: "Find a game by its Steam App ID."
+      argument :epic_games_store_id, String, required: false, description: "Find a game by its Epic Games Store ID."
+      argument :gog_id, String, required: false, description: "Find a game by its GOG.com ID."
 
       # Use validator to validate that one of the arguments is being used.
       validates required: {
-        one_of: [:id, :giantbomb_id],
+        one_of: [
+          :id,
+          :wikidata_id,
+          :giantbomb_id,
+          :igdb_id,
+          :mobygames_id,
+          :pcgamingwiki_id,
+          :steam_app_id,
+          :epic_games_store_id,
+          :gog_id
+        ],
         message: 'Cannot provide more than one argument to game at a time.'
       }
 
-      sig do
-        params(
-          id: T.nilable(T.any(String, Integer)),
-          giantbomb_id: T.nilable(String)
-        ).returns(T.nilable(Game))
-      end
-      def resolve(id: nil, giantbomb_id: nil)
-        if !id.nil?
-          Game.find(id)
-        elsif !giantbomb_id.nil?
-          Game.find_by(giantbomb_id: giantbomb_id)
+      sig { params(kwargs: T.untyped).returns(T.nilable(Game)) }
+      def resolve(**kwargs)
+        if kwargs.key?(:steam_app_id)
+          SteamAppId.find_by(app_id: kwargs[:steam_app_id])&.game
+        else
+          Game.find_by(**kwargs)
         end
       end
     end

--- a/spec/requests/api/games_spec.rb
+++ b/spec/requests/api/games_spec.rb
@@ -11,7 +11,18 @@ RSpec.describe "Games API", type: :request do
     let(:game_with_cover) { create(:game_with_cover) }
     let(:game_with_release_date) { create(:game_with_release_date) }
     let(:game_with_steam_app_ids) { create(:game_with_steam_app_id) }
+    let(:game_with_wikidata_id) { create(:game, :wikidata_id) }
     let(:game_with_giantbomb_id) { create(:game, :giantbomb_id) }
+    let(:game_with_igdb_id) { create(:game, :igdb_id) }
+    let(:game_with_mobygames_id) { create(:game, :mobygames_id) }
+    let(:game_with_pcgamingwiki_id) { create(:game, :pcgamingwiki_id) }
+    let(:game_with_steam_app_id) do
+      create(:game) do |game|
+        create(:steam_app_id, game: game)
+      end
+    end
+    let(:game_with_epic_games_store_id) { create(:game, :epic_games_store_id) }
+    let(:game_with_gog_id) { create(:game, :gog_id) }
 
     it "returns basic data for game" do
       game
@@ -103,6 +114,26 @@ RSpec.describe "Games API", type: :request do
       )
     end
 
+    it "returns basic data for game when searching by wikidata_id" do
+      query_string = <<-GRAPHQL
+        query($wikidataId: Int!) {
+          game(wikidataId: $wikidataId) {
+            id
+            name
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, variables: { wikidata_id: game_with_wikidata_id.wikidata_id.to_i }, token: access_token)
+
+      expect(result.graphql_dig(:game)).to eq(
+        {
+          id: game_with_wikidata_id.id.to_s,
+          name: game_with_wikidata_id.name
+        }
+      )
+    end
+
     it "returns basic data for game when searching by giantbomb_id" do
       query_string = <<-GRAPHQL
         query($giantbombId: String!) {
@@ -119,6 +150,126 @@ RSpec.describe "Games API", type: :request do
         {
           id: game_with_giantbomb_id.id.to_s,
           name: game_with_giantbomb_id.name
+        }
+      )
+    end
+
+    it "returns basic data for game when searching by igdb_id" do
+      query_string = <<-GRAPHQL
+        query($igdbId: String!) {
+          game(igdbId: $igdbId) {
+            id
+            name
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, variables: { igdb_id: game_with_igdb_id.igdb_id }, token: access_token)
+
+      expect(result.graphql_dig(:game)).to eq(
+        {
+          id: game_with_igdb_id.id.to_s,
+          name: game_with_igdb_id.name
+        }
+      )
+    end
+
+    it "returns basic data for game when searching by mobygames_id" do
+      query_string = <<-GRAPHQL
+        query($mobygamesId: String!) {
+          game(mobygamesId: $mobygamesId) {
+            id
+            name
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, variables: { mobygames_id: game_with_mobygames_id.mobygames_id }, token: access_token)
+
+      expect(result.graphql_dig(:game)).to eq(
+        {
+          id: game_with_mobygames_id.id.to_s,
+          name: game_with_mobygames_id.name
+        }
+      )
+    end
+
+    it "returns basic data for game when searching by pcgamingwiki_id" do
+      query_string = <<-GRAPHQL
+        query($pcgamingwikiId: String!) {
+          game(pcgamingwikiId: $pcgamingwikiId) {
+            id
+            name
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, variables: { pcgamingwiki_id: game_with_pcgamingwiki_id.pcgamingwiki_id }, token: access_token)
+
+      expect(result.graphql_dig(:game)).to eq(
+        {
+          id: game_with_pcgamingwiki_id.id.to_s,
+          name: game_with_pcgamingwiki_id.name
+        }
+      )
+    end
+
+    it "returns basic data for game when searching by steam_app_id" do
+      query_string = <<-GRAPHQL
+        query($steamAppId: Int!) {
+          game(steamAppId: $steamAppId) {
+            id
+            name
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, variables: { steam_app_id: game_with_steam_app_id.steam_app_ids.first.app_id.to_i }, token: access_token)
+
+      expect(result.graphql_dig(:game)).to eq(
+        {
+          id: game_with_steam_app_id.id.to_s,
+          name: game_with_steam_app_id.name
+        }
+      )
+    end
+
+    it "returns basic data for game when searching by epic_games_store_id" do
+      query_string = <<-GRAPHQL
+        query($epicGamesStoreId: String!) {
+          game(epicGamesStoreId: $epicGamesStoreId) {
+            id
+            name
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, variables: { epic_games_store_id: game_with_epic_games_store_id.epic_games_store_id }, token: access_token)
+
+      expect(result.graphql_dig(:game)).to eq(
+        {
+          id: game_with_epic_games_store_id.id.to_s,
+          name: game_with_epic_games_store_id.name
+        }
+      )
+    end
+
+    it "returns basic data for game when searching by gog_id" do
+      query_string = <<-GRAPHQL
+        query($gogId: String!) {
+          game(gogId: $gogId) {
+            id
+            name
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, variables: { gog_id: game_with_gog_id.gog_id }, token: access_token)
+
+      expect(result.graphql_dig(:game)).to eq(
+        {
+          id: game_with_gog_id.id.to_s,
+          name: game_with_gog_id.name
         }
       )
     end

--- a/spec/support/api_request_test_helper.rb
+++ b/spec/support/api_request_test_helper.rb
@@ -12,7 +12,7 @@ module ApiRequestTestHelper
     post graphql_path,
       params: {
         query: query_string,
-        variables: variables
+        variables: variables.to_json
       },
       headers: {
         'Authorization': "Bearer #{token.token}"


### PR DESCRIPTION
Now we can get Half-Life 2 from vglist with this query:

```graphql
query {
  game(wikidataId: 193581) {
    id
    name
  }
}
```

Or do it via IDs for GiantBomb, IGDB, GOG, Epic Games Store, Steam, etc.