### PR TITLE
Add liveStatistics GraphQL Query

### DIFF
--- a/app/graphql/resolvers/site_statistic_resolvers/live_resolver.rb
+++ b/app/graphql/resolvers/site_statistic_resolvers/live_resolver.rb
@@ -1,0 +1,56 @@
+# typed: true
+module Resolvers
+  module SiteStatisticResolvers
+    class LiveResolver < Resolvers::BaseResolver
+      type Types::SiteStatisticType, null: false
+
+      description "Current statistics for all records on the site, for use on the admin dashboard. **Only available to admins.**"
+
+      sig { returns(T::Hash[Symbol, Integer]) }
+      def resolve
+        {
+          id: nil,
+          timestamp: nil,
+
+          users: User.count,
+          games: Game.count,
+          platforms: Platform.count,
+          series: Series.count,
+          engines: Engine.count,
+          companies: Company.count,
+          genres: Genre.count,
+          stores: Store.count,
+          events: Event.count,
+          game_purchases: GamePurchase.count,
+          relationships: Relationship.count,
+          games_with_covers: Game.joins(:cover_attachment).count,
+          games_with_release_dates: Game.where.not(release_date: nil).count,
+          banned_users: User.where(banned: true).count,
+
+          mobygames_ids: Game.where.not(mobygames_id: nil).count,
+          pcgamingwiki_ids: Game.where.not(pcgamingwiki_id: nil).count,
+          wikidata_ids: Game.where.not(wikidata_id: nil).count,
+          giantbomb_ids: Game.where.not(giantbomb_id: nil).count,
+          steam_app_ids: Game.joins(:steam_app_ids).count,
+          epic_games_store_ids: Game.where.not(epic_games_store_id: nil).count,
+          gog_ids: Game.where.not(gog_id: nil).count,
+          igdb_ids: Game.where.not(igdb_id: nil).count,
+
+          company_versions: Versions::CompanyVersion.count,
+          game_versions: Versions::GameVersion.count,
+          genre_versions: Versions::GenreVersion.count,
+          engine_versions: Versions::EngineVersion.count,
+          platform_versions: Versions::PlatformVersion.count,
+          series_versions: Versions::SeriesVersion.count
+        }
+      end
+
+      sig { returns(T::Boolean) }
+      def authorized?
+        raise GraphQL::ExecutionError, "Viewing site statistics is only available to admins." unless AdminPolicy.new(@context[:current_user], nil).statistics?
+
+        true
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -50,6 +50,7 @@ module Types
 
     # Admin stuff
     field :site_statistics, resolver: Resolvers::SiteStatisticResolvers::ListResolver
+    field :live_statistics, resolver: Resolvers::SiteStatisticResolvers::LiveResolver
     field :steam_blocklist, resolver: Resolvers::SteamBlocklistResolver
     field :wikidata_blocklist, resolver: Resolvers::WikidataBlocklistResolver
   end

--- a/app/graphql/types/site_statistic_type.rb
+++ b/app/graphql/types/site_statistic_type.rb
@@ -7,13 +7,13 @@ module Types
       `null` where necessary.
     MARKDOWN
 
-    field :id, ID, null: false, description: "ID of the statistic record."
+    field :id, ID, null: true, description: "ID of the statistic record. Shouldn't ever be `null` except in the LiveStatistics query."
 
     # Actually #created_at, but timestamp works better.
     field :timestamp, GraphQL::Types::ISO8601DateTime,
-      null: false,
+      null: true,
       method: :created_at,
-      description: "The point in time at which these statistics were logged, always UTC."
+      description: "The point in time at which these statistics were logged, always UTC. Shouldn't ever be `null` except in the LiveStatistics query."
 
     field :users, Integer, null: false, description: "The number of Users at this point in time."
     field :games, Integer, null: false, description: "The number of Games at this point in time."

--- a/spec/requests/api/live_statistics_spec.rb
+++ b/spec/requests/api/live_statistics_spec.rb
@@ -1,0 +1,139 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "Live Statistics API", type: :request do
+  describe "Query for data on current live statistics" do
+    context 'when signed in as an admin' do
+      let(:user) { create(:confirmed_admin) }
+      let(:application) { build(:application, owner: user) }
+      let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+      let(:game) { create(:game_with_everything) }
+
+      it "returns basic data for live statistics" do
+        query_string = <<-GRAPHQL
+          query {
+            liveStatistics {
+              id
+              timestamp
+              users
+              games
+              platforms
+            }
+          }
+        GRAPHQL
+
+        result = api_request(query_string, token: access_token)
+
+        expect(result.graphql_dig(:live_statistics)).to eq(
+          {
+            id: nil,
+            timestamp: nil,
+            users: 1,
+            games: 0,
+            platforms: 0
+          }
+        )
+      end
+
+      it "returns all data for live statistics" do
+        game
+        query_string = <<-GRAPHQL
+          query {
+            liveStatistics {
+              id
+              timestamp
+              users
+              games
+              platforms
+              series
+              engines
+              companies
+              genres
+              stores
+              events
+              gamePurchases
+              relationships
+              gamesWithCovers
+              gamesWithReleaseDates
+              bannedUsers
+              mobygamesIds
+              pcgamingwikiIds
+              wikidataIds
+              giantbombIds
+              steamAppIds
+              epicGamesStoreIds
+              gogIds
+              igdbIds
+              companyVersions
+              gameVersions
+              genreVersions
+              engineVersions
+              platformVersions
+              seriesVersions
+            }
+          }
+        GRAPHQL
+
+        result = api_request(query_string, token: access_token)
+
+        expect(result.graphql_dig(:live_statistics)).to eq(
+          {
+            id: nil,
+            timestamp: nil,
+            users: 1,
+            games: 1,
+            platforms: 1,
+            series: 1,
+            engines: 1,
+            companies: 2,
+            genres: 1,
+            stores: 0,
+            events: 1,
+            gamePurchases: 0,
+            relationships: 0,
+            gamesWithCovers: 1,
+            gamesWithReleaseDates: 1,
+            bannedUsers: 0,
+            mobygamesIds: 1,
+            pcgamingwikiIds: 1,
+            wikidataIds: 1,
+            giantbombIds: 1,
+            steamAppIds: 1,
+            epicGamesStoreIds: 1,
+            gogIds: 1,
+            igdbIds: 1,
+            companyVersions: 0,
+            gameVersions: 0,
+            genreVersions: 0,
+            engineVersions: 0,
+            platformVersions: 0,
+            seriesVersions: 0
+          }
+        )
+      end
+    end
+
+    context 'when signed in as a normal user' do
+      let(:user) { create(:confirmed_user) }
+      let(:application) { build(:application, owner: user) }
+      let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+
+      it "returns a permissions error for statistics" do
+        query_string = <<-GRAPHQL
+          query {
+            liveStatistics {
+              id
+              timestamp
+              games
+            }
+          }
+        GRAPHQL
+
+        result = api_request(query_string, token: access_token)
+
+        expect(api_result_errors(result)).to include('Viewing site statistics is only available to admins.')
+        expect(result.graphql_dig(:live_statistics)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This uses a bit of a hack in that it sets id and timestamp to `nil`, but otherwise we'd have to create another type just for this query.

Resolves #2048.