### PR TITLE
Add a ratingCount field to the Game type in the GraphQL API.

### DIFF
--- a/app/graphql/types/game_type.rb
+++ b/app/graphql/types/game_type.rb
@@ -9,6 +9,7 @@ module Types
     field :name, String, null: false, description: "Name of the game."
     field :release_date, GraphQL::Types::ISO8601Date, null: true, description: "The release date of the game."
     field :avg_rating, Float, null: true, description: "The average rating from all users who own the game."
+    field :rating_count, Integer, null: false, description: "The number of ratings across all game purchases associated to this game."
     field :wikidata_id, Integer, null: true, description: "Identifier for Wikidata."
     field :pcgamingwiki_id, String, null: true, description: "Identifier for PCGamingWiki."
     field :mobygames_id, String, null: true, description: "Identifier for the MobyGames database."
@@ -37,6 +38,12 @@ module Types
     field :is_favorited, Boolean, null: true, resolver_method: :favorited?, description: "Whether the game is in the current user's favorites, or `null` if there is no logged-in user."
     field :is_in_library, Boolean, null: true, resolver_method: :in_library?, description: "Whether the game is in the current user's library, or `null` if there is no logged-in user."
     field :game_purchase_id, ID, null: true, description: 'The ID of the GamePurchase record if the game is in the current user\'s library, or `null` otherwise.'
+
+    # Get the number of purchases for the game where rating is not nil.
+    sig { returns(Integer) }
+    def rating_count
+      @object.game_purchases.where.not(rating: nil).count
+    end
 
     # Get the Steam App ID values as an array.
     sig { returns(T::Array[Integer]) }

--- a/db/migrate/20210710185728_add_index_for_game_purchase_ratings.rb
+++ b/db/migrate/20210710185728_add_index_for_game_purchase_ratings.rb
@@ -1,0 +1,9 @@
+# typed: true
+class AddIndexForGamePurchaseRatings < ActiveRecord::Migration[6.1]
+  def change
+    add_index :game_purchases,
+              [:rating, :game_id],
+              where: 'rating IS NOT NULL',
+              name: :index_game_purchases_on_extant_rating_and_game_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_27_204700) do
+ActiveRecord::Schema.define(version: 2021_07_10_185728) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -218,6 +218,7 @@ ActiveRecord::Schema.define(version: 2021_02_27_204700) do
     t.integer "replay_count", default: 0, null: false
     t.index ["game_id", "user_id"], name: "index_game_purchases_on_game_id_and_user_id", unique: true
     t.index ["game_id"], name: "index_game_purchases_on_game_id"
+    t.index ["rating", "game_id"], name: "index_game_purchases_on_extant_rating_and_game_id", where: "(rating IS NOT NULL)"
     t.index ["user_id"], name: "index_game_purchases_on_user_id"
     t.check_constraint "replay_count >= 0", name: "game_purchases_replay_count_not_negative"
   end

--- a/spec/requests/api/games/game_spec.rb
+++ b/spec/requests/api/games/game_spec.rb
@@ -373,13 +373,38 @@ RSpec.describe "Game query API", type: :request do
           }
         )
       end
+    end
 
-      it "returns that the user has not added the game to their library" do
+    context 'when getting the count of ratings' do
+      let(:game_purchases) { create_list(:game_purchase, 3, game: game, rating: rand(100)) }
+      let(:query_string) do
+        <<-GRAPHQL
+          query($id: ID!) {
+            game(id: $id) {
+              avgRating
+              ratingCount
+            }
+          }
+        GRAPHQL
+      end
+
+      it 'returns the number of ratings' do
+        game_purchases
         result = api_request(query_string, variables: { id: game.id }, token: access_token)
         expect(result.graphql_dig(:game)).to include(
           {
-            isInLibrary: false,
-            gamePurchaseId: nil
+            avgRating: be_a(Float),
+            ratingCount: 3
+          }
+        )
+      end
+
+      it 'returns zero ratings when none exist' do
+        result = api_request(query_string, variables: { id: game.id }, token: access_token)
+        expect(result.graphql_dig(:game)).to include(
+          {
+            avgRating: nil,
+            ratingCount: 0
           }
         )
       end


### PR DESCRIPTION
And a database index to make calculating this faster.

Implements #2147.