### PR TITLE
Fix an error in Ruby 3.0.

### DIFF
--- a/app/graphql/mutations/games/update_game.rb
+++ b/app/graphql/mutations/games/update_game.rb
@@ -75,7 +75,7 @@ class Mutations::Games::UpdateGame < Mutations::BaseMutation
         engine_ids: engine_ids
       }.compact
 
-      raise GraphQL::ExecutionError, game.errors.full_messages.join(", ") unless game.update(**other_game_attrs)
+      raise GraphQL::ExecutionError, game.errors.full_messages.join(", ") unless game.update(other_game_attrs)
     end
 
     {


### PR DESCRIPTION
For some reason this never caused any deprecation warnings on 2.7, but this code fails on Ruby 3.0 and 3.1. I'm pretty sure it's backwards compatible with 2.7, so I'm making the change now.