### PR TITLE
Change the GlobalSearchResolver to remove page argument and rely instead on the GraphQL connections logic.

### DIFF
--- a/app/graphql/resolvers/global_search_resolver.rb
+++ b/app/graphql/resolvers/global_search_resolver.rb
@@ -1,7 +1,7 @@
 # typed: strict
 module Resolvers
   class GlobalSearchResolver < Resolvers::BaseResolver
-    type Types::SearchResultUnion.connection_type, null: false
+    type [Types::SearchResultUnion], null: false
 
     description <<~MARKDOWN
       Search for records matching a given string. Returns Companies, Engines,
@@ -9,6 +9,9 @@ module Resolvers
 
       Please always debounce/throttle requests to this endpoint. There's no
       reason to send a request for every letter a user types.
+
+      **This query uses pagination that is different from all other endpoints
+      in the API**, please use the `page` argument instead of a cursor.
     MARKDOWN
 
     argument :query, String, required: true, description: 'The query to search for records with.'
@@ -19,16 +22,19 @@ module Resolvers
     argument :page, Int, required: false, default_value: 1, description: "The page of records to get, this is a gross hack and I'm sorry." do
       validates numericality: { greater_than: 0 }
     end
+    argument :per_page, Int, required: false, default_value: 15, description: "The number of records to return in an individual page. Must be a value between 1 and 30." do
+      validates numericality: { greater_than: 0, less_than_or_equal_to: 30 }
+    end
 
     # Technically this should return `PgSearch::Document::RelationType`, but
     # SorbetRails doesn't seem to know about PgSearch::Document, so no types
     # for it exist.
-    sig { params(query: String, page: Integer, searchable_types: T::Array[String]).returns(T.untyped) }
-    def resolve(query:, page:, searchable_types: %w[Game Series Company Platform Engine Genre User])
+    sig { params(query: String, page: Integer, per_page: Integer, searchable_types: T::Array[String]).returns(T.untyped) }
+    def resolve(query:, page:, per_page:, searchable_types: %w[Game Series Company Platform Engine Genre User])
       PgSearch.multisearch(query)
               .where(searchable_type: searchable_types)
               .page(page)
-              .per(15)
+              .per(per_page)
     end
   end
 end

--- a/spec/requests/api/global_search_spec.rb
+++ b/spec/requests/api/global_search_spec.rb
@@ -18,12 +18,10 @@ RSpec.describe "Global Search API", type: :request do
         query_string = <<-GRAPHQL
           query($query: String!) {
             globalSearch(query: $query) {
-              nodes {
-                ... on GameSearchResult {
-                  id
-                  searchableId
-                  content
-                }
+              ... on GameSearchResult {
+                id
+                searchableId
+                content
               }
             }
           }
@@ -31,9 +29,9 @@ RSpec.describe "Global Search API", type: :request do
 
         result = api_request(query_string, variables: { query: 'Portal' }, token: access_token)
 
-        expect(result.graphql_dig(:global_search, :nodes).length).to eq(10)
-        expect(result.graphql_dig(:global_search, :nodes).pluck(:searchableId)).to eq(games.pluck(:id).map(&:to_s))
-        expect(result.graphql_dig(:global_search, :nodes).pluck(:content)).to eq(Array.new(10) { 'Portal' })
+        expect(result.graphql_dig(:global_search).length).to eq(10)
+        expect(result.graphql_dig(:global_search).pluck(:searchableId)).to eq(games.pluck(:id).map(&:to_s))
+        expect(result.graphql_dig(:global_search).pluck(:content)).to eq(Array.new(10) { 'Portal' })
       end
 
       it "returns cover, release date, and developer" do
@@ -41,14 +39,12 @@ RSpec.describe "Global Search API", type: :request do
         query_string = <<-GRAPHQL
           query($query: String!) {
             globalSearch(query: $query) {
-              nodes {
-                ... on GameSearchResult {
-                  searchableId
-                  content
-                  coverUrl
-                  releaseDate
-                  developerName
-                }
+              ... on GameSearchResult {
+                searchableId
+                content
+                coverUrl
+                releaseDate
+                developerName
               }
             }
           }
@@ -58,7 +54,7 @@ RSpec.describe "Global Search API", type: :request do
 
         cover_variant = game2.sized_cover(:small)
 
-        expect(result.graphql_dig(:global_search, :nodes)).to eq(
+        expect(result.graphql_dig(:global_search)).to eq(
           [
             {
               searchableId: game2.id.to_s,
@@ -79,13 +75,11 @@ RSpec.describe "Global Search API", type: :request do
         query_string = <<-GRAPHQL
           query($query: String!) {
             globalSearch(query: $query) {
-              nodes {
-                ... on UserSearchResult {
-                  searchableId
-                  content
-                  avatarUrl
-                  slug
-                }
+              ... on UserSearchResult {
+                searchableId
+                content
+                avatarUrl
+                slug
               }
             }
           }
@@ -95,7 +89,7 @@ RSpec.describe "Global Search API", type: :request do
 
         avatar_variant = user.sized_avatar(:small)
 
-        expect(result.graphql_dig(:global_search, :nodes)).to eq(
+        expect(result.graphql_dig(:global_search)).to eq(
           [
             {
               searchableId: user.id.to_s,
@@ -121,35 +115,33 @@ RSpec.describe "Global Search API", type: :request do
         query_string = <<-GRAPHQL
           query($query: String!) {
             globalSearch(query: $query) {
-              nodes {
-                ... on GameSearchResult {
-                  searchableId
-                  content
-                }
-                ... on UserSearchResult {
-                  searchableId
-                  content
-                }
-                ... on PlatformSearchResult {
-                  searchableId
-                  content
-                }
-                ... on SeriesSearchResult {
-                  searchableId
-                  content
-                }
-                ... on GenreSearchResult {
-                  searchableId
-                  content
-                }
-                ... on EngineSearchResult {
-                  searchableId
-                  content
-                }
-                ... on CompanySearchResult {
-                  searchableId
-                  content
-                }
+              ... on GameSearchResult {
+                searchableId
+                content
+              }
+              ... on UserSearchResult {
+                searchableId
+                content
+              }
+              ... on PlatformSearchResult {
+                searchableId
+                content
+              }
+              ... on SeriesSearchResult {
+                searchableId
+                content
+              }
+              ... on GenreSearchResult {
+                searchableId
+                content
+              }
+              ... on EngineSearchResult {
+                searchableId
+                content
+              }
+              ... on CompanySearchResult {
+                searchableId
+                content
               }
             }
           }
@@ -157,8 +149,8 @@ RSpec.describe "Global Search API", type: :request do
 
         result = api_request(query_string, variables: { query: 'Foo' }, token: access_token)
 
-        expect(result.graphql_dig(:global_search, :nodes).length).to eq(7)
-        expect(result.graphql_dig(:global_search, :nodes)).to eq(
+        expect(result.graphql_dig(:global_search).length).to eq(7)
+        expect(result.graphql_dig(:global_search)).to eq(
           [
             {
               searchableId: company.id.to_s,

--- a/spec/requests/api/global_search_spec.rb
+++ b/spec/requests/api/global_search_spec.rb
@@ -18,10 +18,12 @@ RSpec.describe "Global Search API", type: :request do
         query_string = <<-GRAPHQL
           query($query: String!) {
             globalSearch(query: $query) {
-              ... on GameSearchResult {
-                id
-                searchableId
-                content
+              nodes {
+                ... on GameSearchResult {
+                  id
+                  searchableId
+                  content
+                }
               }
             }
           }
@@ -29,9 +31,9 @@ RSpec.describe "Global Search API", type: :request do
 
         result = api_request(query_string, variables: { query: 'Portal' }, token: access_token)
 
-        expect(result.graphql_dig(:global_search).length).to eq(10)
-        expect(result.graphql_dig(:global_search).pluck(:searchableId)).to eq(games.pluck(:id).map(&:to_s))
-        expect(result.graphql_dig(:global_search).pluck(:content)).to eq(Array.new(10) { 'Portal' })
+        expect(result.graphql_dig(:global_search, :nodes).length).to eq(10)
+        expect(result.graphql_dig(:global_search, :nodes).pluck(:searchableId)).to eq(games.pluck(:id).map(&:to_s))
+        expect(result.graphql_dig(:global_search, :nodes).pluck(:content)).to eq(Array.new(10) { 'Portal' })
       end
 
       it "returns cover, release date, and developer" do
@@ -39,12 +41,14 @@ RSpec.describe "Global Search API", type: :request do
         query_string = <<-GRAPHQL
           query($query: String!) {
             globalSearch(query: $query) {
-              ... on GameSearchResult {
-                searchableId
-                content
-                coverUrl
-                releaseDate
-                developerName
+              nodes {
+                ... on GameSearchResult {
+                  searchableId
+                  content
+                  coverUrl
+                  releaseDate
+                  developerName
+                }
               }
             }
           }
@@ -54,7 +58,7 @@ RSpec.describe "Global Search API", type: :request do
 
         cover_variant = game2.sized_cover(:small)
 
-        expect(result.graphql_dig(:global_search)).to eq(
+        expect(result.graphql_dig(:global_search, :nodes)).to eq(
           [
             {
               searchableId: game2.id.to_s,
@@ -75,11 +79,13 @@ RSpec.describe "Global Search API", type: :request do
         query_string = <<-GRAPHQL
           query($query: String!) {
             globalSearch(query: $query) {
-              ... on UserSearchResult {
-                searchableId
-                content
-                avatarUrl
-                slug
+              nodes {
+                ... on UserSearchResult {
+                  searchableId
+                  content
+                  avatarUrl
+                  slug
+                }
               }
             }
           }
@@ -89,7 +95,7 @@ RSpec.describe "Global Search API", type: :request do
 
         avatar_variant = user.sized_avatar(:small)
 
-        expect(result.graphql_dig(:global_search)).to eq(
+        expect(result.graphql_dig(:global_search, :nodes)).to eq(
           [
             {
               searchableId: user.id.to_s,
@@ -115,33 +121,35 @@ RSpec.describe "Global Search API", type: :request do
         query_string = <<-GRAPHQL
           query($query: String!) {
             globalSearch(query: $query) {
-              ... on GameSearchResult {
-                searchableId
-                content
-              }
-              ... on UserSearchResult {
-                searchableId
-                content
-              }
-              ... on PlatformSearchResult {
-                searchableId
-                content
-              }
-              ... on SeriesSearchResult {
-                searchableId
-                content
-              }
-              ... on GenreSearchResult {
-                searchableId
-                content
-              }
-              ... on EngineSearchResult {
-                searchableId
-                content
-              }
-              ... on CompanySearchResult {
-                searchableId
-                content
+              nodes {
+                ... on GameSearchResult {
+                  searchableId
+                  content
+                }
+                ... on UserSearchResult {
+                  searchableId
+                  content
+                }
+                ... on PlatformSearchResult {
+                  searchableId
+                  content
+                }
+                ... on SeriesSearchResult {
+                  searchableId
+                  content
+                }
+                ... on GenreSearchResult {
+                  searchableId
+                  content
+                }
+                ... on EngineSearchResult {
+                  searchableId
+                  content
+                }
+                ... on CompanySearchResult {
+                  searchableId
+                  content
+                }
               }
             }
           }
@@ -149,8 +157,8 @@ RSpec.describe "Global Search API", type: :request do
 
         result = api_request(query_string, variables: { query: 'Foo' }, token: access_token)
 
-        expect(result.graphql_dig(:global_search).length).to eq(7)
-        expect(result.graphql_dig(:global_search)).to eq(
+        expect(result.graphql_dig(:global_search, :nodes).length).to eq(7)
+        expect(result.graphql_dig(:global_search, :nodes)).to eq(
           [
             {
               searchableId: company.id.to_s,


### PR DESCRIPTION
This is technically a breaking change, which is fun, but it's incredibly confusing to have two kinds of pagination and I think it's worth removing one.

I initially tried removing the connections logic and relying entirely on the `page` argument (as well as a `perPage` argument), but I decided after thinking on it for a while that that was the wrong choice, and went back to using connections for globalSearch. So now it matches every other query in the API, which is good.