### PR TITLE
Add mutations for creating/updating/deleting companies

### DIFF
--- a/app/graphql/mutations/companies/create_company.rb
+++ b/app/graphql/mutations/companies/create_company.rb
@@ -1,0 +1,28 @@
+# typed: true
+class Mutations::Companies::CreateCompany < Mutations::BaseMutation
+  description "Create a new game company."
+
+  argument :name, String, required: true, description: 'The name of the company.'
+  argument :wikidata_id, Integer, required: false, description: 'The ID of the company item in Wikidata.'
+
+  field :company, Types::CompanyType, null: true, description: "The company that was created."
+
+  sig { params(name: String, wikidata_id: T.nilable(Integer)).returns(T::Hash[Symbol, Company]) }
+  def resolve(name:, wikidata_id: nil)
+    company = Company.new(name: name, wikidata_id: wikidata_id)
+
+    raise GraphQL::ExecutionError, company.errors.full_messages.join(", ") unless company.save
+
+    {
+      company: company
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(_object: T.untyped).returns(T::Boolean) }
+  def authorized?(_object)
+    raise GraphQL::ExecutionError, "You aren't allowed to create a company." unless CompanyPolicy.new(@context[:current_user], nil).create?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/companies/create_company.rb
+++ b/app/graphql/mutations/companies/create_company.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Companies::CreateCompany < Mutations::BaseMutation
-  description "Create a new game company."
+  description "Create a new game company. **Not available in production for now.**"
 
   argument :name, String, required: true, description: 'The name of the company.'
   argument :wikidata_id, Integer, required: false, description: 'The ID of the company item in Wikidata.'
@@ -21,6 +21,9 @@ class Mutations::Companies::CreateCompany < Mutations::BaseMutation
   # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
     raise GraphQL::ExecutionError, "You aren't allowed to create a company." unless CompanyPolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/companies/delete_company.rb
+++ b/app/graphql/mutations/companies/delete_company.rb
@@ -1,0 +1,28 @@
+# typed: true
+class Mutations::Companies::DeleteCompany < Mutations::BaseMutation
+  description "Delete a game company. **Only available to moderators and admins.**"
+
+  argument :company_id, ID, required: true, description: 'The ID of the company to delete.'
+
+  field :deleted, Boolean, null: true, description: "Whether the company was successfully deleted."
+
+  sig { params(company_id: T.any(String, Integer)).returns(T::Hash[Symbol, T::Boolean]) }
+  def resolve(company_id:)
+    company = Company.find(company_id)
+
+    raise GraphQL::ExecutionError, company.errors.full_messages.join(", ") unless company.destroy
+
+    {
+      deleted: true
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: { company_id: T.any(String, Integer) }).returns(T::Boolean) }
+  def authorized?(object)
+    company = Company.find(object[:company_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this company." unless CompanyPolicy.new(@context[:current_user], company).destroy?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/companies/delete_company.rb
+++ b/app/graphql/mutations/companies/delete_company.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Companies::DeleteCompany < Mutations::BaseMutation
-  description "Delete a game company. **Only available to moderators and admins.**"
+  description "Delete a game company. **Only available to moderators and admins.** **Not available in production for now.**"
 
   argument :company_id, ID, required: true, description: 'The ID of the company to delete.'
 
@@ -18,8 +18,11 @@ class Mutations::Companies::DeleteCompany < Mutations::BaseMutation
   end
 
   # TODO: Put this mutation behind the "first party" OAuth application flag.
-  sig { params(object: { company_id: T.any(String, Integer) }).returns(T::Boolean) }
+  sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
     company = Company.find(object[:company_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this company." unless CompanyPolicy.new(@context[:current_user], company).destroy?
 

--- a/app/graphql/mutations/companies/update_company.rb
+++ b/app/graphql/mutations/companies/update_company.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Companies::UpdateCompany < Mutations::BaseMutation
+  description "Update an existing game company."
+
+  argument :company_id, ID, required: true, description: 'The ID of the company record.'
+  argument :name, String, required: false, description: 'The name of the company.'
+  argument :wikidata_id, Integer, required: false, description: 'The ID of the company item in Wikidata.'
+
+  field :company, Types::CompanyType, null: false, description: "The company that was updated."
+
+  # Use **args so we don't replace existing fields that aren't provided with `nil`.
+  sig { params(company_id: T.any(String, Integer), args: T.untyped).returns(T::Hash[Symbol, Company]) }
+  def resolve(company_id:, **args)
+    company = Company.find(company_id)
+
+    raise GraphQL::ExecutionError, company.errors.full_messages.join(", ") unless company.update(**args)
+
+    {
+      company: company
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    company = Company.find(object[:company_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to update this company." unless CompanyPolicy.new(@context[:current_user], company).update?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/companies/update_company.rb
+++ b/app/graphql/mutations/companies/update_company.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Companies::UpdateCompany < Mutations::BaseMutation
-  description "Update an existing game company."
+  description "Update an existing game company. **Not available in production for now.**"
 
   argument :company_id, ID, required: true, description: 'The ID of the company record.'
   argument :name, String, required: false, description: 'The name of the company.'
@@ -23,6 +23,9 @@ class Mutations::Companies::UpdateCompany < Mutations::BaseMutation
   # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
     company = Company.find(object[:company_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this company." unless CompanyPolicy.new(@context[:current_user], company).update?
 

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -16,6 +16,11 @@ module Types
     field :update_game_in_library, mutation: Mutations::GamePurchases::UpdateGameInLibrary
     field :remove_game_from_library, mutation: Mutations::GamePurchases::RemoveGameFromLibrary
 
+    # Company mutations
+    field :create_company, mutation: Mutations::Companies::CreateCompany
+    field :update_company, mutation: Mutations::Companies::UpdateCompany
+    field :delete_company, mutation: Mutations::Companies::DeleteCompany
+
     field :delete_event, mutation: Mutations::DeleteEvent
 
     # Admin

--- a/app/graphql/video_game_list_schema.rb
+++ b/app/graphql/video_game_list_schema.rb
@@ -15,8 +15,8 @@ class VideoGameListSchema < GraphQL::Schema
   default_max_page_size 30
 
   # Return a valid response when an ActiveRecord record can't be found.
-  rescue_from(ActiveRecord::RecordNotFound) do |_err, _obj, _args, _ctx, field|
-    # Raise a graphql-friendly error with a custom message
-    raise GraphQL::ExecutionError, "#{field.type.unwrap.graphql_name} not found"
+  rescue_from(ActiveRecord::RecordNotFound) do |err, _obj, _args, _ctx, _field|
+    # Raise a graphql-friendly error with the error message from the exception.
+    raise GraphQL::ExecutionError, "Record not found: #{err.message}"
   end
 end

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -31,13 +31,20 @@ class CompanyPolicy < ApplicationPolicy
     user.present?
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def destroy?
-    user.present?
+    user_is_moderator_or_admin?
   end
 
   sig { returns(T::Boolean) }
   def search?
     user.present?
+  end
+
+  private
+
+  sig { returns(T.nilable(T::Boolean)) }
+  def user_is_moderator_or_admin?
+    user && (user&.moderator? || user&.admin?)
   end
 end

--- a/spec/features/companies_spec.rb
+++ b/spec/features/companies_spec.rb
@@ -75,7 +75,8 @@ RSpec.describe "Companies", type: :feature do
 
   describe "delete company" do
     let!(:company) { create(:company) }
-    let(:user) { create(:confirmed_user) }
+    # Must be a moderator or the company won't be deletable.
+    let(:user) { create(:confirmed_moderator) }
 
     it "accepts valid company data" do
       sign_in(user)

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -8,10 +8,14 @@ RSpec.describe CompanyPolicy, type: :policy do
     let(:user) { create(:user) }
     let(:company) { create(:company) }
 
-    it "let's a user do everything" do
+    it "let's a user do everything except destroy the company" do
       expect(company_policy).to permit_actions(
-        [:index, :show, :create, :new, :edit, :update, :destroy, :search]
+        [:index, :show, :create, :new, :edit, :update, :search]
       )
+    end
+
+    it 'does not let a user destroy companies' do
+      expect(company_policy).to forbid_action(:destroy)
     end
   end
 

--- a/spec/requests/api/mutations/companies/create_company_spec.rb
+++ b/spec/requests/api/mutations/companies/create_company_spec.rb
@@ -1,0 +1,44 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "CreateCompany Mutation API", type: :request do
+  describe "Mutation creates a new company record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($name: String!, $wikidataId: Int!) {
+          createCompany(name: $name, wikidataId: $wikidataId) {
+            company {
+              name
+              wikidataId
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:user, :moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "increases the number of companies" do
+          expect do
+            api_request(query_string, variables: { name: 'Valve', wikidata_id: 123 }, token: access_token)
+          end.to change(Company, :count).by(1)
+        end
+
+        it "returns basic data for company after creation" do
+          result = api_request(query_string, variables: { name: 'Valve', wikidata_id: 123 }, token: access_token)
+
+          expect(result.graphql_dig(:create_company, :company)).to eq(
+            {
+              name: 'Valve',
+              wikidataId: 123
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/companies/delete_company_spec.rb
+++ b/spec/requests/api/mutations/companies/delete_company_spec.rb
@@ -1,0 +1,46 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "DeleteCompany Mutation API", type: :request do
+  describe "Mutation deletes an existing company record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:company) { create(:company) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($companyId: ID!) {
+          deleteCompany(companyId: $companyId) {
+            deleted
+          }
+        }
+      GRAPHQL
+    end
+
+    context "when the current user is an admin" do
+      let(:user) { create(:confirmed_admin) }
+
+      it "decreases the number of companies" do
+        expect do
+          api_request(query_string, variables: { company_id: company.id }, token: access_token)
+        end.to change(Company, :count).by(-1)
+      end
+
+      it "returns true after deletion" do
+        result = api_request(query_string, variables: { company_id: company.id }, token: access_token)
+
+        expect(result.graphql_dig(:delete_company, :deleted)).to eq(true)
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not change the number of companies" do
+        expect do
+          result = api_request(query_string, variables: { company_id: company.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this company.")
+        end.not_to change(Company, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/companies/update_company_spec.rb
+++ b/spec/requests/api/mutations/companies/update_company_spec.rb
@@ -1,0 +1,48 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "UpdateCompany Mutation API", type: :request do
+  describe "Mutation updates an existing company record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:company) { create(:company) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($companyId: ID!, $name: String, $wikidataId: Int) {
+          updateCompany(companyId: $companyId, name: $name, wikidataId: $wikidataId) {
+            company {
+              name
+              wikidataId
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:user, :moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "does not change the number of companies" do
+          expect do
+            api_request(query_string, variables: { company_id: company.id, name: 'Nintendo', wikidata_id: 123 }, token: access_token)
+          end.not_to change(Company, :count)
+        end
+
+        it "returns basic data for company after creation" do
+          result = api_request(query_string, variables: { company_id: company.id, name: 'Nintendo', wikidata_id: 123 }, token: access_token)
+
+          expect(result.graphql_dig(:update_company, :company)).to eq(
+            {
+              name: 'Nintendo',
+              wikidataId: 123
+            }
+          )
+
+          expect(company.reload.name).to eq('Nintendo')
+          expect(company.reload.wikidata_id).to eq(123)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Companies", type: :request do
   end
 
   describe "DELETE company_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let!(:company) { create(:company) }
 
     it "deletes a company" do


### PR DESCRIPTION
Resolves #1970.

This also updates the CompanyPolicy to prevent normal users from deleting company records.

These mutations are intentionally disabled in production to prevent abuse, they'll be made available exclusively to first-party OAuth applications in the future (once I implement those).