### PR TITLE
Add GraphQL mutations for Genres, Series, and Stores

### DIFF
--- a/app/graphql/mutations/genres/create_genre.rb
+++ b/app/graphql/mutations/genres/create_genre.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Genres::CreateGenre < Mutations::BaseMutation
+  description "Create a new game genre. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :name, String, required: true, description: 'The name of the genre.'
+  argument :wikidata_id, Integer, required: false, description: 'The ID of the genre item in Wikidata.'
+
+  field :genre, Types::GenreType, null: true, description: "The genre that was created."
+
+  sig { params(name: String, wikidata_id: T.nilable(Integer)).returns(T::Hash[Symbol, Genre]) }
+  def resolve(name:, wikidata_id: nil)
+    genre = Genre.new(name: name, wikidata_id: wikidata_id)
+
+    raise GraphQL::ExecutionError, genre.errors.full_messages.join(", ") unless genre.save
+
+    {
+      genre: genre
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(_object: T.untyped).returns(T::Boolean) }
+  def authorized?(_object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to create a genre." unless GenrePolicy.new(@context[:current_user], nil).create?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/genres/delete_genre.rb
+++ b/app/graphql/mutations/genres/delete_genre.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Genres::DeleteGenre < Mutations::BaseMutation
+  description "Delete a game genre. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :genre_id, ID, required: true, description: 'The ID of the genre to delete.'
+
+  field :deleted, Boolean, null: true, description: "Whether the genre was successfully deleted."
+
+  sig { params(genre_id: T.any(String, Integer)).returns(T::Hash[Symbol, T::Boolean]) }
+  def resolve(genre_id:)
+    genre = Genre.find(genre_id)
+
+    raise GraphQL::ExecutionError, genre.errors.full_messages.join(", ") unless genre.destroy
+
+    {
+      deleted: true
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    genre = Genre.find(object[:genre_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this genre." unless GenrePolicy.new(@context[:current_user], genre).destroy?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/genres/update_genre.rb
+++ b/app/graphql/mutations/genres/update_genre.rb
@@ -1,0 +1,34 @@
+# typed: true
+class Mutations::Genres::UpdateGenre < Mutations::BaseMutation
+  description "Update an existing game genre. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :genre_id, ID, required: true, description: 'The ID of the genre record.'
+  argument :name, String, required: false, description: 'The name of the genre.'
+  argument :wikidata_id, Integer, required: false, description: 'The ID of the genre item in Wikidata.'
+
+  field :genre, Types::GenreType, null: false, description: "The genre that was updated."
+
+  # Use **args so we don't replace existing fields that aren't provided with `nil`.
+  sig { params(genre_id: T.any(String, Integer), args: T.untyped).returns(T::Hash[Symbol, Genre]) }
+  def resolve(genre_id:, **args)
+    genre = Genre.find(genre_id)
+
+    raise GraphQL::ExecutionError, genre.errors.full_messages.join(", ") unless genre.update(**args)
+
+    {
+      genre: genre
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    genre = Genre.find(object[:genre_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to update this genre." unless GenrePolicy.new(@context[:current_user], genre).update?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/series/create_series.rb
+++ b/app/graphql/mutations/series/create_series.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Series::CreateSeries < Mutations::BaseMutation
+  description "Create a new game series. **Not available in production for now.**"
+
+  argument :name, String, required: true, description: 'The name of the series.'
+  argument :wikidata_id, Integer, required: false, description: 'The ID of the series item in Wikidata.'
+
+  field :series, Types::SeriesType, null: true, description: "The series that was created."
+
+  sig { params(name: String, wikidata_id: T.nilable(Integer)).returns(T::Hash[Symbol, Series]) }
+  def resolve(name:, wikidata_id: nil)
+    series = Series.new(name: name, wikidata_id: wikidata_id)
+
+    raise GraphQL::ExecutionError, series.errors.full_messages.join(", ") unless series.save
+
+    {
+      series: series
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(_object: T.untyped).returns(T::Boolean) }
+  def authorized?(_object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to create a series." unless SeriesPolicy.new(@context[:current_user], nil).create?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/series/delete_series.rb
+++ b/app/graphql/mutations/series/delete_series.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Series::DeleteSeries < Mutations::BaseMutation
+  description "Delete a game series. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :series_id, ID, required: true, description: 'The ID of the series to delete.'
+
+  field :deleted, Boolean, null: true, description: "Whether the series was successfully deleted."
+
+  sig { params(series_id: T.any(String, Integer)).returns(T::Hash[Symbol, T::Boolean]) }
+  def resolve(series_id:)
+    series = Series.find(series_id)
+
+    raise GraphQL::ExecutionError, series.errors.full_messages.join(", ") unless series.destroy
+
+    {
+      deleted: true
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    series = Series.find(object[:series_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this series." unless SeriesPolicy.new(@context[:current_user], series).destroy?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/series/update_series.rb
+++ b/app/graphql/mutations/series/update_series.rb
@@ -1,0 +1,34 @@
+# typed: true
+class Mutations::Series::UpdateSeries < Mutations::BaseMutation
+  description "Update an existing game series. **Not available in production for now.**"
+
+  argument :series_id, ID, required: true, description: 'The ID of the series record.'
+  argument :name, String, required: false, description: 'The name of the series.'
+  argument :wikidata_id, Integer, required: false, description: 'The ID of the series item in Wikidata.'
+
+  field :series, Types::SeriesType, null: false, description: "The series that was updated."
+
+  # Use **args so we don't replace existing fields that aren't provided with `nil`.
+  sig { params(series_id: T.any(String, Integer), args: T.untyped).returns(T::Hash[Symbol, Series]) }
+  def resolve(series_id:, **args)
+    series = Series.find(series_id)
+
+    raise GraphQL::ExecutionError, series.errors.full_messages.join(", ") unless series.update(**args)
+
+    {
+      series: series
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    series = Series.find(object[:series_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to update this series." unless SeriesPolicy.new(@context[:current_user], series).update?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/stores/create_store.rb
+++ b/app/graphql/mutations/stores/create_store.rb
@@ -1,0 +1,30 @@
+# typed: true
+class Mutations::Stores::CreateStore < Mutations::BaseMutation
+  description "Create a new game store. **Not available in production for now.**"
+
+  argument :name, String, required: true, description: 'The name of the store.'
+
+  field :store, Types::StoreType, null: true, description: "The store that was created."
+
+  sig { params(name: String).returns(T::Hash[Symbol, Store]) }
+  def resolve(name:)
+    store = Store.new(name: name)
+
+    raise GraphQL::ExecutionError, store.errors.full_messages.join(", ") unless store.save
+
+    {
+      store: store
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(_object: T.untyped).returns(T::Boolean) }
+  def authorized?(_object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to create a store." unless StorePolicy.new(@context[:current_user], nil).create?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/stores/delete_store.rb
+++ b/app/graphql/mutations/stores/delete_store.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Stores::DeleteStore < Mutations::BaseMutation
+  description "Delete a game store. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :store_id, ID, required: true, description: 'The ID of the store to delete.'
+
+  field :deleted, Boolean, null: true, description: "Whether the store was successfully deleted."
+
+  sig { params(store_id: T.any(String, Integer)).returns(T::Hash[Symbol, T::Boolean]) }
+  def resolve(store_id:)
+    store = Store.find(store_id)
+
+    raise GraphQL::ExecutionError, store.errors.full_messages.join(", ") unless store.destroy
+
+    {
+      deleted: true
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    store = Store.find(object[:store_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this store." unless StorePolicy.new(@context[:current_user], store).destroy?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/stores/update_store.rb
+++ b/app/graphql/mutations/stores/update_store.rb
@@ -1,0 +1,33 @@
+# typed: true
+class Mutations::Stores::UpdateStore < Mutations::BaseMutation
+  description "Update an existing game store. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :store_id, ID, required: true, description: 'The ID of the store record.'
+  argument :name, String, required: false, description: 'The name of the store.'
+
+  field :store, Types::StoreType, null: false, description: "The store that was updated."
+
+  # Use **args so we don't replace existing fields that aren't provided with `nil`.
+  sig { params(store_id: T.any(String, Integer), args: T.untyped).returns(T::Hash[Symbol, Store]) }
+  def resolve(store_id:, **args)
+    store = Store.find(store_id)
+
+    raise GraphQL::ExecutionError, store.errors.full_messages.join(", ") unless store.update(**args)
+
+    {
+      store: store
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    store = Store.find(object[:store_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to update this store." unless StorePolicy.new(@context[:current_user], store).update?
+
+    return true
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -31,6 +31,11 @@ module Types
     field :update_platform, mutation: Mutations::Platforms::UpdatePlatform
     field :delete_platform, mutation: Mutations::Platforms::DeletePlatform
 
+    # Store mutations
+    field :create_store, mutation: Mutations::Stores::CreateStore
+    field :update_store, mutation: Mutations::Stores::UpdateStore
+    field :delete_store, mutation: Mutations::Stores::DeleteStore
+
     field :delete_event, mutation: Mutations::DeleteEvent
 
     # Admin

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -26,6 +26,11 @@ module Types
     field :update_engine, mutation: Mutations::Engines::UpdateEngine
     field :delete_engine, mutation: Mutations::Engines::DeleteEngine
 
+    # Genre mutations
+    field :create_genre, mutation: Mutations::Genres::CreateGenre
+    field :update_genre, mutation: Mutations::Genres::UpdateGenre
+    field :delete_genre, mutation: Mutations::Genres::DeleteGenre
+
     # Platform mutations
     field :create_platform, mutation: Mutations::Platforms::CreatePlatform
     field :update_platform, mutation: Mutations::Platforms::UpdatePlatform

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -36,6 +36,11 @@ module Types
     field :update_platform, mutation: Mutations::Platforms::UpdatePlatform
     field :delete_platform, mutation: Mutations::Platforms::DeletePlatform
 
+    # Series mutations
+    field :create_series, mutation: Mutations::Series::CreateSeries
+    field :update_series, mutation: Mutations::Series::UpdateSeries
+    field :delete_series, mutation: Mutations::Series::DeleteSeries
+
     # Store mutations
     field :create_store, mutation: Mutations::Stores::CreateStore
     field :update_store, mutation: Mutations::Stores::UpdateStore

--- a/spec/requests/api/mutations/genres/create_genre_spec.rb
+++ b/spec/requests/api/mutations/genres/create_genre_spec.rb
@@ -1,0 +1,55 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "CreateGenre Mutation API", type: :request do
+  describe "Mutation creates a new genre record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($name: String!, $wikidataId: Int!) {
+          createGenre(name: $name, wikidataId: $wikidataId) {
+            genre {
+              name
+              wikidataId
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "increases the number of genres" do
+          expect do
+            api_request(query_string, variables: { name: 'First-person shooter', wikidata_id: 123 }, token: access_token)
+          end.to change(Genre, :count).by(1)
+        end
+
+        it "returns basic data for genre after creation" do
+          result = api_request(query_string, variables: { name: 'First-person shooter', wikidata_id: 123 }, token: access_token)
+
+          expect(result.graphql_dig(:create_genre, :genre)).to eq(
+            {
+              name: 'First-person shooter',
+              wikidataId: 123
+            }
+          )
+        end
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not create a new genre" do
+        expect do
+          result = api_request(query_string, variables: { name: 'First-person shooter', wikidata_id: 123 }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to create a genre.")
+        end.not_to change(Genre, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/genres/delete_genre_spec.rb
+++ b/spec/requests/api/mutations/genres/delete_genre_spec.rb
@@ -1,0 +1,46 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "DeleteGenre Mutation API", type: :request do
+  describe "Mutation deletes an existing genre record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:genre) { create(:genre) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($genreId: ID!) {
+          deleteGenre(genreId: $genreId) {
+            deleted
+          }
+        }
+      GRAPHQL
+    end
+
+    context "when the current user is an admin" do
+      let(:user) { create(:confirmed_admin) }
+
+      it "decreases the number of genres" do
+        expect do
+          api_request(query_string, variables: { genre_id: genre.id }, token: access_token)
+        end.to change(Genre, :count).by(-1)
+      end
+
+      it "returns true after deletion" do
+        result = api_request(query_string, variables: { genre_id: genre.id }, token: access_token)
+
+        expect(result.graphql_dig(:delete_genre, :deleted)).to eq(true)
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not change the number of genres" do
+        expect do
+          result = api_request(query_string, variables: { genre_id: genre.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this genre.")
+        end.not_to change(Genre, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/genres/update_genre_spec.rb
+++ b/spec/requests/api/mutations/genres/update_genre_spec.rb
@@ -1,0 +1,59 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "UpdateGenre Mutation API", type: :request do
+  describe "Mutation updates an existing genre record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:genre) { create(:genre, name: 'First-person shooter') }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($genreId: ID!, $name: String, $wikidataId: Int) {
+          updateGenre(genreId: $genreId, name: $name, wikidataId: $wikidataId) {
+            genre {
+              name
+              wikidataId
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "does not change the number of genres" do
+          expect do
+            api_request(query_string, variables: { genre_id: genre.id, name: 'Third-person shooter', wikidata_id: 123 }, token: access_token)
+          end.not_to change(Genre, :count)
+        end
+
+        it "returns basic data for genre after creation" do
+          result = api_request(query_string, variables: { genre_id: genre.id, name: 'Third-person shooter', wikidata_id: 123 }, token: access_token)
+
+          expect(result.graphql_dig(:update_genre, :genre)).to eq(
+            {
+              name: 'Third-person shooter',
+              wikidataId: 123
+            }
+          )
+
+          expect(genre.reload.name).to eq('Third-person shooter')
+          expect(genre.reload.wikidata_id).to eq(123)
+        end
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not update the genre" do
+        expect do
+          result = api_request(query_string, variables: { genre_id: genre.id, name: 'Third-person shooter', wikidata_id: 123 }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to update this genre.")
+        end.not_to change(genre.reload, :name).from('First-person shooter')
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/series/create_series_spec.rb
+++ b/spec/requests/api/mutations/series/create_series_spec.rb
@@ -1,0 +1,44 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "CreateSeries Mutation API", type: :request do
+  describe "Mutation creates a new series record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($name: String!, $wikidataId: Int!) {
+          createSeries(name: $name, wikidataId: $wikidataId) {
+            series {
+              name
+              wikidataId
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:user, :moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "increases the number of series" do
+          expect do
+            api_request(query_string, variables: { name: 'Portal', wikidata_id: 123 }, token: access_token)
+          end.to change(Series, :count).by(1)
+        end
+
+        it "returns basic data for series after creation" do
+          result = api_request(query_string, variables: { name: 'Portal', wikidata_id: 123 }, token: access_token)
+
+          expect(result.graphql_dig(:create_series, :series)).to eq(
+            {
+              name: 'Portal',
+              wikidataId: 123
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/series/delete_series_spec.rb
+++ b/spec/requests/api/mutations/series/delete_series_spec.rb
@@ -1,0 +1,46 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "DeleteSeries Mutation API", type: :request do
+  describe "Mutation deletes an existing series record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:series) { create(:series) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($seriesId: ID!) {
+          deleteSeries(seriesId: $seriesId) {
+            deleted
+          }
+        }
+      GRAPHQL
+    end
+
+    context "when the current user is an admin" do
+      let(:user) { create(:confirmed_admin) }
+
+      it "decreases the number of series" do
+        expect do
+          api_request(query_string, variables: { series_id: series.id }, token: access_token)
+        end.to change(Series, :count).by(-1)
+      end
+
+      it "returns true after deletion" do
+        result = api_request(query_string, variables: { series_id: series.id }, token: access_token)
+
+        expect(result.graphql_dig(:delete_series, :deleted)).to eq(true)
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not change the number of series" do
+        expect do
+          result = api_request(query_string, variables: { series_id: series.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this series.")
+        end.not_to change(Series, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/series/update_series_spec.rb
+++ b/spec/requests/api/mutations/series/update_series_spec.rb
@@ -1,0 +1,48 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "UpdateSeries Mutation API", type: :request do
+  describe "Mutation updates an existing series record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:series) { create(:series, name: 'Half-Life') }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($seriesId: ID!, $name: String, $wikidataId: Int) {
+          updateSeries(seriesId: $seriesId, name: $name, wikidataId: $wikidataId) {
+            series {
+              name
+              wikidataId
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:user, :moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "does not change the number of series" do
+          expect do
+            api_request(query_string, variables: { series_id: series.id, name: 'Portal', wikidata_id: 123 }, token: access_token)
+          end.not_to change(Series, :count)
+        end
+
+        it "returns basic data for series after creation" do
+          result = api_request(query_string, variables: { series_id: series.id, name: 'Portal', wikidata_id: 123 }, token: access_token)
+
+          expect(result.graphql_dig(:update_series, :series)).to eq(
+            {
+              name: 'Portal',
+              wikidataId: 123
+            }
+          )
+
+          expect(series.reload.name).to eq('Portal')
+          expect(series.reload.wikidata_id).to eq(123)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/stores/create_store_spec.rb
+++ b/spec/requests/api/mutations/stores/create_store_spec.rb
@@ -1,0 +1,42 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "CreateStore Mutation API", type: :request do
+  describe "Mutation creates a new store record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($name: String!) {
+          createStore(name: $name) {
+            store {
+              name
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:user, :moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "increases the number of stores" do
+          expect do
+            api_request(query_string, variables: { name: 'Steam' }, token: access_token)
+          end.to change(Store, :count).by(1)
+        end
+
+        it "returns basic data for store after creation" do
+          result = api_request(query_string, variables: { name: 'Steam' }, token: access_token)
+
+          expect(result.graphql_dig(:create_store, :store)).to eq(
+            {
+              name: 'Steam'
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/stores/delete_store_spec.rb
+++ b/spec/requests/api/mutations/stores/delete_store_spec.rb
@@ -1,0 +1,46 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "DeleteStore Mutation API", type: :request do
+  describe "Mutation deletes an existing store record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:store) { create(:store) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($storeId: ID!) {
+          deleteStore(storeId: $storeId) {
+            deleted
+          }
+        }
+      GRAPHQL
+    end
+
+    context "when the current user is an admin" do
+      let(:user) { create(:confirmed_admin) }
+
+      it "decreases the number of stores" do
+        expect do
+          api_request(query_string, variables: { store_id: store.id }, token: access_token)
+        end.to change(Store, :count).by(-1)
+      end
+
+      it "returns true after deletion" do
+        result = api_request(query_string, variables: { store_id: store.id }, token: access_token)
+
+        expect(result.graphql_dig(:delete_store, :deleted)).to eq(true)
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not change the number of stores" do
+        expect do
+          result = api_request(query_string, variables: { store_id: store.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this store.")
+        end.not_to change(Store, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/stores/update_store_spec.rb
+++ b/spec/requests/api/mutations/stores/update_store_spec.rb
@@ -1,0 +1,56 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "UpdateStore Mutation API", type: :request do
+  describe "Mutation updates an existing store record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:store) { create(:store, name: 'Origin') }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($storeId: ID!, $name: String) {
+          updateStore(storeId: $storeId, name: $name) {
+            store {
+              name
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    [:moderator, :admin].each do |role|
+      context "when the current user is a(n) #{role}" do
+        let(:user) { create("confirmed_#{role}".to_sym) }
+
+        it "does not change the number of stores" do
+          expect do
+            api_request(query_string, variables: { store_id: store.id, name: 'Nintendo eShop' }, token: access_token)
+          end.not_to change(Store, :count)
+        end
+
+        it "returns basic data for store after creation" do
+          result = api_request(query_string, variables: { store_id: store.id, name: 'Nintendo eShop' }, token: access_token)
+
+          expect(result.graphql_dig(:update_store, :store)).to eq(
+            {
+              name: 'Nintendo eShop'
+            }
+          )
+
+          expect(store.reload.name).to eq('Nintendo eShop')
+        end
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not update the store" do
+        expect do
+          result = api_request(query_string, variables: { store_id: store.id, name: 'Nintendo eShop' }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to update this store.")
+        end.not_to change(store.reload, :name).from('Origin')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add GraphQL mutations for creating, updating, and deleting series records, store records, and genre records.

Disabled in production until the first-party OAuth applications are added.

Resolves #1965.
Resolves #1966.
Resolves #1969.