### PR TITLE
Disable game creation and updating for normal users.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -516,6 +516,9 @@ RSpec/IdenticalEqualityAssertion:
 RSpec/Rails/AvoidSetupHook:
   Enabled: true
 
+RSpec/NestedGroups:
+  Enabled: false
+
 Performance/BlockGivenWithExplicitBlock:
   Enabled: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v2023.06.19
+- Fix GraphiQL failing to load.
+- Disallow normal users from creating and editing game records. ([#3251])
+
 ## v2022.08.27
 ### Changed
 - Upgrade Ruby on Rails to Rails 7.0. ([#2837])
@@ -940,3 +944,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#2834]: https://github.com/connorshea/vglist/pull/2834
 [#2837]: https://github.com/connorshea/vglist/pull/2837
 [#2840]: https://github.com/connorshea/vglist/pull/2840
+[#3251]: https://github.com/connorshea/vglist/pull/3251

--- a/app/graphql/mutations/games/create_game.rb
+++ b/app/graphql/mutations/games/create_game.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Games::CreateGame < Mutations::BaseMutation
-  description "Create a new game. **Only available when using a first-party OAuth Application.**"
+  description "Create a new game. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :name, String, required: true, description: 'The name of the game.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the game item in Wikidata.'

--- a/app/graphql/mutations/games/update_game.rb
+++ b/app/graphql/mutations/games/update_game.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Games::UpdateGame < Mutations::BaseMutation
-  description "Update an existing game. **Only available when using a first-party OAuth Application.**"
+  description "Update an existing game. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :game_id, ID, required: true, description: 'The ID of the game record.'
   argument :name, String, required: false, description: 'The name of the game.'

--- a/app/policies/game_policy.rb
+++ b/app/policies/game_policy.rb
@@ -21,14 +21,14 @@ class GamePolicy < ApplicationPolicy
     true
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def create?
-    user.present?
+    user&.moderator? || user&.admin?
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def update?
-    user.present?
+    user&.moderator? || user&.admin?
   end
 
   sig { returns(T.nilable(T::Boolean)) }

--- a/spec/features/games_spec.rb
+++ b/spec/features/games_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Games", type: :feature do
   describe "games index" do
     let!(:game) { create(:game) }
     let(:user) { create(:confirmed_user) }
+    let(:moderator) { create(:confirmed_moderator) }
 
     it "with no user" do
       visit(games_path)
@@ -14,6 +15,14 @@ RSpec.describe "Games", type: :feature do
 
     it "with user" do
       sign_in(user)
+
+      visit(games_path)
+      expect(page).to have_link(href: game_path(game))
+      expect(page).to have_no_link(href: new_game_path)
+    end
+
+    it "with user" do
+      sign_in(moderator)
 
       visit(games_path)
       expect(page).to have_link(href: game_path(game))
@@ -32,13 +41,12 @@ RSpec.describe "Games", type: :feature do
       expect(page).to have_no_link(href: edit_game_path(game))
     end
 
-    it "with user" do
+    it "with normal user" do
       sign_in(user)
 
       visit(game_path(game))
       expect(page).to have_content(game.name)
-      find('#actions-dropdown').click
-      expect(page).to have_link(href: edit_game_path(game))
+      expect(page).to have_no_link(href: edit_game_path(game))
     end
 
     it "with moderator" do
@@ -52,7 +60,7 @@ RSpec.describe "Games", type: :feature do
   end
 
   describe "new game page", js: true do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
 
     it "accepts valid game data" do
       sign_in(user)
@@ -69,7 +77,7 @@ RSpec.describe "Games", type: :feature do
 
   describe "edit game page", js: true do
     let!(:game) { create(:game) }
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
 
     it "accepts valid game data" do
       sign_in(user)
@@ -87,7 +95,7 @@ RSpec.describe "Games", type: :feature do
   describe "edit game page has content in multi-select", js: true do
     let(:company) { create(:company, name: 'Gearbox') }
     let(:game) { create(:game_with_everything, publishers: [company]) }
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
 
     it "displays the correct publisher" do
       sign_in(user)

--- a/spec/features/games_spec.rb
+++ b/spec/features/games_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Games", type: :feature do
       expect(page).to have_no_link(href: new_game_path)
     end
 
-    it "with user" do
+    it "with moderator" do
       sign_in(moderator)
 
       visit(games_path)

--- a/spec/policies/game_policy_spec.rb
+++ b/spec/policies/game_policy_spec.rb
@@ -8,15 +8,11 @@ RSpec.describe GamePolicy, type: :policy do
     let(:user) { create(:user) }
     let(:game) { create(:game) }
 
-    it 'can do most things' do
+    it 'can do basic things' do
       expect(game_policy).to permit_actions(
         [
           :index,
           :show,
-          :create,
-          :new,
-          :edit,
-          :update,
           :search,
           :favorite,
           :unfavorite,
@@ -25,9 +21,13 @@ RSpec.describe GamePolicy, type: :policy do
       )
     end
 
-    it 'cannot delete games, remove covers, or merge games' do
+    it 'cannot create, update, or delete games, remove covers, or merge games' do
       expect(game_policy).to forbid_actions(
         [
+          :create,
+          :new,
+          :edit,
+          :update,
           :destroy,
           :remove_cover,
           :merge

--- a/spec/requests/api/mutations/games/create_game_spec.rb
+++ b/spec/requests/api/mutations/games/create_game_spec.rb
@@ -3,11 +3,205 @@ require 'rails_helper'
 
 RSpec.describe "CreateGame Mutation API", type: :request do
   describe "Mutation creates a game record" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let(:application) { build(:application, owner: user) }
     let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
 
-    context 'with basic game' do
+    context 'with a moderator' do
+      context 'with basic game' do
+        let(:query_string) do
+          <<-GRAPHQL
+            mutation($name: String!) {
+              createGame(name: $name) {
+                game {
+                  id
+                  name
+                }
+              }
+            }
+          GRAPHQL
+        end
+
+        it "creates a game" do
+          expect do
+            api_request(query_string, variables: { name: 'Half-Life' }, token: access_token)
+          end.to change(Game, :count).by(1)
+        end
+
+        it "returns basic data for game after creating it" do
+          result = api_request(query_string, variables: { name: 'Half-Life' }, token: access_token)
+
+          expect(result.graphql_dig(:create_game, :game, :name)).to eq('Half-Life')
+        end
+      end
+
+      context 'with more complex game' do
+        let(:query_string) do
+          <<-GRAPHQL
+            mutation(
+              $name: String!,
+              $releaseDate: ISO8601Date,
+              $seriesId: ID,
+              $developerIds: [ID!],
+              $publisherIds: [ID!],
+              $platformIds: [ID!],
+              $engineIds: [ID!],
+              $genreIds: [ID!],
+              $steamAppIds: [Int!],
+              $gogId: String,
+              $epicGamesStoreId: String,
+              $mobygamesId: String,
+              $giantbombId: String,
+              $pcgamingwikiId: String,
+              $wikidataId: ID,
+              $igdbId: String
+            ) {
+              createGame(
+                name: $name,
+                releaseDate: $releaseDate,
+                seriesId: $seriesId,
+                developerIds: $developerIds,
+                publisherIds: $publisherIds,
+                platformIds: $platformIds,
+                engineIds: $engineIds,
+                genreIds: $genreIds,
+                steamAppIds: $steamAppIds,
+                gogId: $gogId,
+                epicGamesStoreId: $epicGamesStoreId,
+                mobygamesId: $mobygamesId,
+                giantbombId: $giantbombId
+                pcgamingwikiId: $pcgamingwikiId,
+                wikidataId: $wikidataId,
+                igdbId: $igdbId
+              ) {
+                game {
+                  name
+                  releaseDate
+                  series {
+                    id
+                  }
+                  developers {
+                    nodes {
+                      id
+                    }
+                  }
+                  publishers {
+                    nodes {
+                      id
+                    }
+                  }
+                  platforms {
+                    nodes {
+                      id
+                    }
+                  }
+                  engines {
+                    nodes {
+                      id
+                    }
+                  }
+                  genres {
+                    nodes {
+                      id
+                    }
+                  }
+                  steamAppIds
+                  gogId
+                  epicGamesStoreId
+                  giantbombId
+                  mobygamesId
+                  pcgamingwikiId
+                  wikidataId
+                  igdbId
+                }
+              }
+            }
+          GRAPHQL
+        end
+        let(:series) { create(:series) }
+        let(:developer) { create(:company) }
+        let(:publisher) { create(:company) }
+        let(:platform) { create(:platform) }
+        let(:engine) { create(:engine) }
+        let(:genre) { create(:genre) }
+        let(:variables) do
+          {
+            name: 'Portal 2',
+            release_date: '2011-04-18',
+            series_id: series.id,
+            developer_ids: [developer.id],
+            publisher_ids: [publisher.id],
+            platform_ids: [platform.id],
+            engine_ids: [engine.id],
+            genre_ids: [genre.id],
+            steam_app_ids: [123, 456],
+            gog_id: 'portal_2',
+            epic_games_store_id: 'foo',
+            giantbomb_id: '3030-1539',
+            mobygames_id: 'bar',
+            pcgamingwiki_id: 'baz',
+            wikidata_id: 123_456_789,
+            igdb_id: 'portal-2'
+          }
+        end
+
+        it "creates a game" do
+          expect do
+            api_request(query_string, variables: variables, token: access_token)
+          end.to change(Game, :count).by(1)
+        end
+
+        it "returns the data for game after creating it" do
+          result = api_request(query_string, variables: variables, token: access_token)
+
+          expect(result.graphql_dig(:create_game, :game)).to eq(
+            {
+              name: 'Portal 2',
+              releaseDate: '2011-04-18',
+              series: {
+                id: series.id.to_s
+              },
+              developers: {
+                nodes: [
+                  id: developer.id.to_s
+                ]
+              },
+              publishers: {
+                nodes: [
+                  id: publisher.id.to_s
+                ]
+              },
+              platforms: {
+                nodes: [
+                  id: platform.id.to_s
+                ]
+              },
+              engines: {
+                nodes: [
+                  id: engine.id.to_s
+                ]
+              },
+              genres: {
+                nodes: [
+                  id: genre.id.to_s
+                ]
+              },
+              steamAppIds: [123, 456],
+              gogId: 'portal_2',
+              epicGamesStoreId: 'foo',
+              giantbombId: '3030-1539',
+              mobygamesId: 'bar',
+              pcgamingwikiId: 'baz',
+              wikidataId: 123_456_789,
+              igdbId: 'portal-2'
+            }
+          )
+        end
+      end
+    end
+
+    context 'with a normal user' do
+      let(:user) { create(:confirmed_user) }
       let(:query_string) do
         <<-GRAPHQL
           mutation($name: String!) {
@@ -21,180 +215,11 @@ RSpec.describe "CreateGame Mutation API", type: :request do
         GRAPHQL
       end
 
-      it "creates a game" do
+      it "does not change the number of games" do
         expect do
-          api_request(query_string, variables: { name: 'Half-Life' }, token: access_token)
-        end.to change(Game, :count).by(1)
-      end
-
-      it "returns basic data for game after creating it" do
-        result = api_request(query_string, variables: { name: 'Half-Life' }, token: access_token)
-
-        expect(result.graphql_dig(:create_game, :game, :name)).to eq('Half-Life')
-      end
-    end
-
-    context 'with more complex game' do
-      let(:query_string) do
-        <<-GRAPHQL
-          mutation(
-            $name: String!,
-            $releaseDate: ISO8601Date,
-            $seriesId: ID,
-            $developerIds: [ID!],
-            $publisherIds: [ID!],
-            $platformIds: [ID!],
-            $engineIds: [ID!],
-            $genreIds: [ID!],
-            $steamAppIds: [Int!],
-            $gogId: String,
-            $epicGamesStoreId: String,
-            $mobygamesId: String,
-            $giantbombId: String,
-            $pcgamingwikiId: String,
-            $wikidataId: ID,
-            $igdbId: String
-          ) {
-            createGame(
-              name: $name,
-              releaseDate: $releaseDate,
-              seriesId: $seriesId,
-              developerIds: $developerIds,
-              publisherIds: $publisherIds,
-              platformIds: $platformIds,
-              engineIds: $engineIds,
-              genreIds: $genreIds,
-              steamAppIds: $steamAppIds,
-              gogId: $gogId,
-              epicGamesStoreId: $epicGamesStoreId,
-              mobygamesId: $mobygamesId,
-              giantbombId: $giantbombId
-              pcgamingwikiId: $pcgamingwikiId,
-              wikidataId: $wikidataId,
-              igdbId: $igdbId
-            ) {
-              game {
-                name
-                releaseDate
-                series {
-                  id
-                }
-                developers {
-                  nodes {
-                    id
-                  }
-                }
-                publishers {
-                  nodes {
-                    id
-                  }
-                }
-                platforms {
-                  nodes {
-                    id
-                  }
-                }
-                engines {
-                  nodes {
-                    id
-                  }
-                }
-                genres {
-                  nodes {
-                    id
-                  }
-                }
-                steamAppIds
-                gogId
-                epicGamesStoreId
-                giantbombId
-                mobygamesId
-                pcgamingwikiId
-                wikidataId
-                igdbId
-              }
-            }
-          }
-        GRAPHQL
-      end
-      let(:series) { create(:series) }
-      let(:developer) { create(:company) }
-      let(:publisher) { create(:company) }
-      let(:platform) { create(:platform) }
-      let(:engine) { create(:engine) }
-      let(:genre) { create(:genre) }
-      let(:variables) do
-        {
-          name: 'Portal 2',
-          release_date: '2011-04-18',
-          series_id: series.id,
-          developer_ids: [developer.id],
-          publisher_ids: [publisher.id],
-          platform_ids: [platform.id],
-          engine_ids: [engine.id],
-          genre_ids: [genre.id],
-          steam_app_ids: [123, 456],
-          gog_id: 'portal_2',
-          epic_games_store_id: 'foo',
-          giantbomb_id: '3030-1539',
-          mobygames_id: 'bar',
-          pcgamingwiki_id: 'baz',
-          wikidata_id: 123_456_789,
-          igdb_id: 'portal-2'
-        }
-      end
-
-      it "creates a game" do
-        expect do
-          api_request(query_string, variables: variables, token: access_token)
-        end.to change(Game, :count).by(1)
-      end
-
-      it "returns the data for game after creating it" do
-        result = api_request(query_string, variables: variables, token: access_token)
-
-        expect(result.graphql_dig(:create_game, :game)).to eq(
-          {
-            name: 'Portal 2',
-            releaseDate: '2011-04-18',
-            series: {
-              id: series.id.to_s
-            },
-            developers: {
-              nodes: [
-                id: developer.id.to_s
-              ]
-            },
-            publishers: {
-              nodes: [
-                id: publisher.id.to_s
-              ]
-            },
-            platforms: {
-              nodes: [
-                id: platform.id.to_s
-              ]
-            },
-            engines: {
-              nodes: [
-                id: engine.id.to_s
-              ]
-            },
-            genres: {
-              nodes: [
-                id: genre.id.to_s
-              ]
-            },
-            steamAppIds: [123, 456],
-            gogId: 'portal_2',
-            epicGamesStoreId: 'foo',
-            giantbombId: '3030-1539',
-            mobygamesId: 'bar',
-            pcgamingwikiId: 'baz',
-            wikidataId: 123_456_789,
-            igdbId: 'portal-2'
-          }
-        )
+          result = api_request(query_string, variables: { name: 'Half-Life' }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to create a game.")
+        end.not_to change(Game, :count)
       end
     end
   end

--- a/spec/requests/api/mutations/games/update_game_spec.rb
+++ b/spec/requests/api/mutations/games/update_game_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe "UpdateGame Mutation API", type: :request do
   describe "Mutation updates an existing game record" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let(:application) { build(:application, owner: user) }
     let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
 

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Games", type: :request do
   end
 
   describe "POST games_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let(:game_attributes) { attributes_for(:game) }
 
     it "creates a new game" do
@@ -92,7 +92,7 @@ RSpec.describe "Games", type: :request do
   end
 
   describe "PUT game_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let!(:game) { create(:game) }
     let(:game_attributes) { attributes_for(:game) }
 


### PR DESCRIPTION
Moderators and admins are stil able to create and edit games, but not normal users. I'm making this change to prevent any chance of vandalism, since >99% of the edits on the site are automated via Wikidata imports anyway.

If an attacker chose to vandalize the site by editing dozens or hundreds of game records, they could do serious damage that would be difficult to reverse (most likely I'd need to restore the games table from a database backup). This would take a good amount of time to fix and potentially result in the site either going down temporarily or even in data loss of recent, legitimate changes due to the database being reverted to an older state.

Since the edit rate by users is pretty low, this shouldn't be a significant disruption to site usage, and I've chosen not to implement an approval system since that'd require a lot of new code and maintenance work long-term.

Editing games can still be done by anyone, by creating/editing the corresponding records on Wikidata. They'll be picked up automatically the next time the Wikidata import script is run.