### PR TITLE
Add a SteamBlocklist endpoint for the GraphQL API.

### DIFF
--- a/app/graphql/resolvers/site_statistic_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/site_statistic_resolvers/list_resolver.rb
@@ -4,7 +4,7 @@ module Resolvers
     class ListResolver < Resolvers::BaseResolver
       type Types::SiteStatisticType.connection_type, null: true
 
-      description "List all statistics. **This information is only available to admins.**"
+      description "List all statistics. **Only available to admins.**"
 
       sig { returns(Statistic::RelationType) }
       def resolve

--- a/app/graphql/resolvers/steam_blocklist_resolver.rb
+++ b/app/graphql/resolvers/steam_blocklist_resolver.rb
@@ -1,0 +1,20 @@
+# typed: true
+module Resolvers
+  class SteamBlocklistResolver < Resolvers::BaseResolver
+    type Types::SteamBlocklistEntryType.connection_type, null: true
+
+    description "List all steam blocklist entries. **Only available to admins.**"
+
+    sig { returns(T.nilable(SteamBlocklist::RelationType)) }
+    def resolve
+      SteamBlocklist.all
+    end
+
+    sig { returns(T::Boolean) }
+    def authorized?
+      raise GraphQL::ExecutionError, "Viewing the Steam Blocklist is only available to admins." unless AdminPolicy.new(@context[:current_user], nil).steam_blocklist?
+
+      true
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -42,7 +42,10 @@ module Types
 
     field :activity, resolver: Resolvers::ActivityResolver
 
-    field :site_statistics, resolver: Resolvers::SiteStatisticResolvers::ListResolver
     field :basic_site_statistics, resolver: Resolvers::SiteStatisticResolvers::BasicResolver
+
+    # Admin stuff
+    field :site_statistics, resolver: Resolvers::SiteStatisticResolvers::ListResolver
+    field :steam_blocklist, resolver: Resolvers::SteamBlocklistResolver
   end
 end

--- a/app/graphql/types/steam_blocklist_entry_type.rb
+++ b/app/graphql/types/steam_blocklist_entry_type.rb
@@ -1,0 +1,19 @@
+# typed: strict
+module Types
+  class SteamBlocklistEntryType < Types::BaseObject
+    description <<~MARKDOWN
+      Entries in the Steam Blocklist, for blocking the creation of games with a
+      given Steam App ID. Mainly used for things we don't want to track, such
+      as DLC or non-game Steam applications.
+    MARKDOWN
+
+    field :id, ID, null: false, description: "ID of the Steam Blocklist entry."
+    field :name, String, null: false, description: "Name of the game that has been blocked."
+    field :steam_app_id, Integer, null: false, description: "The blocked Steam App ID."
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: "When this blocklist entry was first created."
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false, description: "When this blocklist entry was last updated."
+
+    # Associations
+    field :user, UserType, null: true, description: "User that created this blocklist entry, can be null if the user deleted their account."
+  end
+end

--- a/spec/requests/api/steam_blocklist_spec.rb
+++ b/spec/requests/api/steam_blocklist_spec.rb
@@ -1,0 +1,75 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "Steam Blocklist API", type: :request do
+  describe "Query for data on steam blocklist entries" do
+    context 'when signed in as an admin' do
+      let(:user) { create(:confirmed_admin) }
+      let(:application) { build(:application, owner: user) }
+      let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+      let(:steam_blocklist_entries) { create_list(:steam_blocklist, 2) }
+
+      it "returns basic data for steam blocklist entries" do
+        steam_blocklist_entries
+        query_string = <<-GRAPHQL
+          query {
+            steamBlocklist {
+              nodes {
+                id
+                name
+                user {
+                  id
+                  username
+                }
+              }
+            }
+          }
+        GRAPHQL
+
+        result = api_request(query_string, token: access_token)
+
+        expect(result.graphql_dig(:steam_blocklist, :nodes).length).to eq(2)
+        expect(result.graphql_dig(:steam_blocklist, :nodes).first).to eq(
+          {
+            id: steam_blocklist_entries.first.id.to_s,
+            name: steam_blocklist_entries.first.name,
+            user: {
+              id: steam_blocklist_entries.first.user.id.to_s,
+              username: steam_blocklist_entries.first.user.username
+            }
+          }
+        )
+      end
+    end
+
+    context 'when signed in as a normal user' do
+      let(:user) { create(:confirmed_user) }
+      let(:application) { build(:application, owner: user) }
+      let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+      let(:steam_blocklist_entry) { create(:steam_blocklist) }
+
+      it "returns a permissions error" do
+        steam_blocklist_entry
+        query_string = <<-GRAPHQL
+          query {
+            steamBlocklist {
+              nodes {
+                id
+                name
+                user {
+                  id
+                  username
+                }
+              }
+            }
+          }
+        GRAPHQL
+
+        result = api_request(query_string, token: access_token)
+
+        expect(api_result_errors(result)).to include('Viewing the Steam Blocklist is only available to admins.')
+        expect(result.graphql_dig(:steam_blocklist)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pretty self-explanatory, only available to admins.

Resolves #1900.