### PR TITLE
Add GraphQL mutations for banning and unbanning users.

### DIFF
--- a/app/graphql/mutations/ban_user.rb
+++ b/app/graphql/mutations/ban_user.rb
@@ -1,0 +1,36 @@
+# typed: true
+class Mutations::BanUser < Mutations::BaseMutation
+  description "Ban a user. Only available to moderators and admins."
+
+  argument :user_id, ID, required: true, description: "ID of user to ban."
+
+  field :user, Types::UserType, null: true, description: "The user that has been banned."
+
+  sig { params(user_id: T.any(String, Integer)).returns(T::Hash[Symbol, User]) }
+  def resolve(user_id:)
+    user = User.find(user_id)
+
+    raise GraphQL::ExecutionError, "User has already been banned." if user.banned?
+
+    user.banned = true
+    # Revoke any special roles from the banned user.
+    user.role = :member unless user.member?
+
+    raise GraphQL::ExecutionError, user.errors.full_messages.join(", ") unless user.save
+
+    {
+      user: user
+    }
+  end
+
+  sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
+  def authorized?(object)
+    user = User.find_by(id: object[:user_id])
+
+    return false if user.nil?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to ban this user." unless UserPolicy.new(@context[:current_user], user).ban?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/unban_user.rb
+++ b/app/graphql/mutations/unban_user.rb
@@ -1,0 +1,34 @@
+# typed: true
+class Mutations::UnbanUser < Mutations::BaseMutation
+  description "Unban a user. Only available to moderators and admins."
+
+  argument :user_id, ID, required: true, description: "ID of user to unban."
+
+  field :user, Types::UserType, null: true, description: "The user that has been unbanned."
+
+  sig { params(user_id: T.any(String, Integer)).returns(T::Hash[Symbol, User]) }
+  def resolve(user_id:)
+    user = User.find(user_id)
+
+    raise GraphQL::ExecutionError, "User has not been banned." unless user.banned?
+
+    user.banned = false
+
+    raise GraphQL::ExecutionError, user.errors.full_messages.join(", ") unless user.save
+
+    {
+      user: user
+    }
+  end
+
+  sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
+  def authorized?(object)
+    user = User.find_by(id: object[:user_id])
+
+    return false if user.nil?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to unban this user." unless UserPolicy.new(@context[:current_user], user).unban?
+
+    return true
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -8,6 +8,8 @@ module Types
 
     field :follow_user, mutation: Mutations::FollowUser
     field :unfollow_user, mutation: Mutations::UnfollowUser
+    field :ban_user, mutation: Mutations::BanUser
+    field :unban_user, mutation: Mutations::UnbanUser
 
     field :add_game_to_library, mutation: Mutations::AddGameToLibrary
     field :update_game_in_library, mutation: Mutations::UpdateGameInLibrary

--- a/spec/requests/api/mutations/ban_user_spec.rb
+++ b/spec/requests/api/mutations/ban_user_spec.rb
@@ -1,0 +1,63 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "BanUser Mutation API", type: :request do
+  describe "Mutation bans the user" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          banUser(userId: $id) {
+            user {
+              id
+              username
+              banned
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'when the current user is an admin' do
+      let(:user) { create(:confirmed_admin) }
+      let(:user2) { create(:confirmed_user) }
+
+      it "increases the number of banned users" do
+        user2
+
+        expect do
+          api_request(query_string, variables: { id: user2.id }, token: access_token)
+        end.to change(User.where(banned: true), :count).by(1)
+      end
+
+      it "returns basic data for user after banning them" do
+        user2
+
+        result = api_request(query_string, variables: { id: user2.id }, token: access_token)
+
+        expect(result.graphql_dig(:ban_user, :user)).to eq(
+          {
+            id: user2.id.to_s,
+            username: user2.username,
+            banned: true
+          }
+        )
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+      let(:user2) { create(:confirmed_user) }
+
+      it "does not change the number of banned users" do
+        user2
+
+        expect do
+          result = api_request(query_string, variables: { id: user2.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to ban this user.")
+        end.not_to change(User.where(banned: true), :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/unban_user_spec.rb
+++ b/spec/requests/api/mutations/unban_user_spec.rb
@@ -1,0 +1,63 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "UnbanUser Mutation API", type: :request do
+  describe "Mutation unbans the user" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          unbanUser(userId: $id) {
+            user {
+              id
+              username
+              banned
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'when the current user is an admin' do
+      let(:user) { create(:confirmed_admin) }
+      let(:user2) { create(:confirmed_user, banned: true) }
+
+      it "decreases the number of banned users" do
+        user2
+
+        expect do
+          api_request(query_string, variables: { id: user2.id }, token: access_token)
+        end.to change(User.where(banned: true), :count).by(-1)
+      end
+
+      it "returns basic data for user after unbanning them" do
+        user2
+
+        result = api_request(query_string, variables: { id: user2.id }, token: access_token)
+
+        expect(result.graphql_dig(:unban_user, :user)).to eq(
+          {
+            id: user2.id.to_s,
+            username: user2.username,
+            banned: false
+          }
+        )
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+      let(:user2) { create(:confirmed_user) }
+
+      it "does not change the number of banned users" do
+        user2
+
+        expect do
+          result = api_request(query_string, variables: { id: user2.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to unban this user.")
+        end.not_to change(User.where(banned: true), :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pretty simple, just checks to make sure the current user is a moderator or admin.

Fixes #1928.