### PR TITLE
Add a Rake task to clean out Unmatched Games.

### DIFF
--- a/lib/tasks/unmatched_games.rake
+++ b/lib/tasks/unmatched_games.rake
@@ -1,4 +1,5 @@
 # typed: false
+# rubocop:disable Rails/PluckInWhere
 namespace :vglist do
   namespace :unmatched_games do
     desc "Clean out the unmatched_games table."
@@ -21,3 +22,4 @@ namespace :vglist do
     end
   end
 end
+# rubocop:enable Rails/PluckInWhere

--- a/lib/tasks/unmatched_games.rake
+++ b/lib/tasks/unmatched_games.rake
@@ -1,0 +1,23 @@
+# typed: false
+namespace :vglist do
+  namespace :unmatched_games do
+    desc "Clean out the unmatched_games table."
+    task clean: :environment do
+      # Destroy all the UnmatchedGame records where the game is already on the
+      # Steam Blocklist.
+      UnmatchedGame.where(
+        external_service_name: 'Steam',
+        external_service_id: SteamBlocklist.pluck(:steam_app_id)
+      ).each(&:destroy!)
+
+      # Destroy all the UnmatchedGame records where the game is already
+      # represented by a SteamAppId for a game.
+      UnmatchedGame.where(
+        external_service_name: 'Steam',
+        external_service_id: SteamAppId.pluck(:app_id)
+      ).each(&:destroy!)
+
+      puts "Unmatched Games updated."
+    end
+  end
+end


### PR DESCRIPTION
Delete unmatched games automatically when they end up getting created (either added to the Steam blocklist or added as an App ID on a game record).

Can be run with `bundle exec rake vglist:unmatched_games:clean`

Resolves #2663.