### PR TITLE
Use slim version of ruby container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for running the application in a CI environment.
-FROM ruby:3.0.5
+FROM ruby:3.0.5-slim
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -


### PR DESCRIPTION
To compare:

1. 3.0.5 for linux/amd64: 335 MB
2. 3.0.5-slim for linux/amd64: 67 MB