### PR TITLE
Upgrade to Node 16

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 - Ruby 3.0
 - Postgres 14.x
-- Node.js 14.x
+- Node.js 16.x
 - Yarn 1.x
 - ImageMagick (for images, like avatars or game covers)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Dockerfile for running the application in a CI environment.
-FROM ruby:3.0.3
+FROM ruby:3.0.5
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && echo "deb https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update -qqy && apt-get install -qqyy google-chrome-stable yarn nodejs postgresql postgresql-client

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@rails/webpacker": "5.4.3",
     "@sentry/browser": "5.29.0",
     "@sentry/integrations": "^5.29.0",
-    "@types/node": "^14.0.0",
+    "@types/node": "^16.0.0",
     "babel-preset-typescript-vue": "^1.1.1",
     "bulma": "https://github.com/connorshea/bulma#css-variables-with-fallback",
     "graphiql": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,10 +1497,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.2.tgz#5764ca9aa94470adb4e1185fe2e9f19458992b2e"
   integrity sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==
 
-"@types/node@^14.0.0":
-  version "14.11.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.10.tgz#8c102aba13bf5253f35146affbf8b26275069bef"
-  integrity sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==
+"@types/node@^16.0.0":
+  version "16.18.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.11.tgz#cbb15c12ca7c16c85a72b6bdc4d4b01151bb3cae"
+  integrity sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Node 14 is EOL in two months, and Node 18 doesn't work due to Webpacker+fork-ts-checker-thing. So for now, just upgrade to Node 16. This punts the problem into the future, which never comes back to haunt me.