### PR TITLE
Add totalCount to GraphQL's base connection object

### DIFF
--- a/API.md
+++ b/API.md
@@ -171,6 +171,20 @@ query($id: ID!) {
 
 You may want to use a variable for the cursor value, to make it easier to page through the query response.
 
+You can also use `totalCount` on any Connection types to get the total number of records that a given query returns, regardless of pagination.
+
+```graphql
+query {
+  games {
+    nodes {
+      id
+      name
+    }
+    totalCount
+  }
+}
+```
+
 ## Mutations
 
 In GraphQL, API requests that are intended to change the data in the API (e.g. adding a game to a user's library) are called [Mutations](https://graphql.org/learn/queries/#mutations). Unlike queries, which only _read_ data, mutations can be used to _write_ data.

--- a/app/graphql/types/base_connection_object.rb
+++ b/app/graphql/types/base_connection_object.rb
@@ -1,4 +1,12 @@
 # typed: strict
 class Types::BaseConnectionObject < GraphQL::Types::Relay::BaseConnection
+  extend T::Sig
+
   field :page_info, Types::PageInfoType, null: false, description: "Information to aid in pagination."
+  field :total_count, Integer, null: false, description: "The total number of records returned by this query."
+
+  sig { returns(Integer) }
+  def total_count
+    object.items.size
+  end
 end

--- a/spec/requests/api/generic_spec.rb
+++ b/spec/requests/api/generic_spec.rb
@@ -30,5 +30,24 @@ RSpec.describe "API", type: :request do
       expect(result.graphql_dig(:games, :page_info, :has_next_page)).to eq(true)
       expect(result.graphql_dig(:games, :page_info, :page_size)).to eq(30)
     end
+
+    it "returns correct totalCount with 31 records" do
+      games
+      query_string = <<-GRAPHQL
+        query {
+          games {
+            nodes {
+              id
+              name
+            }
+            totalCount
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, token: access_token)
+
+      expect(result.graphql_dig(:games, :total_count)).to eq(31)
+    end
   end
 end


### PR DESCRIPTION
Now you can get the totalCount of a connection like this:

```graphql
query {
  games {
    nodes {
      id
      name
    }
    totalCount
  }
}
```