### PR TITLE
Add GraphQL mutations for deleting a user and resetting a user library.

### DIFF
--- a/app/graphql/mutations/users/delete_user.rb
+++ b/app/graphql/mutations/users/delete_user.rb
@@ -1,0 +1,32 @@
+# typed: true
+class Mutations::Users::DeleteUser < Mutations::BaseMutation
+  description "Delete a user. **Only available to users deleting their own accounts using a first-party OAuth Application.**"
+
+  argument :user_id, ID, required: true, description: "ID of user to delete."
+
+  field :deleted, Boolean, null: false, description: "Whether the user was deleted successfully or not."
+
+  sig { params(user_id: String).returns(T::Hash[Symbol, T::Boolean]) }
+  def resolve(user_id:)
+    user = User.find_by(id: user_id)
+
+    raise GraphQL::ExecutionError, "User does not exist or could not be deleted." unless user&.destroy!
+
+    {
+      deleted: true
+    }
+  end
+
+  sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
+  def authorized?(object)
+    require_permissions!(:first_party)
+
+    user = User.find_by(id: object[:user_id])
+
+    return false if user.nil?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this user." unless UserPolicy.new(@context[:current_user], user).destroy?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/users/reset_user_library.rb
+++ b/app/graphql/mutations/users/reset_user_library.rb
@@ -1,0 +1,36 @@
+# typed: true
+class Mutations::Users::ResetUserLibrary < Mutations::BaseMutation
+  description "Reset a user's game library. This will remove the user's entire game library from the database. **Only available to users resetting their own libraries using a first-party OAuth Application.**"
+
+  argument :user_id, ID, required: true, description: "ID of user who's library will be reset."
+
+  field :deleted, Boolean, null: false, description: "Whether the user's library was reset successfully or not."
+
+  sig { params(user_id: String).returns(T::Hash[Symbol, T::Boolean]) }
+  def resolve(user_id:)
+    user = User.find_by(id: user_id)
+
+    raise GraphQL::ExecutionError, "User does not exist" unless user.present?
+
+    game_purchases = GamePurchase.where(user_id: user.id)
+
+    raise GraphQL::ExecutionError, "User could not have their library reset." unless game_purchases.destroy_all
+
+    {
+      deleted: true
+    }
+  end
+
+  sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
+  def authorized?(object)
+    require_permissions!(:first_party)
+
+    user = User.find_by(id: object[:user_id])
+
+    return false if user.nil?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to reset this user's library." unless UserPolicy.new(@context[:current_user], user).reset_game_library?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/users/reset_user_library.rb
+++ b/app/graphql/mutations/users/reset_user_library.rb
@@ -10,7 +10,7 @@ class Mutations::Users::ResetUserLibrary < Mutations::BaseMutation
   def resolve(user_id:)
     user = User.find_by(id: user_id)
 
-    raise GraphQL::ExecutionError, "User does not exist" unless user.present?
+    raise GraphQL::ExecutionError, "User does not exist." if user.blank?
 
     game_purchases = GamePurchase.where(user_id: user.id)
 

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -18,6 +18,8 @@ module Types
     field :unban_user, mutation: Mutations::Users::UnbanUser
     field :update_user_role, mutation: Mutations::Users::UpdateUserRole
     field :remove_user_avatar, mutation: Mutations::Users::RemoveUserAvatar
+    field :reset_user_library, mutation: Mutations::Users::ResetUserLibrary
+    field :delete_user, mutation: Mutations::Users::DeleteUser
 
     # GamePurchase mutations
     field :add_game_to_library, mutation: Mutations::GamePurchases::AddGameToLibrary

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -124,6 +124,12 @@ class UserPolicy < ApplicationPolicy
     (current_user&.admin? || current_user&.moderator?) && !user_is_current_user?
   end
 
+  sig { returns(T.nilable(T::Boolean)) }
+  def destroy?
+    # Only the user in question can destroy themselves.
+    user_is_current_user?
+  end
+
   private
 
   sig { returns(T.nilable(T::Boolean)) }

--- a/spec/requests/api/mutations/users/delete_user_spec.rb
+++ b/spec/requests/api/mutations/users/delete_user_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "DeleteUser Mutation API", type: :request do
         user
 
         expect do
-          result = api_request(query_string, variables: { id: user.id }, token: access_token)
+          api_request(query_string, variables: { id: user.id }, token: access_token)
         end.to change(User, :count).by(-1)
       end
     end
@@ -56,7 +56,7 @@ RSpec.describe "DeleteUser Mutation API", type: :request do
         user
 
         expect do
-          result = api_request(query_string, variables: { id: user.id }, token: access_token)
+          api_request(query_string, variables: { id: user.id }, token: access_token)
         end.to change(User, :count).by(-1)
       end
     end

--- a/spec/requests/api/mutations/users/delete_user_spec.rb
+++ b/spec/requests/api/mutations/users/delete_user_spec.rb
@@ -1,0 +1,64 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "DeleteUser Mutation API", type: :request do
+  describe "Mutation deletes the user" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          deleteUser(userId: $id) {
+            deleted
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'when the current user is an admin' do
+      let(:user) { create(:confirmed_admin) }
+      let(:user2) { create(:confirmed_user) }
+
+      it "does not delete the user" do
+        user
+        user2
+
+        expect do
+          result = api_request(query_string, variables: { id: user2.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this user.")
+        end.not_to change(User, :count)
+      end
+
+      it "they are able to delete themselves" do
+        user
+
+        expect do
+          result = api_request(query_string, variables: { id: user.id }, token: access_token)
+        end.to change(User, :count).by(-1)
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+      let(:user2) { create(:confirmed_user) }
+
+      it "does not delete the user" do
+        user
+        user2
+
+        expect do
+          result = api_request(query_string, variables: { id: user2.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to delete this user.")
+        end.not_to change(User, :count)
+      end
+
+      it "they are able to delete themselves" do
+        user
+
+        expect do
+          result = api_request(query_string, variables: { id: user.id }, token: access_token)
+        end.to change(User, :count).by(-1)
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/users/reset_user_library_spec.rb
+++ b/spec/requests/api/mutations/users/reset_user_library_spec.rb
@@ -1,0 +1,67 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "ResetUserLibrary Mutation API", type: :request do
+  describe "Mutation deletes the user" do
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          resetUserLibrary(userId: $id) {
+            deleted
+          }
+        }
+      GRAPHQL
+    end
+
+    context 'when the current user is an admin' do
+      let(:user) { create(:confirmed_admin) }
+      let(:user_games) { create_list(:game_purchase, 10, user: user) }
+      let(:user2) { create(:confirmed_user) }
+      let(:user2_games) { create_list(:game_purchase, 10, user: user2) }
+
+      it "does not reset the user's library" do
+        user2_games
+
+        expect do
+          result = api_request(query_string, variables: { id: user2.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to reset this user's library.")
+        end.not_to change(GamePurchase, :count)
+      end
+
+      it "they are able to reset their own library" do
+        user_games
+
+        expect do
+          result = api_request(query_string, variables: { id: user.id }, token: access_token)
+        end.to change(GamePurchase, :count).by(-10)
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+      let(:user_games) { create_list(:game_purchase, 10, user: user) }
+      let(:user2) { create(:confirmed_user) }
+      let(:user2_games) { create_list(:game_purchase, 10, user: user2) }
+
+      it "does not reset the user's library" do
+        user
+        user2_games
+
+        expect do
+          result = api_request(query_string, variables: { id: user2.id }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to reset this user's library.")
+        end.not_to change(GamePurchase, :count)
+      end
+
+      it "they are able to reset their own library" do
+        user_games
+
+        expect do
+          result = api_request(query_string, variables: { id: user.id }, token: access_token)
+        end.to change(GamePurchase, :count).by(-10)
+      end
+    end
+  end
+end

--- a/spec/requests/api/mutations/users/reset_user_library_spec.rb
+++ b/spec/requests/api/mutations/users/reset_user_library_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "ResetUserLibrary Mutation API", type: :request do
         user_games
 
         expect do
-          result = api_request(query_string, variables: { id: user.id }, token: access_token)
+          api_request(query_string, variables: { id: user.id }, token: access_token)
         end.to change(GamePurchase, :count).by(-10)
       end
     end
@@ -59,7 +59,7 @@ RSpec.describe "ResetUserLibrary Mutation API", type: :request do
         user_games
 
         expect do
-          result = api_request(query_string, variables: { id: user.id }, token: access_token)
+          api_request(query_string, variables: { id: user.id }, token: access_token)
         end.to change(GamePurchase, :count).by(-10)
       end
     end


### PR DESCRIPTION
These are for first-party usage only and can only be used on the user's own account/library.

Resolves #1899.