### PR TITLE
Add GraphQL Mutations for Platforms and Engines

### DIFF
--- a/app/graphql/mutations/engines/create_engine.rb
+++ b/app/graphql/mutations/engines/create_engine.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Engines::CreateEngine < Mutations::BaseMutation
+  description "Create a new game engine. **Not available in production for now.**"
+
+  argument :name, String, required: true, description: 'The name of the engine.'
+  argument :wikidata_id, Integer, required: false, description: 'The ID of the engine item in Wikidata.'
+
+  field :engine, Types::EngineType, null: true, description: "The engine that was created."
+
+  sig { params(name: String, wikidata_id: T.nilable(Integer)).returns(T::Hash[Symbol, Engine]) }
+  def resolve(name:, wikidata_id: nil)
+    engine = Engine.new(name: name, wikidata_id: wikidata_id)
+
+    raise GraphQL::ExecutionError, engine.errors.full_messages.join(", ") unless engine.save
+
+    {
+      engine: engine
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(_object: T.untyped).returns(T::Boolean) }
+  def authorized?(_object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to create an engine." unless EnginePolicy.new(@context[:current_user], nil).create?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/engines/delete_engine.rb
+++ b/app/graphql/mutations/engines/delete_engine.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Engines::DeleteEngine < Mutations::BaseMutation
+  description "Delete a game engine. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :engine_id, ID, required: true, description: 'The ID of the engine to delete.'
+
+  field :deleted, Boolean, null: true, description: "Whether the engine was successfully deleted."
+
+  sig { params(engine_id: T.any(String, Integer)).returns(T::Hash[Symbol, T::Boolean]) }
+  def resolve(engine_id:)
+    engine = Engine.find(engine_id)
+
+    raise GraphQL::ExecutionError, engine.errors.full_messages.join(", ") unless engine.destroy
+
+    {
+      deleted: true
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    engine = Engine.find(object[:engine_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this engine." unless EnginePolicy.new(@context[:current_user], engine).destroy?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/engines/update_engine.rb
+++ b/app/graphql/mutations/engines/update_engine.rb
@@ -1,0 +1,34 @@
+# typed: true
+class Mutations::Engines::UpdateEngine < Mutations::BaseMutation
+  description "Update an existing game engine. **Not available in production for now.**"
+
+  argument :engine_id, ID, required: true, description: 'The ID of the engine record.'
+  argument :name, String, required: false, description: 'The name of the engine.'
+  argument :wikidata_id, Integer, required: false, description: 'The ID of the engine item in Wikidata.'
+
+  field :engine, Types::EngineType, null: false, description: "The engine that was updated."
+
+  # Use **args so we don't replace existing fields that aren't provided with `nil`.
+  sig { params(engine_id: T.any(String, Integer), args: T.untyped).returns(T::Hash[Symbol, Engine]) }
+  def resolve(engine_id:, **args)
+    engine = Engine.find(engine_id)
+
+    raise GraphQL::ExecutionError, engine.errors.full_messages.join(", ") unless engine.update(**args)
+
+    {
+      engine: engine
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    engine = Engine.find(object[:engine_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to update this engine." unless EnginePolicy.new(@context[:current_user], engine).update?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/platforms/create_platform.rb
+++ b/app/graphql/mutations/platforms/create_platform.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Platforms::CreatePlatform < Mutations::BaseMutation
+  description "Create a new game platform. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :name, String, required: true, description: 'The name of the platform.'
+  argument :wikidata_id, Integer, required: false, description: 'The ID of the platform item in Wikidata.'
+
+  field :platform, Types::PlatformType, null: true, description: "The platform that was created."
+
+  sig { params(name: String, wikidata_id: T.nilable(Integer)).returns(T::Hash[Symbol, Platform]) }
+  def resolve(name:, wikidata_id: nil)
+    platform = Platform.new(name: name, wikidata_id: wikidata_id)
+
+    raise GraphQL::ExecutionError, platform.errors.full_messages.join(", ") unless platform.save
+
+    {
+      platform: platform
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(_object: T.untyped).returns(T::Boolean) }
+  def authorized?(_object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to create a platform." unless PlatformPolicy.new(@context[:current_user], nil).create?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/platforms/delete_platform.rb
+++ b/app/graphql/mutations/platforms/delete_platform.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Platforms::DeletePlatform < Mutations::BaseMutation
+  description "Delete a game platform. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :platform_id, ID, required: true, description: 'The ID of the platform to delete.'
+
+  field :deleted, Boolean, null: true, description: "Whether the platform was successfully deleted."
+
+  sig { params(platform_id: T.any(String, Integer)).returns(T::Hash[Symbol, T::Boolean]) }
+  def resolve(platform_id:)
+    platform = Platform.find(platform_id)
+
+    raise GraphQL::ExecutionError, platform.errors.full_messages.join(", ") unless platform.destroy
+
+    {
+      deleted: true
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    platform = Platform.find(object[:platform_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this platform." unless PlatformPolicy.new(@context[:current_user], platform).destroy?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/platforms/update_platform.rb
+++ b/app/graphql/mutations/platforms/update_platform.rb
@@ -1,0 +1,34 @@
+# typed: true
+class Mutations::Platforms::UpdatePlatform < Mutations::BaseMutation
+  description "Update an existing game platform. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :platform_id, ID, required: true, description: 'The ID of the platform record.'
+  argument :name, String, required: false, description: 'The name of the platform.'
+  argument :wikidata_id, Integer, required: false, description: 'The ID of the platform item in Wikidata.'
+
+  field :platform, Types::PlatformType, null: false, description: "The platform that was updated."
+
+  # Use **args so we don't replace existing fields that aren't provided with `nil`.
+  sig { params(platform_id: T.any(String, Integer), args: T.untyped).returns(T::Hash[Symbol, Platform]) }
+  def resolve(platform_id:, **args)
+    platform = Platform.find(platform_id)
+
+    raise GraphQL::ExecutionError, platform.errors.full_messages.join(", ") unless platform.update(**args)
+
+    {
+      platform: platform
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    platform = Platform.find(object[:platform_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to update this platform." unless PlatformPolicy.new(@context[:current_user], platform).update?
+
+    return true
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -21,6 +21,11 @@ module Types
     field :update_company, mutation: Mutations::Companies::UpdateCompany
     field :delete_company, mutation: Mutations::Companies::DeleteCompany
 
+    # Engine mutations
+    field :create_engine, mutation: Mutations::Engines::CreateEngine
+    field :update_engine, mutation: Mutations::Engines::UpdateEngine
+    field :delete_engine, mutation: Mutations::Engines::DeleteEngine
+
     # Platform mutations
     field :create_platform, mutation: Mutations::Platforms::CreatePlatform
     field :update_platform, mutation: Mutations::Platforms::UpdatePlatform

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -21,6 +21,11 @@ module Types
     field :update_company, mutation: Mutations::Companies::UpdateCompany
     field :delete_company, mutation: Mutations::Companies::DeleteCompany
 
+    # Platform mutations
+    field :create_platform, mutation: Mutations::Platforms::CreatePlatform
+    field :update_platform, mutation: Mutations::Platforms::UpdatePlatform
+    field :delete_platform, mutation: Mutations::Platforms::DeletePlatform
+
     field :delete_event, mutation: Mutations::DeleteEvent
 
     # Admin

--- a/spec/requests/api/mutations/engines/create_engine_spec.rb
+++ b/spec/requests/api/mutations/engines/create_engine_spec.rb
@@ -1,0 +1,44 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "CreateEngine Mutation API", type: :request do
+  describe "Mutation creates a new engine record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($name: String!, $wikidataId: Int!) {
+          createEngine(name: $name, wikidataId: $wikidataId) {
+            engine {
+              name
+              wikidataId
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:user, :moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "increases the number of engines" do
+          expect do
+            api_request(query_string, variables: { name: 'GoldSrc', wikidata_id: 123 }, token: access_token)
+          end.to change(Engine, :count).by(1)
+        end
+
+        it "returns basic data for engine after creation" do
+          result = api_request(query_string, variables: { name: 'GoldSrc', wikidata_id: 123 }, token: access_token)
+
+          expect(result.graphql_dig(:create_engine, :engine)).to eq(
+            {
+              name: 'GoldSrc',
+              wikidataId: 123
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/engines/delete_engine_spec.rb
+++ b/spec/requests/api/mutations/engines/delete_engine_spec.rb
@@ -1,0 +1,46 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "DeleteEngine Mutation API", type: :request do
+  describe "Mutation deletes an existing engine record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:engine) { create(:engine) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($engineId: ID!) {
+          deleteEngine(engineId: $engineId) {
+            deleted
+          }
+        }
+      GRAPHQL
+    end
+
+    context "when the current user is an admin" do
+      let(:user) { create(:confirmed_admin) }
+
+      it "decreases the number of engines" do
+        expect do
+          api_request(query_string, variables: { engine_id: engine.id }, token: access_token)
+        end.to change(Engine, :count).by(-1)
+      end
+
+      it "returns true after deletion" do
+        result = api_request(query_string, variables: { engine_id: engine.id }, token: access_token)
+
+        expect(result.graphql_dig(:delete_engine, :deleted)).to eq(true)
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not change the number of engines" do
+        expect do
+          result = api_request(query_string, variables: { engine_id: engine.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this engine.")
+        end.not_to change(Engine, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/engines/update_engine_spec.rb
+++ b/spec/requests/api/mutations/engines/update_engine_spec.rb
@@ -1,0 +1,48 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "UpdateEngine Mutation API", type: :request do
+  describe "Mutation updates an existing engine record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:engine) { create(:engine) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($engineId: ID!, $name: String, $wikidataId: Int) {
+          updateEngine(engineId: $engineId, name: $name, wikidataId: $wikidataId) {
+            engine {
+              name
+              wikidataId
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:user, :moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "does not change the number of engines" do
+          expect do
+            api_request(query_string, variables: { engine_id: engine.id, name: 'GoldSrc', wikidata_id: 123 }, token: access_token)
+          end.not_to change(Engine, :count)
+        end
+
+        it "returns basic data for engine after creation" do
+          result = api_request(query_string, variables: { engine_id: engine.id, name: 'GoldSrc', wikidata_id: 123 }, token: access_token)
+
+          expect(result.graphql_dig(:update_engine, :engine)).to eq(
+            {
+              name: 'GoldSrc',
+              wikidataId: 123
+            }
+          )
+
+          expect(engine.reload.name).to eq('GoldSrc')
+          expect(engine.reload.wikidata_id).to eq(123)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/platforms/create_platform_spec.rb
+++ b/spec/requests/api/mutations/platforms/create_platform_spec.rb
@@ -1,0 +1,44 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "CreatePlatform Mutation API", type: :request do
+  describe "Mutation creates a new platform record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($name: String!, $wikidataId: Int!) {
+          createPlatform(name: $name, wikidataId: $wikidataId) {
+            platform {
+              name
+              wikidataId
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "increases the number of platforms" do
+          expect do
+            api_request(query_string, variables: { name: 'Nintendo Switch', wikidata_id: 123 }, token: access_token)
+          end.to change(Platform, :count).by(1)
+        end
+
+        it "returns basic data for platform after creation" do
+          result = api_request(query_string, variables: { name: 'Nintendo Switch', wikidata_id: 123 }, token: access_token)
+
+          expect(result.graphql_dig(:create_platform, :platform)).to eq(
+            {
+              name: 'Nintendo Switch',
+              wikidataId: 123
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/platforms/delete_platform_spec.rb
+++ b/spec/requests/api/mutations/platforms/delete_platform_spec.rb
@@ -1,0 +1,46 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "DeletePlatform Mutation API", type: :request do
+  describe "Mutation deletes an existing platform record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:platform) { create(:platform) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($platformId: ID!) {
+          deletePlatform(platformId: $platformId) {
+            deleted
+          }
+        }
+      GRAPHQL
+    end
+
+    context "when the current user is an admin" do
+      let(:user) { create(:confirmed_admin) }
+
+      it "decreases the number of platforms" do
+        expect do
+          api_request(query_string, variables: { platform_id: platform.id }, token: access_token)
+        end.to change(Platform, :count).by(-1)
+      end
+
+      it "returns true after deletion" do
+        result = api_request(query_string, variables: { platform_id: platform.id }, token: access_token)
+
+        expect(result.graphql_dig(:delete_platform, :deleted)).to eq(true)
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not change the number of platforms" do
+        expect do
+          result = api_request(query_string, variables: { platform_id: platform.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this platform.")
+        end.not_to change(Platform, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/platforms/update_platform_spec.rb
+++ b/spec/requests/api/mutations/platforms/update_platform_spec.rb
@@ -1,0 +1,59 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "UpdatePlatform Mutation API", type: :request do
+  describe "Mutation updates an existing platform record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:platform) { create(:platform, name: 'Xbox 360') }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($platformId: ID!, $name: String, $wikidataId: Int) {
+          updatePlatform(platformId: $platformId, name: $name, wikidataId: $wikidataId) {
+            platform {
+              name
+              wikidataId
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "does not change the number of platforms" do
+          expect do
+            api_request(query_string, variables: { platform_id: platform.id, name: 'Nintendo Switch', wikidata_id: 123 }, token: access_token)
+          end.not_to change(Platform, :count)
+        end
+
+        it "returns basic data for platform after creation" do
+          result = api_request(query_string, variables: { platform_id: platform.id, name: 'Nintendo Switch', wikidata_id: 123 }, token: access_token)
+
+          expect(result.graphql_dig(:update_platform, :platform)).to eq(
+            {
+              name: 'Nintendo Switch',
+              wikidataId: 123
+            }
+          )
+
+          expect(platform.reload.name).to eq('Nintendo Switch')
+          expect(platform.reload.wikidata_id).to eq(123)
+        end
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not update the platform" do
+        expect do
+          result = api_request(query_string, variables: { platform_id: platform.id, name: 'Nintendo Switch', wikidata_id: 123 }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to update this platform.")
+        end.not_to change(platform.reload, :name).from('Xbox 360')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pretty much the same as the Company mutations in #1972, disabled in production until I can get the first-party OAuth applications working.

Resolves #1971.
Resolves #1968.