### PR TITLE
Add a GraphQL mutation for deleting games.

### DIFF
--- a/app/graphql/mutations/games/delete_game.rb
+++ b/app/graphql/mutations/games/delete_game.rb
@@ -1,0 +1,31 @@
+# typed: true
+class Mutations::Games::DeleteGame < Mutations::BaseMutation
+  description "Delete a game. **Only available to moderators and admins.** **Not available in production for now.**"
+
+  argument :game_id, ID, required: true, description: 'The ID of the game to delete.'
+
+  field :deleted, Boolean, null: true, description: "Whether the game was successfully deleted."
+
+  sig { params(game_id: T.any(String, Integer)).returns(T::Hash[Symbol, T::Boolean]) }
+  def resolve(game_id:)
+    game = Game.find(game_id)
+
+    raise GraphQL::ExecutionError, game.errors.full_messages.join(", ") unless game.destroy
+
+    {
+      deleted: true
+    }
+  end
+
+  # TODO: Put this mutation behind the "first party" OAuth application flag.
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def authorized?(object)
+    # TODO: Remove this line when the first-party OAuth applications are ready.
+    return false if Rails.env.production?
+
+    game = Game.find(object[:game_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this game." unless GamePolicy.new(@context[:current_user], game).destroy?
+
+    return true
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -3,15 +3,19 @@ module Types
   class MutationType < Types::BaseObject
     description "Mutations are GraphQL requests that can be used to create, update, or delete records on vglist."
 
+    # Game mutations
+    field :delete_game, mutation: Mutations::Games::DeleteGame
     field :favorite_game, mutation: Mutations::Games::FavoriteGame
     field :unfavorite_game, mutation: Mutations::Games::UnfavoriteGame
     field :remove_game_cover, mutation: Mutations::Games::RemoveGameCover
 
+    # User mutations
     field :follow_user, mutation: Mutations::Users::FollowUser
     field :unfollow_user, mutation: Mutations::Users::UnfollowUser
     field :ban_user, mutation: Mutations::Users::BanUser
     field :unban_user, mutation: Mutations::Users::UnbanUser
 
+    # GamePurchase mutations
     field :add_game_to_library, mutation: Mutations::GamePurchases::AddGameToLibrary
     field :update_game_in_library, mutation: Mutations::GamePurchases::UpdateGameInLibrary
     field :remove_game_from_library, mutation: Mutations::GamePurchases::RemoveGameFromLibrary
@@ -46,9 +50,10 @@ module Types
     field :update_store, mutation: Mutations::Stores::UpdateStore
     field :delete_store, mutation: Mutations::Stores::DeleteStore
 
+    # Event mutations
     field :delete_event, mutation: Mutations::DeleteEvent
 
-    # Admin
+    # Admin dashboard mutations
     field :add_to_steam_blocklist, mutation: Mutations::Admin::AddToSteamBlocklist
     field :remove_from_steam_blocklist, mutation: Mutations::Admin::RemoveFromSteamBlocklist
     field :add_to_wikidata_blocklist, mutation: Mutations::Admin::AddToWikidataBlocklist

--- a/spec/requests/api/mutations/games/delete_game_spec.rb
+++ b/spec/requests/api/mutations/games/delete_game_spec.rb
@@ -1,0 +1,46 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "DeleteGame Mutation API", type: :request do
+  describe "Mutation deletes an existing game record" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let!(:game) { create(:game) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($gameId: ID!) {
+          deleteGame(gameId: $gameId) {
+            deleted
+          }
+        }
+      GRAPHQL
+    end
+
+    context "when the current user is an admin" do
+      let(:user) { create(:confirmed_admin) }
+
+      it "decreases the number of games" do
+        expect do
+          api_request(query_string, variables: { game_id: game.id }, token: access_token)
+        end.to change(Game, :count).by(-1)
+      end
+
+      it "returns true after deletion" do
+        result = api_request(query_string, variables: { game_id: game.id }, token: access_token)
+
+        expect(result.graphql_dig(:delete_game, :deleted)).to eq(true)
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not change the number of games" do
+        expect do
+          result = api_request(query_string, variables: { game_id: game.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this game.")
+        end.not_to change(Game, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Only available to moderators and admins, not enabled in production for now.

Resolves #1975.