### PR TITLE
Update MobyGames IDs to the new format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v2023.07.13
+- Migrate MobyGames IDs from the old slug format to the new numeric identifiers. ([#3286])
+
 ## v2023.06.19
 - Fix GraphiQL failing to load.
 - Disallow normal users from creating and editing game records. ([#3251])
@@ -945,3 +948,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#2837]: https://github.com/connorshea/vglist/pull/2837
 [#2840]: https://github.com/connorshea/vglist/pull/2840
 [#3251]: https://github.com/connorshea/vglist/pull/3251
+[#3286]: https://github.com/connorshea/vglist/pull/3286

--- a/app/graphql/mutations/games/create_game.rb
+++ b/app/graphql/mutations/games/create_game.rb
@@ -12,7 +12,7 @@ class Mutations::Games::CreateGame < Mutations::BaseMutation
   argument :genre_ids, [ID], required: false, description: 'The ID(s) of the game\'s genres.'
   argument :engine_ids, [ID], required: false, description: 'The ID(s) of the game\'s engines.'
   argument :pcgamingwiki_id, String, required: false, description: 'The ID of the game on PCGamingWiki.'
-  argument :mobygames_id, String, required: false, description: 'The ID of the game on MobyGames.'
+  argument :mobygames_id, Integer, required: false, description: 'The ID of the game on MobyGames.'
   argument :giantbomb_id, String, required: false, description: 'The ID of the game on the GiantBomb Wiki.'
   argument :epic_games_store_id, String, required: false, description: 'The ID of the game on the Epic Games Store.'
   argument :gog_id, String, required: false, description: 'The ID of the game on GOG.com.'
@@ -35,7 +35,7 @@ class Mutations::Games::CreateGame < Mutations::BaseMutation
       genre_ids: T::Array[T.any(String, Integer)],
       engine_ids: T::Array[T.any(String, Integer)],
       pcgamingwiki_id: T.nilable(String),
-      mobygames_id: T.nilable(String),
+      mobygames_id: T.nilable(Integer),
       giantbomb_id: T.nilable(String),
       epic_games_store_id: T.nilable(String),
       gog_id: T.nilable(String),

--- a/app/graphql/mutations/games/update_game.rb
+++ b/app/graphql/mutations/games/update_game.rb
@@ -13,7 +13,7 @@ class Mutations::Games::UpdateGame < Mutations::BaseMutation
   argument :genre_ids, [ID], required: false, description: 'The ID(s) of the game\'s genres.'
   argument :engine_ids, [ID], required: false, description: 'The ID(s) of the game\'s engines.'
   argument :pcgamingwiki_id, String, required: false, description: 'The ID of the game on PCGamingWiki.'
-  argument :mobygames_id, String, required: false, description: 'The ID of the game on MobyGames.'
+  argument :mobygames_id, Integer, required: false, description: 'The ID of the game on MobyGames.'
   argument :giantbomb_id, String, required: false, description: 'The ID of the game on the GiantBomb Wiki.'
   argument :epic_games_store_id, String, required: false, description: 'The ID of the game on the Epic Games Store.'
   argument :gog_id, String, required: false, description: 'The ID of the game on GOG.com.'

--- a/app/graphql/resolvers/game_resolvers/game_resolver.rb
+++ b/app/graphql/resolvers/game_resolvers/game_resolver.rb
@@ -10,7 +10,7 @@ module Resolvers
       argument :wikidata_id, Integer, required: false, description: "Find a game by its Wikidata ID."
       argument :giantbomb_id, String, required: false, description: "Find a game by its GiantBomb ID, e.g. `'3030-23708'`."
       argument :igdb_id, String, required: false, description: "Find a game by its IGDB ID."
-      argument :mobygames_id, String, required: false, description: "Find a game by its MobyGames ID."
+      argument :mobygames_id, Integer, required: false, description: "Find a game by its MobyGames ID."
       argument :pcgamingwiki_id, String, required: false, description: "Find a game by its PCGamingWiki ID."
       argument :steam_app_id, Integer, required: false, description: "Find a game by its Steam App ID."
       argument :epic_games_store_id, String, required: false, description: "Find a game by its Epic Games Store ID."

--- a/app/graphql/types/game_type.rb
+++ b/app/graphql/types/game_type.rb
@@ -12,7 +12,7 @@ module Types
     field :rating_count, Integer, null: false, description: "The number of ratings across all game purchases associated to this game."
     field :wikidata_id, Integer, null: true, description: "Identifier for Wikidata."
     field :pcgamingwiki_id, String, null: true, description: "Identifier for PCGamingWiki."
-    field :mobygames_id, String, null: true, description: "Identifier for the MobyGames database."
+    field :mobygames_id, Integer, null: true, description: "Identifier for the MobyGames database."
     field :giantbomb_id, String, null: true, description: "Identifier for Giant Bomb."
     field :epic_games_store_id, String, null: true, description: "Identifier for the Epic Games Store."
     field :gog_id, String, null: true, description: "Identifier for GOG.com."

--- a/app/javascript/src/components/game-form.vue
+++ b/app/javascript/src/components/game-form.vue
@@ -238,7 +238,7 @@ export default {
       required: false
     },
     mobygamesId: {
-      type: String,
+      type: Number,
       required: false
     },
     giantbombId: {

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -141,10 +141,11 @@ class Game < ApplicationRecord
 
   validates :mobygames_id,
     uniqueness: true,
-    allow_nil: true,
-    format: %r{\A[a-z\-_0-9]+/?([a-z\-_0-9]+)?\z},
-    # Allow up to 300 characters just in case there's some game with an incredibly long name.
-    length: { maximum: 300 }
+    allow_blank: true,
+    numericality: {
+      only_integer: true,
+      greater_than: 0
+    }
 
   validates :giantbomb_id,
     uniqueness: true,

--- a/db/migrate/20230714020617_drop_moby_games_id_column.rb
+++ b/db/migrate/20230714020617_drop_moby_games_id_column.rb
@@ -1,0 +1,7 @@
+# typed: true
+class DropMobyGamesIdColumn < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :games, :mobygames_id, unique: true
+    remove_column :games, :mobygames_id, :text
+  end
+end

--- a/db/migrate/20230714020627_add_moby_games_id_numeric_to_games.rb
+++ b/db/migrate/20230714020627_add_moby_games_id_numeric_to_games.rb
@@ -1,0 +1,7 @@
+# typed: true
+class AddMobyGamesIdNumericToGames < ActiveRecord::Migration[7.0]
+  def change
+    add_column :games, :mobygames_id, :bigint
+    add_index :games, :mobygames_id, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -770,13 +770,13 @@ CREATE TABLE public.games (
     series_id bigint,
     wikidata_id bigint,
     pcgamingwiki_id text,
-    mobygames_id text,
     release_date date,
     giantbomb_id text,
     epic_games_store_id text,
     gog_id text,
     avg_rating double precision,
-    igdb_id text
+    igdb_id text,
+    mobygames_id bigint
 );
 
 
@@ -3206,6 +3206,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220612160618'),
 ('20220612160627'),
 ('20220612192154'),
-('20220827144350');
+('20220827144350'),
+('20230714020617'),
+('20230714020627');
 
 

--- a/lib/tasks/import/mobygames.rake
+++ b/lib/tasks/import/mobygames.rake
@@ -191,7 +191,7 @@ namespace :import do
     sparql = <<-SPARQL
       SELECT ?item ?mobygamesId WHERE {
         ?item wdt:P31 wd:Q7889; # Instances of video games
-              wdt:P1933 ?mobygamesId. # Items with a MobyGames ID.
+              wdt:P11688 ?mobygamesId. # Items with a MobyGames ID.
       }
     SPARQL
 

--- a/lib/tasks/import/wikidata_import_games.rake
+++ b/lib/tasks/import/wikidata_import_games.rake
@@ -97,7 +97,7 @@ namespace 'import:wikidata' do
         # Remove the 'game/' prefix from the GOG.com IDs.
         gog_id = wikidata_json['P2725']&.first&.dig('mainsnak', 'datavalue', 'value')&.gsub('game/', '')
         igdb_id = wikidata_json['P5794']&.first&.dig('mainsnak', 'datavalue', 'value')
-        mobygames_id = wikidata_json['P1933']&.first&.dig('mainsnak', 'datavalue', 'value')
+        mobygames_id = wikidata_json['P11688']&.first&.dig('mainsnak', 'datavalue', 'value')
         giantbomb_id = wikidata_json['P5247']&.first&.dig('mainsnak', 'datavalue', 'value')
 
         release_dates = wikidata_json['P577']&.map { |date| date.dig('mainsnak', 'datavalue', 'value', 'time') }

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -46,7 +46,7 @@ FactoryBot.define do
     end
 
     trait :mobygames_id do
-      mobygames_id {Faker::Number.number(digits: 6) }
+      mobygames_id { Faker::Number.number(digits: 6) }
     end
 
     trait :giantbomb_id do

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -46,7 +46,7 @@ FactoryBot.define do
     end
 
     trait :mobygames_id do
-      mobygames_id { Faker::Lorem.words(number: 3).join('-') }
+      mobygames_id {Faker::Number.number(digits: 6) }
     end
 
     trait :giantbomb_id do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -55,26 +55,11 @@ RSpec.describe Game, type: :model do
     end
 
     it { should validate_uniqueness_of(:mobygames_id).allow_nil }
-    it { should validate_length_of(:mobygames_id).is_at_most(300) }
-
-    it 'allows valid MobyGames IDs' do
-      expect(game).to allow_values(
-        'star-wars-battlefront-ii',
-        'star-wars-battlefront-ii_',
-        'borderlands-2',
-        'star-wars-knights-of-the-old-republic-ii-the-sith-lords',
-        'windows/disciples-ii-dark-prophecy',
-        'ps3/game-name',
-        'z'
-      ).for(:mobygames_id)
-    end
-
-    it 'disallows invalid MobyGames IDs' do
-      expect(game).not_to allow_values(
-        'CapitalLetters',
-        'Game with spaces in name',
-        'PS3/game'
-      ).for(:mobygames_id)
+    it 'validates numericality of mobygames_id' do
+      expect(game).to validate_numericality_of(:mobygames_id)
+        .only_integer
+        .allow_nil
+        .is_greater_than(0)
     end
 
     it { should validate_uniqueness_of(:giantbomb_id).allow_nil }

--- a/spec/requests/api/games/game_spec.rb
+++ b/spec/requests/api/games/game_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe "Game query API", type: :request do
 
     it "returns basic data for game when searching by mobygames_id" do
       query_string = <<-GRAPHQL
-        query($mobygamesId: String!) {
+        query($mobygamesId: Int!) {
           game(mobygamesId: $mobygamesId) {
             id
             name

--- a/spec/requests/api/mutations/games/create_game_spec.rb
+++ b/spec/requests/api/mutations/games/create_game_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "CreateGame Mutation API", type: :request do
               $steamAppIds: [Int!],
               $gogId: String,
               $epicGamesStoreId: String,
-              $mobygamesId: String,
+              $mobygamesId: Int,
               $giantbombId: String,
               $pcgamingwikiId: String,
               $wikidataId: ID,
@@ -138,7 +138,7 @@ RSpec.describe "CreateGame Mutation API", type: :request do
             gog_id: 'portal_2',
             epic_games_store_id: 'foo',
             giantbomb_id: '3030-1539',
-            mobygames_id: 'bar',
+            mobygames_id: 123,
             pcgamingwiki_id: 'baz',
             wikidata_id: 123_456_789,
             igdb_id: 'portal-2'
@@ -190,7 +190,7 @@ RSpec.describe "CreateGame Mutation API", type: :request do
               gogId: 'portal_2',
               epicGamesStoreId: 'foo',
               giantbombId: '3030-1539',
-              mobygamesId: 'bar',
+              mobygamesId: 123,
               pcgamingwikiId: 'baz',
               wikidataId: 123_456_789,
               igdbId: 'portal-2'

--- a/spec/requests/api/mutations/games/update_game_spec.rb
+++ b/spec/requests/api/mutations/games/update_game_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "UpdateGame Mutation API", type: :request do
             $steamAppIds: [Int!],
             $gogId: String,
             $epicGamesStoreId: String,
-            $mobygamesId: String,
+            $mobygamesId: Int,
             $giantbombId: String,
             $pcgamingwikiId: String,
             $wikidataId: ID,
@@ -144,7 +144,7 @@ RSpec.describe "UpdateGame Mutation API", type: :request do
           gog_id: 'portal_2',
           epic_games_store_id: 'foo',
           giantbomb_id: '3030-1539',
-          mobygames_id: 'bar',
+          mobygames_id: 123,
           pcgamingwiki_id: 'baz',
           wikidata_id: 123_456_789,
           igdb_id: 'portal-2'
@@ -198,7 +198,7 @@ RSpec.describe "UpdateGame Mutation API", type: :request do
             gogId: 'portal_2',
             epicGamesStoreId: 'foo',
             giantbombId: '3030-1539',
-            mobygamesId: 'bar',
+            mobygamesId: 123,
             pcgamingwikiId: 'baz',
             wikidataId: 123_456_789,
             igdbId: 'portal-2'


### PR DESCRIPTION
MobyGames released "v2" a few months ago and switched their IDs from slugs to ints.

This will delete all the existing MobyGames IDs in the database, but they all came from Wikidata anyway, so we can just import the updated MobyGames IDs after this is deployed.

This is a breaking change to the GraphQL API, but I don't think it's a big enough one that we should go to the trouble of a deprecation cycle.

Resolves #3285.