### PR TITLE
Add graphql:copy_to_frontend Rake task.

### DIFF
--- a/lib/tasks/generate_frontend_schema.rake
+++ b/lib/tasks/generate_frontend_schema.rake
@@ -10,7 +10,6 @@ namespace :graphql do
     # Error out if no vglist-frontend sister directory exists.
     raise StandardError, 'No sister vglist-frontend directory could be found.' unless Dir.exist?('../vglist-frontend')
 
-
     # Copy schema.graphql to vglist-frontend sister directory.
     FileUtils.cp(Rails.root.join('schema.graphql'), '../vglist-frontend')
 

--- a/lib/tasks/generate_frontend_schema.rake
+++ b/lib/tasks/generate_frontend_schema.rake
@@ -1,0 +1,23 @@
+# typed: false
+# Generate the GraphQL schema, copy it to vglist-frontend, and generate the
+# TypeScript type signatures.
+namespace :graphql do
+  desc "Generate the GraphQL schema, copy it over to the vglist-frontend repo, and generate TypeScript type signatures."
+  task copy_to_frontend: :environment do
+    # Invoke the Rake task to generate the GraphQL schema.
+    Rake::Task['graphql:schema:dump'].invoke
+
+    # Error out if no vglist-frontend sister directory exists.
+    raise StandardError, 'No sister vglist-frontend directory could be found.' unless Dir.exist?('../vglist-frontend')
+
+
+    # Copy schema.graphql to vglist-frontend sister directory.
+    FileUtils.cp(Rails.root.join('schema.graphql'), '../vglist-frontend')
+
+    # Use the `yarn run generate` command in vglist-frontend to generate
+    # the TypeScript types.
+    Dir.chdir('../vglist-frontend') do
+      system('yarn run generate')
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2699.

Generates the GraphQL schema, copies it to the vglist-frontend directory, and then regenerates TypeScript types.