### PR TITLE
Remove invalid 'image/jpg' content type from codebase.

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -112,7 +112,7 @@ class Game < ApplicationRecord
 
   validates :cover,
     attached: false,
-    content_type: ['image/png', 'image/jpg', 'image/jpeg'],
+    content_type: ['image/png', 'image/jpeg'],
     size: { less_than: 4.megabytes }
 
   validates :avg_rating,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,7 +147,7 @@ class User < ApplicationRecord
 
   validates :avatar,
     attached: false,
-    content_type: ['image/png', 'image/jpg', 'image/jpeg'],
+    content_type: ['image/png', 'image/jpeg'],
     size: { less_than: 3.megabytes },
     aspect_ratio: :square
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -107,6 +107,10 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  # Use an evented file watcher to asynchronously detect changes in source code,
+  # routes, locales, etc. This feature depends on the listen gem.
+  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -5,9 +5,9 @@
 #
 # The default for this value includes various other content types as well, but
 # we don't use any of them.
-Rails.application.config.active_storage.variable_content_types = ['image/png', 'image/jpg', 'image/jpeg']
+Rails.application.config.active_storage.variable_content_types = ['image/png', 'image/jpeg']
 
 # An array of content types in which variants can be processed without being
 # converted to the fallback PNG format. This is set here explicitly to prevent
 # the usage of gifs or any other formats from future Rails versions.
-Rails.application.config.active_storage.web_image_content_types = ['image/png', 'image/jpg', 'image/jpeg']
+Rails.application.config.active_storage.web_image_content_types = ['image/png', 'image/jpeg']

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -6,7 +6,7 @@ namespace 'active_storage:vglist:clean' do
     # they're associated with an attachment somehow.
     # Ideally this should never happen, but somehow it occasionally does. Need
     # to investigate this more.
-    blobs = ActiveStorage::Blob.joins(:attachments).where.not(content_type: ['image/png', 'image/jpeg', 'image/jpg'])
+    blobs = ActiveStorage::Blob.joins(:attachments).where.not(content_type: ['image/png', 'image/jpeg'])
 
     puts "Found #{blobs.count} ActiveStorage::Blobs with a bad content type."
 

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     trait :cover do
       after(:build) do |game|
-        game.cover.attach(io: File.open(Rails.root.join('spec/factories/images/crysis.jpg')), filename: 'crysis.jpg', content_type: 'image/jpg')
+        game.cover.attach(io: File.open(Rails.root.join('spec/factories/images/crysis.jpg')), filename: 'crysis.jpg', content_type: 'image/jpeg')
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
 
     trait :avatar do
       after(:build) do |user|
-        user.avatar.attach(io: File.open(Rails.root.join('spec/factories/images/avatar.jpg')), filename: 'avatar.jpg', content_type: 'image/jpg')
+        user.avatar.attach(io: File.open(Rails.root.join('spec/factories/images/avatar.jpg')), filename: 'avatar.jpg', content_type: 'image/jpeg')
       end
     end
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Game, type: :model do
 
     it 'has an optional cover' do
       expect(game).not_to validate_attached_of(:cover)
-      expect(game).to validate_content_type_of(:cover).allowing('image/png', 'image/jpg', 'image/jpeg')
+      expect(game).to validate_content_type_of(:cover).allowing('image/png', 'image/jpeg')
       expect(game).to validate_size_of(:cover).less_than(4.megabytes)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe User, type: :model do
 
     it 'has an optional avatar' do
       expect(user).not_to validate_attached_of(:avatar)
-      expect(user).to validate_content_type_of(:avatar).allowing('image/png', 'image/jpg', 'image/jpeg')
+      expect(user).to validate_content_type_of(:avatar).allowing('image/png', 'image/jpeg')
       expect(user).to validate_size_of(:avatar).less_than(3.megabytes)
     end
   end


### PR DESCRIPTION
I confirmed in the prod DB that this content type is not used by any ActiveStorage records, so this removal should be safe.

These were causing annoying deprecation warnings in the test suite, and are now fixed.