### PR TITLE
Upgrade Node.js to 14 and update Bundler to latest patch version.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   RACK_ENV: test
   NODE_ENV: test
   CI: 'true'
-  BUNDLER_VERSION: '2.2.3'
+  BUNDLER_VERSION: '2.2.13'
 
 # Cache gems and node_modules in between builds
 cache:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,14 @@
 
 - Ruby 2.7
 - Postgres 12.x
-- Node.js 10.x
+- Node.js 14.x
 - Yarn 1.x
 - ImageMagick (for images, like avatars or game covers)
 
 ### Setup instructions
 
 1. Clone the repository with git
-1. To get Bundler 2.2.3, `gem install bundler:2.2.3`
+1. To get Bundler 2.2.13, `gem install bundler:2.2.13`
 1. `bundle install`
 1. `yarn install`
 1. `bundle exec rails db:setup`

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ruby:2.7.2
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && echo "deb https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update -qqy && apt-get install -qqyy google-chrome-stable yarn nodejs postgresql postgresql-client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -525,4 +525,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.3
+   2.2.13


### PR DESCRIPTION
Node 10 is EOL at the end of April (and my new M1 Mac can only use 15 or newer), so upgrading is kind of necessary at this point.

Upgraded Bundler as well, because why not.