### PR TITLE
Add removeUserAvatar mutation to GraphQL API.

### DIFF
--- a/app/graphql/mutations/games/remove_game_cover.rb
+++ b/app/graphql/mutations/games/remove_game_cover.rb
@@ -1,12 +1,12 @@
 # typed: true
 class Mutations::Games::RemoveGameCover < Mutations::BaseMutation
-  description "Remove the cover from a game. **Only available to moderators and admins.**"
+  description "Remove the cover from a game. **Only available to moderators and admins using a first-party OAuth Application.**"
 
-  argument :game_id, ID, required: true, description: "ID of game to remove a cover from."
+  argument :game_id, ID, required: true, description: "ID of game to remove cover from."
 
   field :game, Types::GameType, null: false, description: "The game thats cover was removed."
 
-  sig { params(game_id: String).returns(T::Hash[Symbol, T::Boolean]) }
+  sig { params(game_id: String).returns(T::Hash[Symbol, Game]) }
   def resolve(game_id:)
     game = Game.find_by(id: game_id)
 
@@ -21,6 +21,8 @@ class Mutations::Games::RemoveGameCover < Mutations::BaseMutation
 
   sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
   def authorized?(object)
+    require_permissions!(:first_party)
+
     game = Game.find_by(id: object[:game_id])
 
     return false if game.nil?

--- a/app/graphql/mutations/users/remove_user_avatar.rb
+++ b/app/graphql/mutations/users/remove_user_avatar.rb
@@ -1,0 +1,34 @@
+# typed: true
+class Mutations::Users::RemoveUserAvatar < Mutations::BaseMutation
+  description "Remove the avatar from a user. **Only available when using a first-party OAuth application.**"
+
+  argument :user_id, ID, required: true, description: "ID of user to remove avatar from."
+
+  field :user, Types::UserType, null: false, description: "The user thats avatar was removed."
+
+  sig { params(user_id: String).returns(T::Hash[Symbol, User]) }
+  def resolve(user_id:)
+    user = User.find_by(id: user_id)
+
+    raise GraphQL::ExecutionError, "User has no avatar attached." unless user&.avatar&.attached?
+
+    user&.avatar&.purge
+
+    {
+      user: user
+    }
+  end
+
+  sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
+  def authorized?(object)
+    require_permissions!(:first_party)
+
+    user = User.find_by(id: object[:user_id])
+
+    return false if user.nil?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to remove this user's avatar." unless UserPolicy.new(@context[:current_user], user).remove_avatar?
+
+    return true
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -15,6 +15,7 @@ module Types
     field :ban_user, mutation: Mutations::Users::BanUser
     field :unban_user, mutation: Mutations::Users::UnbanUser
     field :update_user_role, mutation: Mutations::Users::UpdateUserRole
+    field :remove_user_avatar, mutation: Mutations::Users::RemoveUserAvatar
 
     # GamePurchase mutations
     field :add_game_to_library, mutation: Mutations::GamePurchases::AddGameToLibrary

--- a/spec/requests/api/mutations/users/remove_user_avatar_spec.rb
+++ b/spec/requests/api/mutations/users/remove_user_avatar_spec.rb
@@ -1,0 +1,75 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "RemoveUserAvatar Mutation API", type: :request do
+  describe "Mutation removes the user's avatar" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          removeUserAvatar(userId: $id) {
+            user {
+              id
+              username
+              avatarUrl(size: SMALL)
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'when the current user is an admin' do
+      let!(:user) { create(:confirmed_admin) } # rubocop:disable RSpec/LetSetup
+      let(:user2) { create(:user_with_avatar) }
+
+      it "increases the number of users without avatars" do
+        user2
+
+        expect do
+          api_request(query_string, variables: { id: user2.id }, token: access_token)
+        end.to change(User.where.missing(:avatar_attachment), :count).by(1)
+      end
+
+      it "returns basic data for user after removing avatar" do
+        user2
+
+        result = api_request(query_string, variables: { id: user2.id }, token: access_token)
+
+        expect(result.graphql_dig(:remove_user_avatar, :user)).to eq(
+          {
+            id: user2.id.to_s,
+            username: user2.username,
+            avatarUrl: nil
+          }
+        )
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let!(:user) { create(:confirmed_user) } # rubocop:disable RSpec/LetSetup
+      let(:user2) { create(:user_with_avatar) }
+
+      it "does not change the number of users with avatars" do
+        user2
+
+        expect do
+          result = api_request(query_string, variables: { id: user2.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to remove this user's avatar.")
+        end.not_to change(User.where.missing(:avatar_attachment), :count)
+      end
+    end
+
+    context 'when the current user is a normal member removing their own avatar' do
+      let(:user) { create(:user_with_avatar) }
+
+      it "increases the number of users without avatars" do
+        user
+
+        expect do
+          api_request(query_string, variables: { id: user.id }, token: access_token)
+        end.to change(User.where.missing(:avatar_attachment), :count).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows users to remove their own avatar image, otherwise only moderators/admins can.

Resolves #1905.