### PR TITLE
Split Live Statistics into its own GraphQL type.

### DIFF
--- a/app/graphql/resolvers/site_statistic_resolvers/live_resolver.rb
+++ b/app/graphql/resolvers/site_statistic_resolvers/live_resolver.rb
@@ -2,16 +2,13 @@
 module Resolvers
   module SiteStatisticResolvers
     class LiveResolver < Resolvers::BaseResolver
-      type Types::SiteStatisticType, null: false
+      type Types::LiveSiteStatisticType, null: false
 
       description "Current statistics for all records on the site, for use on the admin dashboard. **Only available to admins.**"
 
       sig { returns(T::Hash[Symbol, Integer]) }
       def resolve
         {
-          id: nil,
-          timestamp: nil,
-
           users: User.count,
           games: Game.count,
           platforms: Platform.count,

--- a/app/graphql/types/live_site_statistic_type.rb
+++ b/app/graphql/types/live_site_statistic_type.rb
@@ -1,0 +1,10 @@
+# typed: strict
+module Types
+  class LiveSiteStatisticType < Types::BaseObject
+    description <<~MARKDOWN
+      Live-updated site statistics for the vglist database.
+    MARKDOWN
+
+    implements Types::SiteStatisticItem
+  end
+end

--- a/app/graphql/types/site_statistic_item.rb
+++ b/app/graphql/types/site_statistic_item.rb
@@ -1,0 +1,39 @@
+module Types::SiteStatisticItem
+  include Types::BaseInterface
+
+  description "Site statistics attributes"
+
+  field :users, Integer, null: false, description: "The number of Users at this point in time."
+  field :games, Integer, null: false, description: "The number of Games at this point in time."
+  field :platforms, Integer, null: false, description: "The number of Platforms at this point in time."
+  field :series, Integer, null: false, description: "The number of Series at this point in time."
+  field :engines, Integer, null: false, description: "The number of Engines at this point in time."
+  field :companies, Integer, null: false, description: "The number of Companies at this point in time."
+  field :genres, Integer, null: false, description: "The number of Genres at this point in time."
+  field :stores, Integer, null: false, description: "The number of Stores at this point in time."
+  field :events, Integer, null: false, description: "The number of Events at this point in time."
+  field :game_purchases, Integer, null: false, description: "The number of Game Purchases at this point in time."
+  field :relationships, Integer, null: false, description: "The number of Relationships at this point in time."
+  field :games_with_covers, Integer, null: false, description: "The number of Games with covers at this point in time."
+  field :games_with_release_dates, Integer, null: false, description: "The number of Games with release dates at this point in time."
+  field :banned_users, Integer, null: false, description: "The number of Banned Users at this point in time."
+  field :unmatched_games, Integer, null: true, description: "The number of Unmatched Games collected via imports from external services (e.g. Steam) at this point in time."
+
+  # External IDs
+  field :mobygames_ids, Integer, null: false, description: "The number of MobyGames IDs at this point in time."
+  field :pcgamingwiki_ids, Integer, null: false, description: "The number of PCGamingWiki IDs at this point in time."
+  field :wikidata_ids, Integer, null: false, description: "The number of Wikidata IDs at this point in time."
+  field :giantbomb_ids, Integer, null: false, description: "The number of GiantBomb IDs at this point in time."
+  field :steam_app_ids, Integer, null: false, description: "The number of Steam App IDs at this point in time."
+  field :epic_games_store_ids, Integer, null: false, description: "The number of Epic Games Store IDs at this point in time."
+  field :gog_ids, Integer, null: false, description: "The number of GOG.com IDs at this point in time."
+  field :igdb_ids, Integer, null: true, description: "The number of IGDB IDs at this point in time."
+
+  # Versions
+  field :company_versions, Integer, null: true, description: "The number of Company Versions at this point in time."
+  field :game_versions, Integer, null: true, description: "The number of Game Versions at this point in time."
+  field :genre_versions, Integer, null: true, description: "The number of Genre Versions at this point in time."
+  field :engine_versions, Integer, null: true, description: "The number of Engine Versions at this point in time."
+  field :platform_versions, Integer, null: true, description: "The number of Platform Versions at this point in time."
+  field :series_versions, Integer, null: true, description: "The number of Series Versions at this point in time."
+end

--- a/app/graphql/types/site_statistic_type.rb
+++ b/app/graphql/types/site_statistic_type.rb
@@ -7,46 +7,14 @@ module Types
       `null` where necessary.
     MARKDOWN
 
-    field :id, ID, null: true, description: "ID of the statistic record. Shouldn't ever be `null` except in the LiveStatistics query."
+    implements Types::SiteStatisticItem
+
+    field :id, ID, null: false, description: "ID of the statistic record."
 
     # Actually #created_at, but timestamp works better.
     field :timestamp, GraphQL::Types::ISO8601DateTime,
-      null: true,
+      null: false,
       method: :created_at,
-      description: "The point in time at which these statistics were logged, always UTC. Shouldn't ever be `null` except in the LiveStatistics query."
-
-    field :users, Integer, null: false, description: "The number of Users at this point in time."
-    field :games, Integer, null: false, description: "The number of Games at this point in time."
-    field :platforms, Integer, null: false, description: "The number of Platforms at this point in time."
-    field :series, Integer, null: false, description: "The number of Series at this point in time."
-    field :engines, Integer, null: false, description: "The number of Engines at this point in time."
-    field :companies, Integer, null: false, description: "The number of Companies at this point in time."
-    field :genres, Integer, null: false, description: "The number of Genres at this point in time."
-    field :stores, Integer, null: false, description: "The number of Stores at this point in time."
-    field :events, Integer, null: false, description: "The number of Events at this point in time."
-    field :game_purchases, Integer, null: false, description: "The number of Game Purchases at this point in time."
-    field :relationships, Integer, null: false, description: "The number of Relationships at this point in time."
-    field :games_with_covers, Integer, null: false, description: "The number of Games with covers at this point in time."
-    field :games_with_release_dates, Integer, null: false, description: "The number of Games with release dates at this point in time."
-    field :banned_users, Integer, null: false, description: "The number of Banned Users at this point in time."
-    field :unmatched_games, Integer, null: true, description: "The number of Unmatched Games collected via imports from external services (e.g. Steam) at this point in time."
-
-    # External IDs
-    field :mobygames_ids, Integer, null: false, description: "The number of MobyGames IDs at this point in time."
-    field :pcgamingwiki_ids, Integer, null: false, description: "The number of PCGamingWiki IDs at this point in time."
-    field :wikidata_ids, Integer, null: false, description: "The number of Wikidata IDs at this point in time."
-    field :giantbomb_ids, Integer, null: false, description: "The number of GiantBomb IDs at this point in time."
-    field :steam_app_ids, Integer, null: false, description: "The number of Steam App IDs at this point in time."
-    field :epic_games_store_ids, Integer, null: false, description: "The number of Epic Games Store IDs at this point in time."
-    field :gog_ids, Integer, null: false, description: "The number of GOG.com IDs at this point in time."
-    field :igdb_ids, Integer, null: true, description: "The number of IGDB IDs at this point in time."
-
-    # Versions
-    field :company_versions, Integer, null: true, description: "The number of Company Versions at this point in time."
-    field :game_versions, Integer, null: true, description: "The number of Game Versions at this point in time."
-    field :genre_versions, Integer, null: true, description: "The number of Genre Versions at this point in time."
-    field :engine_versions, Integer, null: true, description: "The number of Engine Versions at this point in time."
-    field :platform_versions, Integer, null: true, description: "The number of Platform Versions at this point in time."
-    field :series_versions, Integer, null: true, description: "The number of Series Versions at this point in time."
+      description: "The point in time at which these statistics were logged, always UTC."
   end
 end

--- a/spec/requests/api/live_statistics_spec.rb
+++ b/spec/requests/api/live_statistics_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe "Live Statistics API", type: :request do
         query_string = <<-GRAPHQL
           query {
             liveStatistics {
-              id
-              timestamp
               users
               games
               platforms
@@ -26,8 +24,6 @@ RSpec.describe "Live Statistics API", type: :request do
 
         expect(result.graphql_dig(:live_statistics)).to eq(
           {
-            id: nil,
-            timestamp: nil,
             users: 1,
             games: 0,
             platforms: 0
@@ -40,8 +36,6 @@ RSpec.describe "Live Statistics API", type: :request do
         query_string = <<-GRAPHQL
           query {
             liveStatistics {
-              id
-              timestamp
               users
               games
               platforms
@@ -78,8 +72,6 @@ RSpec.describe "Live Statistics API", type: :request do
 
         expect(result.graphql_dig(:live_statistics)).to eq(
           {
-            id: nil,
-            timestamp: nil,
             users: 1,
             games: 1,
             platforms: 1,
@@ -122,8 +114,6 @@ RSpec.describe "Live Statistics API", type: :request do
         query_string = <<-GRAPHQL
           query {
             liveStatistics {
-              id
-              timestamp
               games
             }
           }


### PR DESCRIPTION
This refactors the shared fields from the two main statistics types into an interface so they don't need to both define all these fields. The live statistics using the same GraphQL type made the type signatures kinda wonky, and with this change the SiteStatisticType won't ever have a null ID or timestamp.