### PR TITLE
Add an admin-only site statistics query in the GraphQL API.

### DIFF
--- a/app/graphql/resolvers/site_statistic_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/site_statistic_resolvers/list_resolver.rb
@@ -13,7 +13,7 @@ module Resolvers
 
       sig { returns(T::Boolean) }
       def authorized?
-        raise GraphQL::ExecutionError, "You aren't allowed to view site statistics." unless AdminPolicy.new(@context[:current_user], nil).statistics?
+        raise GraphQL::ExecutionError, "Viewing site statistics is only available to admins." unless AdminPolicy.new(@context[:current_user], nil).statistics?
 
         true
       end

--- a/app/graphql/resolvers/site_statistic_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/site_statistic_resolvers/list_resolver.rb
@@ -1,0 +1,22 @@
+# typed: true
+module Resolvers
+  module SiteStatisticResolvers
+    class ListResolver < Resolvers::BaseResolver
+      type Types::SiteStatisticType.connection_type, null: true
+
+      description "List all statistics. **This information is only available to admins.**"
+
+      sig { returns(Statistic::RelationType) }
+      def resolve
+        Statistic.all
+      end
+
+      sig { returns(T::Boolean) }
+      def authorized?
+        raise GraphQL::ExecutionError, "You aren't allowed to view site statistics." unless AdminPolicy.new(@context[:current_user], nil).statistics?
+
+        true
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -41,5 +41,7 @@ module Types
     field :game_purchase, resolver: Resolvers::GamePurchaseResolver
 
     field :activity, resolver: Resolvers::ActivityResolver
+
+    field :site_statistics, resolver: Resolvers::SiteStatisticResolvers::ListResolver
   end
 end

--- a/app/graphql/types/site_statistic_type.rb
+++ b/app/graphql/types/site_statistic_type.rb
@@ -1,0 +1,51 @@
+# typed: strict
+module Types
+  class SiteStatisticType < Types::BaseObject
+    description <<~MARKDOWN
+      Historical site statistics for vglist. Most of these values cannot be
+      `null`, but some may be if you go back far enough. Make sure to handle
+      `null` where necessary.
+    MARKDOWN
+
+    field :id, ID, null: false, description: "ID of the statistic record."
+
+    # Actually #created_at, but timestamp works better.
+    field :timestamp, GraphQL::Types::ISO8601DateTime,
+      null: false,
+      method: :created_at,
+      description: "The point in time at which these statistics were logged, always UTC."
+
+    field :users, Integer, null: false, description: "The number of Users at this point in time."
+    field :games, Integer, null: false, description: "The number of Games at this point in time."
+    field :platforms, Integer, null: false, description: "The number of Platforms at this point in time."
+    field :series, Integer, null: false, description: "The number of Series at this point in time."
+    field :engines, Integer, null: false, description: "The number of Engines at this point in time."
+    field :companies, Integer, null: false, description: "The number of Companies at this point in time."
+    field :genres, Integer, null: false, description: "The number of Genres at this point in time."
+    field :stores, Integer, null: false, description: "The number of Stores at this point in time."
+    field :events, Integer, null: false, description: "The number of Events at this point in time."
+    field :game_purchases, Integer, null: false, description: "The number of Game Purchases at this point in time."
+    field :relationships, Integer, null: false, description: "The number of Relationships at this point in time."
+    field :games_with_covers, Integer, null: false, description: "The number of Games with covers at this point in time."
+    field :games_with_release_dates, Integer, null: false, description: "The number of Games with release dates at this point in time."
+    field :banned_users, Integer, null: false, description: "The number of Banned Users at this point in time."
+
+    # External IDs
+    field :mobygames_ids, Integer, null: false, description: "The number of MobyGames IDs at this point in time."
+    field :pcgamingwiki_ids, Integer, null: false, description: "The number of PCGamingWiki IDs at this point in time."
+    field :wikidata_ids, Integer, null: false, description: "The number of Wikidata IDs at this point in time."
+    field :giantbomb_ids, Integer, null: false, description: "The number of GiantBomb IDs at this point in time."
+    field :steam_app_ids, Integer, null: false, description: "The number of Steam App IDs at this point in time."
+    field :epic_games_store_ids, Integer, null: false, description: "The number of Epic Games Store IDs at this point in time."
+    field :gog_ids, Integer, null: false, description: "The number of GOG.com IDs at this point in time."
+    field :igdb_ids, Integer, null: true, description: "The number of IGDB IDs at this point in time."
+
+    # Versions
+    field :company_versions, Integer, null: true, description: "The number of Company Versions at this point in time."
+    field :game_versions, Integer, null: true, description: "The number of Game Versions at this point in time."
+    field :genre_versions, Integer, null: true, description: "The number of Genre Versions at this point in time."
+    field :engine_versions, Integer, null: true, description: "The number of Engine Versions at this point in time."
+    field :platform_versions, Integer, null: true, description: "The number of Platform Versions at this point in time."
+    field :series_versions, Integer, null: true, description: "The number of Series Versions at this point in time."
+  end
+end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -12,6 +12,11 @@ class AdminPolicy < ApplicationPolicy
 
   sig { returns(T.nilable(T::Boolean)) }
   def dashboard?
+    statistics?
+  end
+
+  sig { returns(T.nilable(T::Boolean)) }
+  def statistics?
     user&.admin?
   end
 

--- a/spec/requests/api/site_statistics_spec.rb
+++ b/spec/requests/api/site_statistics_spec.rb
@@ -1,0 +1,144 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "Site Statistics API", type: :request do
+  describe "Query for data on site statistics" do
+    context 'when signed in as an admin' do
+      let(:user) { create(:confirmed_admin) }
+      let(:application) { build(:application, owner: user) }
+      let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+      let(:statistic) { create(:statistic) }
+
+      it "returns basic data for statistic" do
+        statistic
+        query_string = <<-GRAPHQL
+          query {
+            siteStatistics {
+              nodes {
+                id
+                timestamp
+                games
+              }
+            }
+          }
+        GRAPHQL
+
+        result = api_request(query_string, token: access_token)
+
+        expect(result.graphql_dig(:site_statistics, :nodes).first).to eq(
+          {
+            id: statistic.id.to_s,
+            timestamp: statistic.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            games: statistic.games
+          }
+        )
+      end
+
+      it "returns all data for statistic" do
+        statistic
+        query_string = <<-GRAPHQL
+          query {
+            siteStatistics {
+              nodes {
+                id
+                timestamp
+                users
+                games
+                platforms
+                series
+                engines
+                companies
+                genres
+                stores
+                events
+                gamePurchases
+                relationships
+                gamesWithCovers
+                gamesWithReleaseDates
+                bannedUsers
+                mobygamesIds
+                pcgamingwikiIds
+                wikidataIds
+                giantbombIds
+                steamAppIds
+                epicGamesStoreIds
+                gogIds
+                igdbIds
+                companyVersions
+                gameVersions
+                genreVersions
+                engineVersions
+                platformVersions
+                seriesVersions
+              }
+            }
+          }
+        GRAPHQL
+
+        result = api_request(query_string, token: access_token)
+
+        expect(result.graphql_dig(:site_statistics, :nodes).first).to eq(
+          {
+            id: statistic.id.to_s,
+            timestamp: statistic.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            users: statistic.users,
+            games: statistic.games,
+            platforms: statistic.platforms,
+            series: statistic.series,
+            engines: statistic.engines,
+            companies: statistic.companies,
+            genres: statistic.genres,
+            stores: statistic.stores,
+            events: statistic.events,
+            gamePurchases: statistic.game_purchases,
+            relationships: statistic.relationships,
+            gamesWithCovers: statistic.games_with_covers,
+            gamesWithReleaseDates: statistic.games_with_release_dates,
+            bannedUsers: statistic.banned_users,
+            mobygamesIds: statistic.mobygames_ids,
+            pcgamingwikiIds: statistic.pcgamingwiki_ids,
+            wikidataIds: statistic.wikidata_ids,
+            giantbombIds: statistic.giantbomb_ids,
+            steamAppIds: statistic.steam_app_ids,
+            epicGamesStoreIds: statistic.epic_games_store_ids,
+            gogIds: statistic.gog_ids,
+            igdbIds: statistic.igdb_ids,
+            companyVersions: statistic.company_versions,
+            gameVersions: statistic.game_versions,
+            genreVersions: statistic.genre_versions,
+            engineVersions: statistic.engine_versions,
+            platformVersions: statistic.platform_versions,
+            seriesVersions: statistic.series_versions
+          }
+        )
+      end
+    end
+
+    context 'when signed in as a normal user' do
+      let(:user) { create(:confirmed_user) }
+      let(:application) { build(:application, owner: user) }
+      let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+      let(:statistic) { create(:statistic) }
+
+      it "returns a permissions error for statistic" do
+        statistic
+        query_string = <<-GRAPHQL
+          query {
+            siteStatistics {
+              nodes {
+                id
+                timestamp
+                games
+              }
+            }
+          }
+        GRAPHQL
+
+        result = api_request(query_string, token: access_token)
+
+        expect(api_result_errors(result)).to include('Viewing site statistics is only available to admins.')
+        expect(result.graphql_dig(:site_statistics)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is necessary for creating the admin dashboard with the GraphQL API.

I'll add another statistics endpoint for the homepage and for live statistics.

TODO: 
- [x] Write tests