### PR TITLE
Centralize permission checks in mutations

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -101,7 +101,9 @@ class GraphqlController < ApplicationController
 
     # Just block it in production for now to prevent malicious usage of the API,
     # but still allow local development.
-    return !Rails.env.production?
+    return false if Rails.env.production?
+
+    true
   end
 
   sig { returns(T.nilable(User)) }

--- a/app/graphql/mutations/admin/add_to_steam_blocklist.rb
+++ b/app/graphql/mutations/admin/add_to_steam_blocklist.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Admin::AddToSteamBlocklist < Mutations::BaseMutation
-  description "Add game to Steam blocklist. **Only available to admins.**"
+  description "Add game to Steam blocklist. **Only available to admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :name, String, required: true, description: 'The name of the game being added to the blocklist.'
   argument :steam_app_id, Integer, required: true, description: 'ID of the Steam game.'
@@ -18,10 +20,9 @@ class Mutations::Admin::AddToSteamBlocklist < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T.nilable(T::Boolean)) }
   def authorized?(_object)
-    raise GraphQL::ExecutionError, "You aren't allowed to add this game to the Steam Blocklist." unless AdminPolicy.new(@context[:current_user], nil).remove_from_steam_blocklist?
+    raise GraphQL::ExecutionError, "You aren't allowed to add this game to the Steam Blocklist." unless AdminPolicy.new(@context[:current_user], nil).add_to_steam_blocklist?
 
     return true
   end

--- a/app/graphql/mutations/admin/add_to_steam_blocklist.rb
+++ b/app/graphql/mutations/admin/add_to_steam_blocklist.rb
@@ -2,8 +2,6 @@
 class Mutations::Admin::AddToSteamBlocklist < Mutations::BaseMutation
   description "Add game to Steam blocklist. **Only available to admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :name, String, required: true, description: 'The name of the game being added to the blocklist.'
   argument :steam_app_id, Integer, required: true, description: 'ID of the Steam game.'
 
@@ -22,6 +20,8 @@ class Mutations::Admin::AddToSteamBlocklist < Mutations::BaseMutation
 
   sig { params(_object: T.untyped).returns(T.nilable(T::Boolean)) }
   def authorized?(_object)
+    require_permissions!(:first_party)
+
     raise GraphQL::ExecutionError, "You aren't allowed to add this game to the Steam Blocklist." unless AdminPolicy.new(@context[:current_user], nil).add_to_steam_blocklist?
 
     return true

--- a/app/graphql/mutations/admin/add_to_wikidata_blocklist.rb
+++ b/app/graphql/mutations/admin/add_to_wikidata_blocklist.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Admin::AddToWikidataBlocklist < Mutations::BaseMutation
-  description "Add game to Wikidata blocklist. **Only available to admins.**"
+  description "Add game to Wikidata blocklist. **Only available to admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :name, String, required: true, description: 'The name of the game being added to the blocklist.'
   argument :wikidata_id, Integer, required: true, description: 'ID of the Wikidata item.'
@@ -18,7 +20,6 @@ class Mutations::Admin::AddToWikidataBlocklist < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T.nilable(T::Boolean)) }
   def authorized?(_object)
     raise GraphQL::ExecutionError, "You aren't allowed to add this game to the Wikidata Blocklist." unless AdminPolicy.new(@context[:current_user], nil).remove_from_wikidata_blocklist?

--- a/app/graphql/mutations/admin/add_to_wikidata_blocklist.rb
+++ b/app/graphql/mutations/admin/add_to_wikidata_blocklist.rb
@@ -2,8 +2,6 @@
 class Mutations::Admin::AddToWikidataBlocklist < Mutations::BaseMutation
   description "Add game to Wikidata blocklist. **Only available to admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :name, String, required: true, description: 'The name of the game being added to the blocklist.'
   argument :wikidata_id, Integer, required: true, description: 'ID of the Wikidata item.'
 
@@ -22,6 +20,8 @@ class Mutations::Admin::AddToWikidataBlocklist < Mutations::BaseMutation
 
   sig { params(_object: T.untyped).returns(T.nilable(T::Boolean)) }
   def authorized?(_object)
+    require_permissions!(:first_party)
+
     raise GraphQL::ExecutionError, "You aren't allowed to add this game to the Wikidata Blocklist." unless AdminPolicy.new(@context[:current_user], nil).remove_from_wikidata_blocklist?
 
     return true

--- a/app/graphql/mutations/admin/remove_from_steam_blocklist.rb
+++ b/app/graphql/mutations/admin/remove_from_steam_blocklist.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Admin::RemoveFromSteamBlocklist < Mutations::BaseMutation
-  description "Remove game from Steam blocklist. **Only available to admins.**"
+  description "Remove game from Steam blocklist. **Only available to admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :steam_blocklist_entry_id, ID, required: true, description: 'The ID of the blocklist entry.'
 
@@ -17,7 +19,6 @@ class Mutations::Admin::RemoveFromSteamBlocklist < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
     raise GraphQL::ExecutionError, "You aren't allowed to remove a Steam blocklist entry." unless AdminPolicy.new(@context[:current_user], nil).remove_from_steam_blocklist?

--- a/app/graphql/mutations/admin/remove_from_steam_blocklist.rb
+++ b/app/graphql/mutations/admin/remove_from_steam_blocklist.rb
@@ -2,8 +2,6 @@
 class Mutations::Admin::RemoveFromSteamBlocklist < Mutations::BaseMutation
   description "Remove game from Steam blocklist. **Only available to admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :steam_blocklist_entry_id, ID, required: true, description: 'The ID of the blocklist entry.'
 
   field :deleted, Boolean, null: false, description: "Whether the blocklist entry was deleted."
@@ -21,6 +19,8 @@ class Mutations::Admin::RemoveFromSteamBlocklist < Mutations::BaseMutation
 
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
+    require_permissions!(:first_party)
+
     raise GraphQL::ExecutionError, "You aren't allowed to remove a Steam blocklist entry." unless AdminPolicy.new(@context[:current_user], nil).remove_from_steam_blocklist?
 
     return true

--- a/app/graphql/mutations/admin/remove_from_wikidata_blocklist.rb
+++ b/app/graphql/mutations/admin/remove_from_wikidata_blocklist.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Admin::RemoveFromWikidataBlocklist < Mutations::BaseMutation
-  description "Remove game from Wikidata blocklist. **Only available to admins.**"
+  description "Remove game from Wikidata blocklist. **Only available to admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :wikidata_blocklist_entry_id, ID, required: true, description: 'The ID of the blocklist entry.'
 
@@ -17,7 +19,6 @@ class Mutations::Admin::RemoveFromWikidataBlocklist < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
     raise GraphQL::ExecutionError, "You aren't allowed to remove a Wikidata blocklist entry." unless AdminPolicy.new(@context[:current_user], nil).remove_from_wikidata_blocklist?

--- a/app/graphql/mutations/admin/remove_from_wikidata_blocklist.rb
+++ b/app/graphql/mutations/admin/remove_from_wikidata_blocklist.rb
@@ -2,8 +2,6 @@
 class Mutations::Admin::RemoveFromWikidataBlocklist < Mutations::BaseMutation
   description "Remove game from Wikidata blocklist. **Only available to admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :wikidata_blocklist_entry_id, ID, required: true, description: 'The ID of the blocklist entry.'
 
   field :deleted, Boolean, null: false, description: "Whether the blocklist entry was deleted."
@@ -21,6 +19,8 @@ class Mutations::Admin::RemoveFromWikidataBlocklist < Mutations::BaseMutation
 
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
+    require_permissions!(:first_party)
+
     raise GraphQL::ExecutionError, "You aren't allowed to remove a Wikidata blocklist entry." unless AdminPolicy.new(@context[:current_user], nil).remove_from_wikidata_blocklist?
 
     return true

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 class Mutations::BaseMutation < GraphQL::Schema::Mutation
   extend T::Sig
 
@@ -7,13 +7,24 @@ class Mutations::BaseMutation < GraphQL::Schema::Mutation
   # This is used for return fields on the mutation's payload
   field_class Types::BaseField
 
-  # Validate that the user's token has the 'write' scope.
+  # The permissions required to perform this mutation. Currently this method
+  # only accepts `:first_party`, but may accept other permission types in the
+  # future.
+  sig { params(permissions: Symbol).void }
+  def self.required_permissions(*permissions)
+    @require_first_party = T.let(permissions.include?(:first_party), T.nilable(T::Boolean))
+  end
+
+  # Validate that the user's token has the 'write' scope and check for a
+  # first-party token if necessary.
   sig { params(_args: T.untyped).returns(T::Boolean) }
   def ready?(**_args)
     # Make sure the doorkeeper scopes include write.
     # Skip this check if the user is using token authentication.
     raise GraphQL::ExecutionError, "Your token must have the 'write' scope to perform a mutation." if !context[:token_auth] &&
                                                                                                       !context[:doorkeeper_scopes]&.include?('write')
+
+    raise GraphQL::ExecutionError, "Your token must be from a first-party OAuth application to perform this mutation." if !context[:first_party] && @require_first_party
 
     return true
   end

--- a/app/graphql/mutations/companies/create_company.rb
+++ b/app/graphql/mutations/companies/create_company.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Companies::CreateCompany < Mutations::BaseMutation
-  description "Create a new game company. **Not available in production for now.**"
+  description "Create a new game company. **Only available when using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :name, String, required: true, description: 'The name of the company.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the company item in Wikidata.'
@@ -18,12 +20,8 @@ class Mutations::Companies::CreateCompany < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     raise GraphQL::ExecutionError, "You aren't allowed to create a company." unless CompanyPolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/companies/create_company.rb
+++ b/app/graphql/mutations/companies/create_company.rb
@@ -2,8 +2,6 @@
 class Mutations::Companies::CreateCompany < Mutations::BaseMutation
   description "Create a new game company. **Only available when using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :name, String, required: true, description: 'The name of the company.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the company item in Wikidata.'
 
@@ -22,6 +20,8 @@ class Mutations::Companies::CreateCompany < Mutations::BaseMutation
 
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
+    require_permissions!(:first_party)
+
     raise GraphQL::ExecutionError, "You aren't allowed to create a company." unless CompanyPolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/companies/delete_company.rb
+++ b/app/graphql/mutations/companies/delete_company.rb
@@ -2,8 +2,6 @@
 class Mutations::Companies::DeleteCompany < Mutations::BaseMutation
   description "Delete a game company. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :company_id, ID, required: true, description: 'The ID of the company to delete.'
 
   field :deleted, Boolean, null: true, description: "Whether the company was successfully deleted."
@@ -21,6 +19,8 @@ class Mutations::Companies::DeleteCompany < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     company = Company.find(object[:company_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this company." unless CompanyPolicy.new(@context[:current_user], company).destroy?
 

--- a/app/graphql/mutations/companies/delete_company.rb
+++ b/app/graphql/mutations/companies/delete_company.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Companies::DeleteCompany < Mutations::BaseMutation
-  description "Delete a game company. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Delete a game company. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :company_id, ID, required: true, description: 'The ID of the company to delete.'
 
@@ -17,12 +19,8 @@ class Mutations::Companies::DeleteCompany < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     company = Company.find(object[:company_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this company." unless CompanyPolicy.new(@context[:current_user], company).destroy?
 

--- a/app/graphql/mutations/companies/update_company.rb
+++ b/app/graphql/mutations/companies/update_company.rb
@@ -2,8 +2,6 @@
 class Mutations::Companies::UpdateCompany < Mutations::BaseMutation
   description "Update an existing game company. **Only available when using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :company_id, ID, required: true, description: 'The ID of the company record.'
   argument :name, String, required: false, description: 'The name of the company.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the company item in Wikidata.'
@@ -24,6 +22,8 @@ class Mutations::Companies::UpdateCompany < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     company = Company.find(object[:company_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this company." unless CompanyPolicy.new(@context[:current_user], company).update?
 

--- a/app/graphql/mutations/companies/update_company.rb
+++ b/app/graphql/mutations/companies/update_company.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Companies::UpdateCompany < Mutations::BaseMutation
-  description "Update an existing game company. **Not available in production for now.**"
+  description "Update an existing game company. **Only available when using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :company_id, ID, required: true, description: 'The ID of the company record.'
   argument :name, String, required: false, description: 'The name of the company.'
@@ -20,12 +22,8 @@ class Mutations::Companies::UpdateCompany < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     company = Company.find(object[:company_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this company." unless CompanyPolicy.new(@context[:current_user], company).update?
 

--- a/app/graphql/mutations/engines/create_engine.rb
+++ b/app/graphql/mutations/engines/create_engine.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Engines::CreateEngine < Mutations::BaseMutation
-  description "Create a new game engine. **Not available in production for now.**"
+  description "Create a new game engine. **Only available when using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :name, String, required: true, description: 'The name of the engine.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the engine item in Wikidata.'
@@ -18,12 +20,8 @@ class Mutations::Engines::CreateEngine < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     raise GraphQL::ExecutionError, "You aren't allowed to create an engine." unless EnginePolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/engines/create_engine.rb
+++ b/app/graphql/mutations/engines/create_engine.rb
@@ -2,8 +2,6 @@
 class Mutations::Engines::CreateEngine < Mutations::BaseMutation
   description "Create a new game engine. **Only available when using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :name, String, required: true, description: 'The name of the engine.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the engine item in Wikidata.'
 
@@ -22,6 +20,8 @@ class Mutations::Engines::CreateEngine < Mutations::BaseMutation
 
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
+    require_permissions!(:first_party)
+
     raise GraphQL::ExecutionError, "You aren't allowed to create an engine." unless EnginePolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/engines/delete_engine.rb
+++ b/app/graphql/mutations/engines/delete_engine.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Engines::DeleteEngine < Mutations::BaseMutation
-  description "Delete a game engine. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Delete a game engine. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :engine_id, ID, required: true, description: 'The ID of the engine to delete.'
 
@@ -17,12 +19,8 @@ class Mutations::Engines::DeleteEngine < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     engine = Engine.find(object[:engine_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this engine." unless EnginePolicy.new(@context[:current_user], engine).destroy?
 

--- a/app/graphql/mutations/engines/delete_engine.rb
+++ b/app/graphql/mutations/engines/delete_engine.rb
@@ -2,8 +2,6 @@
 class Mutations::Engines::DeleteEngine < Mutations::BaseMutation
   description "Delete a game engine. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :engine_id, ID, required: true, description: 'The ID of the engine to delete.'
 
   field :deleted, Boolean, null: true, description: "Whether the engine was successfully deleted."
@@ -21,6 +19,8 @@ class Mutations::Engines::DeleteEngine < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     engine = Engine.find(object[:engine_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this engine." unless EnginePolicy.new(@context[:current_user], engine).destroy?
 

--- a/app/graphql/mutations/engines/update_engine.rb
+++ b/app/graphql/mutations/engines/update_engine.rb
@@ -2,8 +2,6 @@
 class Mutations::Engines::UpdateEngine < Mutations::BaseMutation
   description "Update an existing game engine. **Only available when using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :engine_id, ID, required: true, description: 'The ID of the engine record.'
   argument :name, String, required: false, description: 'The name of the engine.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the engine item in Wikidata.'
@@ -24,6 +22,8 @@ class Mutations::Engines::UpdateEngine < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     engine = Engine.find(object[:engine_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this engine." unless EnginePolicy.new(@context[:current_user], engine).update?
 

--- a/app/graphql/mutations/engines/update_engine.rb
+++ b/app/graphql/mutations/engines/update_engine.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Engines::UpdateEngine < Mutations::BaseMutation
-  description "Update an existing game engine. **Not available in production for now.**"
+  description "Update an existing game engine. **Only available when using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :engine_id, ID, required: true, description: 'The ID of the engine record.'
   argument :name, String, required: false, description: 'The name of the engine.'
@@ -20,12 +22,8 @@ class Mutations::Engines::UpdateEngine < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     engine = Engine.find(object[:engine_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this engine." unless EnginePolicy.new(@context[:current_user], engine).update?
 

--- a/app/graphql/mutations/games/delete_game.rb
+++ b/app/graphql/mutations/games/delete_game.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Games::DeleteGame < Mutations::BaseMutation
-  description "Delete a game. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Delete a game. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :game_id, ID, required: true, description: 'The ID of the game to delete.'
 
@@ -17,12 +19,8 @@ class Mutations::Games::DeleteGame < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     game = Game.find(object[:game_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this game." unless GamePolicy.new(@context[:current_user], game).destroy?
 

--- a/app/graphql/mutations/games/delete_game.rb
+++ b/app/graphql/mutations/games/delete_game.rb
@@ -2,8 +2,6 @@
 class Mutations::Games::DeleteGame < Mutations::BaseMutation
   description "Delete a game. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :game_id, ID, required: true, description: 'The ID of the game to delete.'
 
   field :deleted, Boolean, null: true, description: "Whether the game was successfully deleted."
@@ -21,6 +19,8 @@ class Mutations::Games::DeleteGame < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     game = Game.find(object[:game_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this game." unless GamePolicy.new(@context[:current_user], game).destroy?
 

--- a/app/graphql/mutations/genres/create_genre.rb
+++ b/app/graphql/mutations/genres/create_genre.rb
@@ -2,8 +2,6 @@
 class Mutations::Genres::CreateGenre < Mutations::BaseMutation
   description "Create a new game genre. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :name, String, required: true, description: 'The name of the genre.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the genre item in Wikidata.'
 
@@ -22,6 +20,8 @@ class Mutations::Genres::CreateGenre < Mutations::BaseMutation
 
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
+    require_permissions!(:first_party)
+
     raise GraphQL::ExecutionError, "You aren't allowed to create a genre." unless GenrePolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/genres/create_genre.rb
+++ b/app/graphql/mutations/genres/create_genre.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Genres::CreateGenre < Mutations::BaseMutation
-  description "Create a new game genre. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Create a new game genre. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :name, String, required: true, description: 'The name of the genre.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the genre item in Wikidata.'
@@ -18,12 +20,8 @@ class Mutations::Genres::CreateGenre < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     raise GraphQL::ExecutionError, "You aren't allowed to create a genre." unless GenrePolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/genres/delete_genre.rb
+++ b/app/graphql/mutations/genres/delete_genre.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Genres::DeleteGenre < Mutations::BaseMutation
-  description "Delete a game genre. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Delete a game genre. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :genre_id, ID, required: true, description: 'The ID of the genre to delete.'
 
@@ -17,12 +19,8 @@ class Mutations::Genres::DeleteGenre < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     genre = Genre.find(object[:genre_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this genre." unless GenrePolicy.new(@context[:current_user], genre).destroy?
 

--- a/app/graphql/mutations/genres/delete_genre.rb
+++ b/app/graphql/mutations/genres/delete_genre.rb
@@ -2,8 +2,6 @@
 class Mutations::Genres::DeleteGenre < Mutations::BaseMutation
   description "Delete a game genre. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :genre_id, ID, required: true, description: 'The ID of the genre to delete.'
 
   field :deleted, Boolean, null: true, description: "Whether the genre was successfully deleted."
@@ -21,6 +19,8 @@ class Mutations::Genres::DeleteGenre < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     genre = Genre.find(object[:genre_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this genre." unless GenrePolicy.new(@context[:current_user], genre).destroy?
 

--- a/app/graphql/mutations/genres/update_genre.rb
+++ b/app/graphql/mutations/genres/update_genre.rb
@@ -2,8 +2,6 @@
 class Mutations::Genres::UpdateGenre < Mutations::BaseMutation
   description "Update an existing game genre. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :genre_id, ID, required: true, description: 'The ID of the genre record.'
   argument :name, String, required: false, description: 'The name of the genre.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the genre item in Wikidata.'
@@ -24,6 +22,8 @@ class Mutations::Genres::UpdateGenre < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     genre = Genre.find(object[:genre_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this genre." unless GenrePolicy.new(@context[:current_user], genre).update?
 

--- a/app/graphql/mutations/genres/update_genre.rb
+++ b/app/graphql/mutations/genres/update_genre.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Genres::UpdateGenre < Mutations::BaseMutation
-  description "Update an existing game genre. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Update an existing game genre. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :genre_id, ID, required: true, description: 'The ID of the genre record.'
   argument :name, String, required: false, description: 'The name of the genre.'
@@ -20,12 +22,8 @@ class Mutations::Genres::UpdateGenre < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     genre = Genre.find(object[:genre_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this genre." unless GenrePolicy.new(@context[:current_user], genre).update?
 

--- a/app/graphql/mutations/platforms/create_platform.rb
+++ b/app/graphql/mutations/platforms/create_platform.rb
@@ -2,8 +2,6 @@
 class Mutations::Platforms::CreatePlatform < Mutations::BaseMutation
   description "Create a new game platform. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :name, String, required: true, description: 'The name of the platform.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the platform item in Wikidata.'
 
@@ -22,6 +20,8 @@ class Mutations::Platforms::CreatePlatform < Mutations::BaseMutation
 
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
+    require_permissions!(:first_party)
+
     raise GraphQL::ExecutionError, "You aren't allowed to create a platform." unless PlatformPolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/platforms/create_platform.rb
+++ b/app/graphql/mutations/platforms/create_platform.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Platforms::CreatePlatform < Mutations::BaseMutation
-  description "Create a new game platform. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Create a new game platform. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :name, String, required: true, description: 'The name of the platform.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the platform item in Wikidata.'
@@ -18,12 +20,8 @@ class Mutations::Platforms::CreatePlatform < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     raise GraphQL::ExecutionError, "You aren't allowed to create a platform." unless PlatformPolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/platforms/delete_platform.rb
+++ b/app/graphql/mutations/platforms/delete_platform.rb
@@ -2,8 +2,6 @@
 class Mutations::Platforms::DeletePlatform < Mutations::BaseMutation
   description "Delete a game platform. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :platform_id, ID, required: true, description: 'The ID of the platform to delete.'
 
   field :deleted, Boolean, null: true, description: "Whether the platform was successfully deleted."
@@ -21,6 +19,8 @@ class Mutations::Platforms::DeletePlatform < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     platform = Platform.find(object[:platform_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this platform." unless PlatformPolicy.new(@context[:current_user], platform).destroy?
 

--- a/app/graphql/mutations/platforms/delete_platform.rb
+++ b/app/graphql/mutations/platforms/delete_platform.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Platforms::DeletePlatform < Mutations::BaseMutation
-  description "Delete a game platform. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Delete a game platform. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :platform_id, ID, required: true, description: 'The ID of the platform to delete.'
 
@@ -17,12 +19,8 @@ class Mutations::Platforms::DeletePlatform < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     platform = Platform.find(object[:platform_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this platform." unless PlatformPolicy.new(@context[:current_user], platform).destroy?
 

--- a/app/graphql/mutations/platforms/update_platform.rb
+++ b/app/graphql/mutations/platforms/update_platform.rb
@@ -2,8 +2,6 @@
 class Mutations::Platforms::UpdatePlatform < Mutations::BaseMutation
   description "Update an existing game platform. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :platform_id, ID, required: true, description: 'The ID of the platform record.'
   argument :name, String, required: false, description: 'The name of the platform.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the platform item in Wikidata.'
@@ -24,6 +22,8 @@ class Mutations::Platforms::UpdatePlatform < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     platform = Platform.find(object[:platform_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this platform." unless PlatformPolicy.new(@context[:current_user], platform).update?
 

--- a/app/graphql/mutations/platforms/update_platform.rb
+++ b/app/graphql/mutations/platforms/update_platform.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Platforms::UpdatePlatform < Mutations::BaseMutation
-  description "Update an existing game platform. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Update an existing game platform. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :platform_id, ID, required: true, description: 'The ID of the platform record.'
   argument :name, String, required: false, description: 'The name of the platform.'
@@ -20,12 +22,8 @@ class Mutations::Platforms::UpdatePlatform < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     platform = Platform.find(object[:platform_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this platform." unless PlatformPolicy.new(@context[:current_user], platform).update?
 

--- a/app/graphql/mutations/series/create_series.rb
+++ b/app/graphql/mutations/series/create_series.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Series::CreateSeries < Mutations::BaseMutation
-  description "Create a new game series. **Not available in production for now.**"
+  description "Create a new game series. **Only available when using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :name, String, required: true, description: 'The name of the series.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the series item in Wikidata.'
@@ -18,12 +20,8 @@ class Mutations::Series::CreateSeries < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     raise GraphQL::ExecutionError, "You aren't allowed to create a series." unless SeriesPolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/series/create_series.rb
+++ b/app/graphql/mutations/series/create_series.rb
@@ -2,8 +2,6 @@
 class Mutations::Series::CreateSeries < Mutations::BaseMutation
   description "Create a new game series. **Only available when using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :name, String, required: true, description: 'The name of the series.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the series item in Wikidata.'
 
@@ -22,6 +20,8 @@ class Mutations::Series::CreateSeries < Mutations::BaseMutation
 
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
+    require_permissions!(:first_party)
+
     raise GraphQL::ExecutionError, "You aren't allowed to create a series." unless SeriesPolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/series/delete_series.rb
+++ b/app/graphql/mutations/series/delete_series.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Series::DeleteSeries < Mutations::BaseMutation
-  description "Delete a game series. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Delete a game series. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :series_id, ID, required: true, description: 'The ID of the series to delete.'
 
@@ -17,12 +19,8 @@ class Mutations::Series::DeleteSeries < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     series = Series.find(object[:series_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this series." unless SeriesPolicy.new(@context[:current_user], series).destroy?
 

--- a/app/graphql/mutations/series/delete_series.rb
+++ b/app/graphql/mutations/series/delete_series.rb
@@ -2,8 +2,6 @@
 class Mutations::Series::DeleteSeries < Mutations::BaseMutation
   description "Delete a game series. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :series_id, ID, required: true, description: 'The ID of the series to delete.'
 
   field :deleted, Boolean, null: true, description: "Whether the series was successfully deleted."
@@ -21,6 +19,8 @@ class Mutations::Series::DeleteSeries < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     series = Series.find(object[:series_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this series." unless SeriesPolicy.new(@context[:current_user], series).destroy?
 

--- a/app/graphql/mutations/series/update_series.rb
+++ b/app/graphql/mutations/series/update_series.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Series::UpdateSeries < Mutations::BaseMutation
-  description "Update an existing game series. **Not available in production for now.**"
+  description "Update an existing game series. **Only available when using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :series_id, ID, required: true, description: 'The ID of the series record.'
   argument :name, String, required: false, description: 'The name of the series.'
@@ -20,12 +22,8 @@ class Mutations::Series::UpdateSeries < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     series = Series.find(object[:series_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this series." unless SeriesPolicy.new(@context[:current_user], series).update?
 

--- a/app/graphql/mutations/series/update_series.rb
+++ b/app/graphql/mutations/series/update_series.rb
@@ -2,8 +2,6 @@
 class Mutations::Series::UpdateSeries < Mutations::BaseMutation
   description "Update an existing game series. **Only available when using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :series_id, ID, required: true, description: 'The ID of the series record.'
   argument :name, String, required: false, description: 'The name of the series.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the series item in Wikidata.'
@@ -24,6 +22,8 @@ class Mutations::Series::UpdateSeries < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     series = Series.find(object[:series_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this series." unless SeriesPolicy.new(@context[:current_user], series).update?
 

--- a/app/graphql/mutations/stores/create_store.rb
+++ b/app/graphql/mutations/stores/create_store.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Stores::CreateStore < Mutations::BaseMutation
-  description "Create a new game store. **Not available in production for now.**"
+  description "Create a new game store. **Only available when using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :name, String, required: true, description: 'The name of the store.'
 
@@ -17,12 +19,8 @@ class Mutations::Stores::CreateStore < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     raise GraphQL::ExecutionError, "You aren't allowed to create a store." unless StorePolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/stores/create_store.rb
+++ b/app/graphql/mutations/stores/create_store.rb
@@ -2,8 +2,6 @@
 class Mutations::Stores::CreateStore < Mutations::BaseMutation
   description "Create a new game store. **Only available when using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :name, String, required: true, description: 'The name of the store.'
 
   field :store, Types::StoreType, null: true, description: "The store that was created."
@@ -21,6 +19,8 @@ class Mutations::Stores::CreateStore < Mutations::BaseMutation
 
   sig { params(_object: T.untyped).returns(T::Boolean) }
   def authorized?(_object)
+    require_permissions!(:first_party)
+
     raise GraphQL::ExecutionError, "You aren't allowed to create a store." unless StorePolicy.new(@context[:current_user], nil).create?
 
     return true

--- a/app/graphql/mutations/stores/delete_store.rb
+++ b/app/graphql/mutations/stores/delete_store.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Stores::DeleteStore < Mutations::BaseMutation
-  description "Delete a game store. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Delete a game store. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :store_id, ID, required: true, description: 'The ID of the store to delete.'
 
@@ -17,12 +19,8 @@ class Mutations::Stores::DeleteStore < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     store = Store.find(object[:store_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this store." unless StorePolicy.new(@context[:current_user], store).destroy?
 

--- a/app/graphql/mutations/stores/delete_store.rb
+++ b/app/graphql/mutations/stores/delete_store.rb
@@ -2,8 +2,6 @@
 class Mutations::Stores::DeleteStore < Mutations::BaseMutation
   description "Delete a game store. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :store_id, ID, required: true, description: 'The ID of the store to delete.'
 
   field :deleted, Boolean, null: true, description: "Whether the store was successfully deleted."
@@ -21,6 +19,8 @@ class Mutations::Stores::DeleteStore < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     store = Store.find(object[:store_id])
     raise GraphQL::ExecutionError, "You aren't allowed to delete this store." unless StorePolicy.new(@context[:current_user], store).destroy?
 

--- a/app/graphql/mutations/stores/update_store.rb
+++ b/app/graphql/mutations/stores/update_store.rb
@@ -2,8 +2,6 @@
 class Mutations::Stores::UpdateStore < Mutations::BaseMutation
   description "Update an existing game store. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :store_id, ID, required: true, description: 'The ID of the store record.'
   argument :name, String, required: false, description: 'The name of the store.'
 
@@ -23,6 +21,8 @@ class Mutations::Stores::UpdateStore < Mutations::BaseMutation
 
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     store = Store.find(object[:store_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this store." unless StorePolicy.new(@context[:current_user], store).update?
 

--- a/app/graphql/mutations/stores/update_store.rb
+++ b/app/graphql/mutations/stores/update_store.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Stores::UpdateStore < Mutations::BaseMutation
-  description "Update an existing game store. **Only available to moderators and admins.** **Not available in production for now.**"
+  description "Update an existing game store. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :store_id, ID, required: true, description: 'The ID of the store record.'
   argument :name, String, required: false, description: 'The name of the store.'
@@ -19,12 +21,8 @@ class Mutations::Stores::UpdateStore < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T.untyped).returns(T::Boolean) }
   def authorized?(object)
-    # TODO: Remove this line when the first-party OAuth applications are ready.
-    return false if Rails.env.production?
-
     store = Store.find(object[:store_id])
     raise GraphQL::ExecutionError, "You aren't allowed to update this store." unless StorePolicy.new(@context[:current_user], store).update?
 

--- a/app/graphql/mutations/users/ban_user.rb
+++ b/app/graphql/mutations/users/ban_user.rb
@@ -2,8 +2,6 @@
 class Mutations::Users::BanUser < Mutations::BaseMutation
   description "Ban a user. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :user_id, ID, required: true, description: "ID of user to ban."
 
   field :user, Types::UserType, null: true, description: "The user that has been banned."
@@ -27,6 +25,8 @@ class Mutations::Users::BanUser < Mutations::BaseMutation
 
   sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     user = User.find_by(id: object[:user_id])
 
     return false if user.nil?

--- a/app/graphql/mutations/users/ban_user.rb
+++ b/app/graphql/mutations/users/ban_user.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Users::BanUser < Mutations::BaseMutation
-  description "Ban a user. **Only available to moderators and admins.**"
+  description "Ban a user. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :user_id, ID, required: true, description: "ID of user to ban."
 
@@ -23,7 +25,6 @@ class Mutations::Users::BanUser < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
   def authorized?(object)
     user = User.find_by(id: object[:user_id])

--- a/app/graphql/mutations/users/unban_user.rb
+++ b/app/graphql/mutations/users/unban_user.rb
@@ -2,8 +2,6 @@
 class Mutations::Users::UnbanUser < Mutations::BaseMutation
   description "Unban a user. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  required_permissions :first_party
-
   argument :user_id, ID, required: true, description: "ID of user to unban."
 
   field :user, Types::UserType, null: true, description: "The user that has been unbanned."
@@ -25,6 +23,8 @@ class Mutations::Users::UnbanUser < Mutations::BaseMutation
 
   sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     user = User.find_by(id: object[:user_id])
 
     return false if user.nil?

--- a/app/graphql/mutations/users/unban_user.rb
+++ b/app/graphql/mutations/users/unban_user.rb
@@ -1,6 +1,8 @@
 # typed: true
 class Mutations::Users::UnbanUser < Mutations::BaseMutation
-  description "Unban a user. **Only available to moderators and admins.**"
+  description "Unban a user. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  required_permissions :first_party
 
   argument :user_id, ID, required: true, description: "ID of user to unban."
 
@@ -21,7 +23,6 @@ class Mutations::Users::UnbanUser < Mutations::BaseMutation
     }
   end
 
-  # TODO: Put this mutation behind the "first party" OAuth application flag.
   sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
   def authorized?(object)
     user = User.find_by(id: object[:user_id])


### PR DESCRIPTION
Rather than the implementation I had before, which just checked for production directly in _every_ mutation, this PR extracts the logic out into its own method so when first party OAuth Applications are actually implemented we can just change it in one central place. It also removes a lot of noisy TODOs.

I tried to do this in a cooler way (first commit) but couldn't figure out how to get it to work, and so I fell back on a simpler implementation that just calls a method inside `authorized?`.