### PR TITLE
Update platforms, genres, series, engines, and companies to require Wikidata IDs and restrict their editing/creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v2024.06.16
+### Changed
+- Require Wikidata IDs for genres, platforms, series, engines, and companies. ([#3734])
+- Disallow editing and creation of series, engines, and companies for normal users. This should primarily be done by editing Wikidata itself, rather than vglist. ([#3734])
+
 ## v2024.06.15
+### Changed
 - Upgrade to Rails 7.1. ([#3697])
 
 ## v2024.04.26
+### Changed
 - Upgrade to Ruby 3.3. ([#3651], [#3652])
 
 ## v2023.07.13
+### Changed
 - Migrate MobyGames IDs from the old slug format to the new numeric identifiers. ([#3286])
 
 ## v2023.06.19
+### Fixed
 - Fix GraphiQL failing to load.
+
+### Changed
 - Disallow normal users from creating and editing game records. ([#3251])
 
 ## v2022.08.27
@@ -958,3 +969,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#3651]: https://github.com/connorshea/vglist/pull/3651
 [#3652]: https://github.com/connorshea/vglist/pull/3652
 [#3697]: https://github.com/connorshea/vglist/pull/3697
+[#3734]: https://github.com/connorshea/vglist/pull/3734

--- a/app/graphql/mutations/companies/create_company.rb
+++ b/app/graphql/mutations/companies/create_company.rb
@@ -3,12 +3,12 @@ class Mutations::Companies::CreateCompany < Mutations::BaseMutation
   description "Create a new game company. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :name, String, required: true, description: 'The name of the company.'
-  argument :wikidata_id, ID, required: false, description: 'The ID of the company item in Wikidata.'
+  argument :wikidata_id, ID, required: true, description: 'The ID of the company item in Wikidata.'
 
   field :company, Types::CompanyType, null: true, description: "The company that was created."
 
-  sig { params(name: String, wikidata_id: T.nilable(T.any(String, Integer))).returns(T::Hash[Symbol, Company]) }
-  def resolve(name:, wikidata_id: nil)
+  sig { params(name: String, wikidata_id: T.any(String, Integer)).returns(T::Hash[Symbol, Company]) }
+  def resolve(name:, wikidata_id:)
     company = Company.new(name: name, wikidata_id: wikidata_id)
 
     raise GraphQL::ExecutionError, company.errors.full_messages.join(", ") unless company.save

--- a/app/graphql/mutations/companies/create_company.rb
+++ b/app/graphql/mutations/companies/create_company.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Companies::CreateCompany < Mutations::BaseMutation
-  description "Create a new game company. **Only available when using a first-party OAuth Application.**"
+  description "Create a new game company. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :name, String, required: true, description: 'The name of the company.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the company item in Wikidata.'

--- a/app/graphql/mutations/companies/update_company.rb
+++ b/app/graphql/mutations/companies/update_company.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Companies::UpdateCompany < Mutations::BaseMutation
-  description "Update an existing game company. **Only available when using a first-party OAuth Application.**"
+  description "Update an existing game company. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :company_id, ID, required: true, description: 'The ID of the company record.'
   argument :name, String, required: false, description: 'The name of the company.'

--- a/app/graphql/mutations/engines/create_engine.rb
+++ b/app/graphql/mutations/engines/create_engine.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Engines::CreateEngine < Mutations::BaseMutation
-  description "Create a new game engine. **Only available when using a first-party OAuth Application.**"
+  description "Create a new game engine. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :name, String, required: true, description: 'The name of the engine.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the engine item in Wikidata.'

--- a/app/graphql/mutations/engines/create_engine.rb
+++ b/app/graphql/mutations/engines/create_engine.rb
@@ -3,12 +3,12 @@ class Mutations::Engines::CreateEngine < Mutations::BaseMutation
   description "Create a new game engine. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :name, String, required: true, description: 'The name of the engine.'
-  argument :wikidata_id, ID, required: false, description: 'The ID of the engine item in Wikidata.'
+  argument :wikidata_id, ID, required: true, description: 'The ID of the engine item in Wikidata.'
 
   field :engine, Types::EngineType, null: true, description: "The engine that was created."
 
-  sig { params(name: String, wikidata_id: T.nilable(T.any(String, Integer))).returns(T::Hash[Symbol, Engine]) }
-  def resolve(name:, wikidata_id: nil)
+  sig { params(name: String, wikidata_id: T.any(String, Integer)).returns(T::Hash[Symbol, Engine]) }
+  def resolve(name:, wikidata_id:)
     engine = Engine.new(name: name, wikidata_id: wikidata_id)
 
     raise GraphQL::ExecutionError, engine.errors.full_messages.join(", ") unless engine.save

--- a/app/graphql/mutations/engines/update_engine.rb
+++ b/app/graphql/mutations/engines/update_engine.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Engines::UpdateEngine < Mutations::BaseMutation
-  description "Update an existing game engine. **Only available when using a first-party OAuth Application.**"
+  description "Update an existing game engine. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :engine_id, ID, required: true, description: 'The ID of the engine record.'
   argument :name, String, required: false, description: 'The name of the engine.'

--- a/app/graphql/mutations/genres/create_genre.rb
+++ b/app/graphql/mutations/genres/create_genre.rb
@@ -3,12 +3,12 @@ class Mutations::Genres::CreateGenre < Mutations::BaseMutation
   description "Create a new game genre. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :name, String, required: true, description: 'The name of the genre.'
-  argument :wikidata_id, ID, required: false, description: 'The ID of the genre item in Wikidata.'
+  argument :wikidata_id, ID, required: true, description: 'The ID of the genre item in Wikidata.'
 
   field :genre, Types::GenreType, null: true, description: "The genre that was created."
 
-  sig { params(name: String, wikidata_id: T.nilable(T.any(String, Integer))).returns(T::Hash[Symbol, Genre]) }
-  def resolve(name:, wikidata_id: nil)
+  sig { params(name: String, wikidata_id: T.any(String, Integer)).returns(T::Hash[Symbol, Genre]) }
+  def resolve(name:, wikidata_id:)
     genre = Genre.new(name: name, wikidata_id: wikidata_id)
 
     raise GraphQL::ExecutionError, genre.errors.full_messages.join(", ") unless genre.save

--- a/app/graphql/mutations/platforms/create_platform.rb
+++ b/app/graphql/mutations/platforms/create_platform.rb
@@ -3,12 +3,12 @@ class Mutations::Platforms::CreatePlatform < Mutations::BaseMutation
   description "Create a new game platform. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :name, String, required: true, description: 'The name of the platform.'
-  argument :wikidata_id, ID, required: false, description: 'The ID of the platform item in Wikidata.'
+  argument :wikidata_id, ID, required: true, description: 'The ID of the platform item in Wikidata.'
 
   field :platform, Types::PlatformType, null: true, description: "The platform that was created."
 
-  sig { params(name: String, wikidata_id: T.nilable(T.any(String, Integer))).returns(T::Hash[Symbol, Platform]) }
-  def resolve(name:, wikidata_id: nil)
+  sig { params(name: String, wikidata_id: T.any(String, Integer)).returns(T::Hash[Symbol, Platform]) }
+  def resolve(name:, wikidata_id:)
     platform = Platform.new(name: name, wikidata_id: wikidata_id)
 
     raise GraphQL::ExecutionError, platform.errors.full_messages.join(", ") unless platform.save

--- a/app/graphql/mutations/series/create_series.rb
+++ b/app/graphql/mutations/series/create_series.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Series::CreateSeries < Mutations::BaseMutation
-  description "Create a new game series. **Only available when using a first-party OAuth Application.**"
+  description "Create a new game series. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :name, String, required: true, description: 'The name of the series.'
   argument :wikidata_id, ID, required: false, description: 'The ID of the series item in Wikidata.'

--- a/app/graphql/mutations/series/create_series.rb
+++ b/app/graphql/mutations/series/create_series.rb
@@ -3,12 +3,12 @@ class Mutations::Series::CreateSeries < Mutations::BaseMutation
   description "Create a new game series. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :name, String, required: true, description: 'The name of the series.'
-  argument :wikidata_id, ID, required: false, description: 'The ID of the series item in Wikidata.'
+  argument :wikidata_id, ID, required: true, description: 'The ID of the series item in Wikidata.'
 
   field :series, Types::SeriesType, null: true, description: "The series that was created."
 
-  sig { params(name: String, wikidata_id: T.nilable(T.any(String, Integer))).returns(T::Hash[Symbol, Series]) }
-  def resolve(name:, wikidata_id: nil)
+  sig { params(name: String, wikidata_id: T.any(String, Integer)).returns(T::Hash[Symbol, Series]) }
+  def resolve(name:, wikidata_id:)
     series = Series.new(name: name, wikidata_id: wikidata_id)
 
     raise GraphQL::ExecutionError, series.errors.full_messages.join(", ") unless series.save

--- a/app/graphql/mutations/series/update_series.rb
+++ b/app/graphql/mutations/series/update_series.rb
@@ -1,6 +1,6 @@
 # typed: true
 class Mutations::Series::UpdateSeries < Mutations::BaseMutation
-  description "Update an existing game series. **Only available when using a first-party OAuth Application.**"
+  description "Update an existing game series. **Only available to moderators and admins using a first-party OAuth Application.**"
 
   argument :series_id, ID, required: true, description: 'The ID of the series record.'
   argument :name, String, required: false, description: 'The name of the series.'

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -20,7 +20,7 @@ class Company < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
-    allow_blank: true,
+    presence: true,
     numericality: {
       only_integer: true,
       greater_than: 0

--- a/app/models/engine.rb
+++ b/app/models/engine.rb
@@ -17,7 +17,7 @@ class Engine < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
-    allow_blank: true,
+    presence: true,
     numericality: {
       only_integer: true,
       greater_than: 0

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -17,7 +17,7 @@ class Genre < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
-    allow_blank: true,
+    presence: true,
     numericality: {
       only_integer: true,
       greater_than: 0

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -20,7 +20,7 @@ class Platform < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
-    allow_blank: true,
+    presence: true,
     numericality: {
       only_integer: true,
       greater_than: 0

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -16,7 +16,7 @@ class Series < ApplicationRecord
 
   validates :wikidata_id,
     uniqueness: true,
-    allow_blank: true,
+    presence: true,
     numericality: {
       only_integer: true,
       greater_than: 0

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -21,14 +21,14 @@ class CompanyPolicy < ApplicationPolicy
     true
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def create?
-    user.present?
+    user_is_moderator_or_admin?
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def update?
-    user.present?
+    user_is_moderator_or_admin?
   end
 
   sig { returns(T.nilable(T::Boolean)) }

--- a/app/policies/engine_policy.rb
+++ b/app/policies/engine_policy.rb
@@ -21,14 +21,14 @@ class EnginePolicy < ApplicationPolicy
     true
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def create?
-    user.present?
+    user_is_moderator_or_admin?
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def update?
-    user.present?
+    user_is_moderator_or_admin?
   end
 
   sig { returns(T.nilable(T::Boolean)) }

--- a/app/policies/series_policy.rb
+++ b/app/policies/series_policy.rb
@@ -21,14 +21,14 @@ class SeriesPolicy < ApplicationPolicy
     true
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def create?
-    user.present?
+    user_is_moderator_or_admin?
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def update?
-    user.present?
+    user_is_moderator_or_admin?
   end
 
   sig { returns(T.nilable(T::Boolean)) }

--- a/app/views/companies/index.html.erb
+++ b/app/views/companies/index.html.erb
@@ -3,7 +3,7 @@
 
 <h1 class="title">Companies</h1>
 
-<% if user_signed_in? %>
+<% if policy(@companies).create? %>
   <p><%= link_to("Create a new company", new_company_path, class: 'button is-fullwidth-mobile mb-10') %></p>
 <% end %>
 

--- a/app/views/series/index.html.erb
+++ b/app/views/series/index.html.erb
@@ -3,7 +3,7 @@
 
 <h1 class="title">Series</h1>
 
-<% if user_signed_in? %>
+<% if policy(@series).create? %>
   <p><%= link_to("Create a new series", new_series_path, class: 'button is-fullwidth-mobile mb-10') %></p>
 <% end %>
 

--- a/db/migrate/20240616170248_require_wikidata_id.rb
+++ b/db/migrate/20240616170248_require_wikidata_id.rb
@@ -1,0 +1,9 @@
+class RequireWikidataId < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :genres, :wikidata_id, false
+    change_column_null :engines, :wikidata_id, false
+    change_column_null :companies, :wikidata_id, false
+    change_column_null :series, :wikidata_id, false
+    change_column_null :platforms, :wikidata_id, false
+  end
+end

--- a/db/migrate/20240616170248_require_wikidata_id.rb
+++ b/db/migrate/20240616170248_require_wikidata_id.rb
@@ -1,3 +1,4 @@
+# typed: true
 class RequireWikidataId < ActiveRecord::Migration[7.1]
   def change
     change_column_null :genres, :wikidata_id, false

--- a/db/seeds/companies.rb
+++ b/db/seeds/companies.rb
@@ -3,6 +3,7 @@ puts "Creating Companies..."
 
 20.times do
   Company.create!(
-    name: Faker::Game.unique.company
+    name: Faker::Game.unique.company,
+    wikidata_id: Faker::Number.unique.number(digits: 6)
   )
 end

--- a/db/seeds/engines.rb
+++ b/db/seeds/engines.rb
@@ -2,5 +2,8 @@
 puts "Creating Engines..."
 
 10.times do
-  Engine.create!(name: Faker::Game.unique.engine)
+  Engine.create!(
+    name: Faker::Game.unique.engine,
+    wikidata_id: Faker::Number.unique.number(digits: 6)
+  )
 end

--- a/db/seeds/genres.rb
+++ b/db/seeds/genres.rb
@@ -4,6 +4,7 @@ puts "Creating Genres..."
 # Create 20 unique genres.
 20.times do
   Genre.create!(
-    name: Faker::Game.unique.genre
+    name: Faker::Game.unique.genre,
+    wikidata_id: Faker::Number.unique.number(digits: 6)
   )
 end

--- a/db/seeds/platforms.rb
+++ b/db/seeds/platforms.rb
@@ -4,6 +4,7 @@ puts "Creating Platforms..."
 # Create 20 Platforms.
 20.times do
   Platform.create!(
-    name: Faker::Game.unique.platform
+    name: Faker::Game.unique.platform,
+    wikidata_id: Faker::Number.unique.number(digits: 6)
   )
 end

--- a/db/seeds/series.rb
+++ b/db/seeds/series.rb
@@ -4,6 +4,7 @@ puts "Creating Series..."
 # Create 20 Series.
 20.times do
   Series.create!(
-    name: Faker::Game.unique.series
+    name: Faker::Game.unique.series,
+    wikidata_id: Faker::Number.unique.number(digits: 6)
   )
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -175,7 +175,7 @@ CREATE TABLE public.companies (
     name text DEFAULT ''::text NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    wikidata_id bigint
+    wikidata_id bigint NOT NULL
 );
 
 
@@ -279,7 +279,7 @@ CREATE TABLE public.engines (
     name text DEFAULT ''::text NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    wikidata_id bigint
+    wikidata_id bigint NOT NULL
 );
 
 
@@ -844,7 +844,7 @@ CREATE TABLE public.genres (
     name text DEFAULT ''::text NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    wikidata_id bigint
+    wikidata_id bigint NOT NULL
 );
 
 
@@ -1167,7 +1167,7 @@ CREATE TABLE public.platforms (
     name text NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    wikidata_id bigint
+    wikidata_id bigint NOT NULL
 );
 
 
@@ -1240,7 +1240,7 @@ CREATE TABLE public.series (
     name text DEFAULT ''::text NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    wikidata_id bigint
+    wikidata_id bigint NOT NULL
 );
 
 
@@ -3084,6 +3084,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240616170248'),
 ('20240615183529'),
 ('20240615182736'),
 ('20240615182019'),

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -2,6 +2,7 @@
 FactoryBot.define do
   factory :company do
     name { "Valve Corporation" }
+    wikidata_id { Faker::Number.number(digits: 6) }
 
     trait :game_as_developer do
       after(:create) { |company| create(:game_developer, company: company) }
@@ -11,10 +12,6 @@ FactoryBot.define do
       after(:create) { |company| create(:game_publisher, company: company) }
     end
 
-    trait :wikidata_id do
-      wikidata_id { Faker::Number.number(digits: 6) }
-    end
-
-    factory :company_with_everything, traits: [:game_as_developer, :game_as_publisher, :wikidata_id]
+    factory :company_with_everything, traits: [:game_as_developer, :game_as_publisher]
   end
 end

--- a/spec/factories/engines.rb
+++ b/spec/factories/engines.rb
@@ -2,15 +2,12 @@
 FactoryBot.define do
   factory :engine do
     name { "Source Engine" }
+    wikidata_id { Faker::Number.number(digits: 6) }
 
     trait :game do
       after(:create) { |engine| create(:game_engine, engine: engine) }
     end
 
-    trait :wikidata_id do
-      wikidata_id { Faker::Number.number(digits: 6) }
-    end
-
-    factory :engine_with_everything, traits: [:game, :wikidata_id]
+    factory :engine_with_everything, traits: [:game]
   end
 end

--- a/spec/factories/genres.rb
+++ b/spec/factories/genres.rb
@@ -2,15 +2,12 @@
 FactoryBot.define do
   factory :genre do
     name { "First-person shooter" }
+    wikidata_id { Faker::Number.number(digits: 6) }
 
     trait :game do
       after(:create) { |genre| create(:game_genre, genre: genre) }
     end
 
-    trait :wikidata_id do
-      wikidata_id { Faker::Number.number(digits: 6) }
-    end
-
-    factory :genre_with_everything, traits: [:game, :wikidata_id]
+    factory :genre_with_everything, traits: [:game]
   end
 end

--- a/spec/factories/platforms.rb
+++ b/spec/factories/platforms.rb
@@ -2,15 +2,12 @@
 FactoryBot.define do
   factory :platform do
     name { "Xbox 360" }
+    wikidata_id { Faker::Number.number(digits: 6) }
 
     trait :game do
       after(:create) { |platform| create(:game_platform, platform: platform) }
     end
 
-    trait :wikidata_id do
-      wikidata_id { Faker::Number.number(digits: 6) }
-    end
-
-    factory :platform_with_everything, traits: [:game, :wikidata_id]
+    factory :platform_with_everything, traits: [:game]
   end
 end

--- a/spec/factories/series.rb
+++ b/spec/factories/series.rb
@@ -2,15 +2,12 @@
 FactoryBot.define do
   factory :series do
     name { "Half-Life" }
+    wikidata_id { Faker::Number.number(digits: 6) }
 
     trait :game do
       after(:create) { |series| create(:game, series: series) }
     end
 
-    trait :wikidata_id do
-      wikidata_id { Faker::Number.number(digits: 6) }
-    end
-
-    factory :series_with_everything, traits: [:game, :wikidata_id]
+    factory :series_with_everything, traits: [:game]
   end
 end

--- a/spec/features/companies_spec.rb
+++ b/spec/features/companies_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Companies", type: :feature do
       visit(new_company_path)
       within('#new_company') do
         fill_in('company[name]', with: 'Half-Life')
+        fill_in('company[wikidata_id]', with: 'Q123')
       end
       click_button 'Submit'
 

--- a/spec/features/companies_spec.rb
+++ b/spec/features/companies_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Companies", type: :feature do
   describe "companies index" do
     let!(:company) { create(:company) }
     let(:user) { create(:confirmed_user) }
+    let(:moderator) { create(:confirmed_moderator) }
 
     it "with no user" do
       visit(companies_path)
@@ -17,6 +18,14 @@ RSpec.describe "Companies", type: :feature do
 
       visit(companies_path)
       expect(page).to have_link(href: company_path(company))
+      expect(page).to have_no_link(href: new_company_path)
+    end
+
+    it "with moderator" do
+      sign_in(moderator)
+
+      visit(companies_path)
+      expect(page).to have_link(href: company_path(company))
       expect(page).to have_link(href: new_company_path)
     end
   end
@@ -24,6 +33,7 @@ RSpec.describe "Companies", type: :feature do
   describe "company page" do
     let!(:company) { create(:company) }
     let(:user) { create(:confirmed_user) }
+    let(:moderator) { create(:confirmed_moderator) }
 
     it "with no user" do
       visit(company_path(company))
@@ -36,12 +46,20 @@ RSpec.describe "Companies", type: :feature do
 
       visit(company_path(company))
       expect(page).to have_content(company.name)
+      expect(page).to have_no_link(href: edit_company_path(company))
+    end
+
+    it "with moderator" do
+      sign_in(moderator)
+
+      visit(company_path(company))
+      expect(page).to have_content(company.name)
       expect(page).to have_link(href: edit_company_path(company))
     end
   end
 
   describe "new company page", js: true do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
 
     it "accepts valid company data" do
       sign_in(user)
@@ -59,7 +77,7 @@ RSpec.describe "Companies", type: :feature do
 
   describe "edit company page", js: true do
     let!(:company) { create(:company) }
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
 
     it "accepts valid company data" do
       sign_in(user)

--- a/spec/features/engines_spec.rb
+++ b/spec/features/engines_spec.rb
@@ -1,0 +1,119 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "Engines", type: :feature do
+  describe "engines index" do
+    let!(:engine) { create(:engine) }
+    let(:user) { create(:confirmed_user) }
+    let(:moderator) { create(:confirmed_moderator) }
+
+    it "with no user" do
+      visit(engines_path)
+      expect(page).to have_link(href: engine_path(engine))
+      expect(page).to have_no_link(href: new_engine_path)
+    end
+
+    it "with user" do
+      sign_in(user)
+
+      visit(engines_path)
+      expect(page).to have_link(href: engine_path(engine))
+      expect(page).to have_no_link(href: new_engine_path)
+    end
+
+    it "with moderator" do
+      sign_in(moderator)
+
+      visit(engines_path)
+      expect(page).to have_link(href: engine_path(engine))
+      expect(page).to have_link(href: new_engine_path)
+    end
+  end
+
+  describe "engine page" do
+    let!(:engine) { create(:engine) }
+    let(:user) { create(:confirmed_user) }
+    let(:moderator) { create(:confirmed_moderator) }
+
+    it "with no user" do
+      visit(engine_path(engine))
+      expect(page).to have_content(engine.name)
+      expect(page).to have_no_link(href: edit_engine_path(engine))
+    end
+
+    it "with user" do
+      sign_in(user)
+
+      visit(engine_path(engine))
+      expect(page).to have_content(engine.name)
+      expect(page).to have_no_link(href: edit_engine_path(engine))
+    end
+
+    it "with moderator" do
+      sign_in(moderator)
+
+      visit(engine_path(engine))
+      expect(page).to have_content(engine.name)
+      expect(page).to have_link(href: edit_engine_path(engine))
+    end
+  end
+
+  describe "new engine page" do
+    let(:moderator) { create(:confirmed_moderator) }
+
+    it "accepts valid engine data" do
+      sign_in(moderator)
+
+      visit(new_engine_path)
+      within('#new_engine') do
+        fill_in('engine[name]', with: 'GoldSrc')
+        fill_in('engine[wikidata_id]', with: 'Q123')
+      end
+      click_button 'Submit'
+
+      expect(page).to have_no_selector('#new_engine')
+    end
+  end
+
+  describe "edit engine page" do
+    let!(:engine) { create(:engine) }
+    let(:moderator) { create(:confirmed_moderator) }
+
+    it "accepts valid engine data" do
+      sign_in(moderator)
+
+      visit(edit_engine_path(engine))
+      within("#edit_engine_#{engine.id}") do
+        fill_in('engine[name]', with: 'GoldSrc')
+      end
+      click_button 'Submit'
+
+      expect(page).to have_current_path(engine_path(engine))
+    end
+  end
+
+  describe "delete engine" do
+    let!(:engine) { create(:engine) }
+    let(:moderator) { create(:confirmed_moderator) }
+    let(:user) { create(:confirmed_user) }
+
+    it "does not let user delete it" do
+      sign_in(user)
+      visit(engine_path(engine))
+
+      expect(page).to have_no_link('Delete')
+    end
+
+    it "lets moderator delete it" do
+      sign_in(moderator)
+      visit(engine_path(engine))
+
+      accept_alert do
+        click_link 'Delete'
+      end
+
+      expect(page).to have_current_path(engines_path)
+      expect(page).to have_no_content(engine.name)
+    end
+  end
+end

--- a/spec/features/genres_spec.rb
+++ b/spec/features/genres_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "Genres", type: :feature do
       visit(new_genre_path)
       within('#new_genre') do
         fill_in('genre[name]', with: 'FPS')
+        fill_in('genre[wikidata_id]', with: 'Q123')
       end
       click_button 'Submit'
 

--- a/spec/features/platforms_spec.rb
+++ b/spec/features/platforms_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "Platforms", type: :feature do
       visit(new_platform_path)
       within('#new_platform') do
         fill_in('platform[name]', with: 'Nintendo Switch')
+        fill_in('platform[wikidata_id]', with: 'Q123')
       end
       click_button 'Submit'
 

--- a/spec/features/series_spec.rb
+++ b/spec/features/series_spec.rb
@@ -1,0 +1,119 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "Series", type: :feature do
+  describe "series index" do
+    let!(:series) { create(:series) }
+    let(:user) { create(:confirmed_user) }
+    let(:moderator) { create(:confirmed_moderator) }
+
+    it "with no user" do
+      visit(series_index_path)
+      expect(page).to have_link(href: series_path(series))
+      expect(page).to have_no_link(href: new_series_path)
+    end
+
+    it "with user" do
+      sign_in(user)
+
+      visit(series_index_path)
+      expect(page).to have_link(href: series_path(series))
+      expect(page).to have_no_link(href: new_series_path)
+    end
+
+    it "with moderator" do
+      sign_in(moderator)
+
+      visit(series_index_path)
+      expect(page).to have_link(href: series_path(series))
+      expect(page).to have_link(href: new_series_path)
+    end
+  end
+
+  describe "series page" do
+    let!(:series) { create(:series) }
+    let(:user) { create(:confirmed_user) }
+    let(:moderator) { create(:confirmed_moderator) }
+
+    it "with no user" do
+      visit(series_path(series))
+      expect(page).to have_content(series.name)
+      expect(page).to have_no_link(href: edit_series_path(series))
+    end
+
+    it "with user" do
+      sign_in(user)
+
+      visit(series_path(series))
+      expect(page).to have_content(series.name)
+      expect(page).to have_no_link(href: edit_series_path(series))
+    end
+
+    it "with moderator" do
+      sign_in(moderator)
+
+      visit(series_path(series))
+      expect(page).to have_content(series.name)
+      expect(page).to have_link(href: edit_series_path(series))
+    end
+  end
+
+  describe "new series page" do
+    let(:moderator) { create(:confirmed_moderator) }
+
+    it "accepts valid series data" do
+      sign_in(moderator)
+
+      visit(new_series_path)
+      within('#new_series') do
+        fill_in('series[name]', with: 'Half-Life')
+        fill_in('series[wikidata_id]', with: 'Q123')
+      end
+      click_button 'Submit'
+
+      expect(page).to have_no_selector('#new_series')
+    end
+  end
+
+  describe "edit series page" do
+    let!(:series) { create(:series) }
+    let(:moderator) { create(:confirmed_moderator) }
+
+    it "accepts valid series data" do
+      sign_in(moderator)
+
+      visit(edit_series_path(series))
+      within("#edit_series_#{series.id}") do
+        fill_in('series[name]', with: 'Half-Life')
+      end
+      click_button 'Submit'
+
+      expect(page).to have_current_path(series_path(series))
+    end
+  end
+
+  describe "delete series" do
+    let!(:series) { create(:series) }
+    let(:moderator) { create(:confirmed_moderator) }
+    let(:user) { create(:confirmed_user) }
+
+    it "does not let user delete it" do
+      sign_in(user)
+      visit(series_path(series))
+
+      expect(page).to have_no_link('Delete')
+    end
+
+    it "lets moderator delete it" do
+      sign_in(moderator)
+      visit(series_path(series))
+
+      accept_alert do
+        click_link 'Delete'
+      end
+
+      expect(page).to have_current_path(series_index_path)
+      expect(page).to have_no_content(series.name)
+    end
+  end
+end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Company, type: :model do
     it { should validate_length_of(:name).is_at_most(120) }
 
     it { should validate_uniqueness_of(:wikidata_id) }
+    it { should validate_presence_of(:wikidata_id) }
     it 'validates numericality' do
       expect(company).to validate_numericality_of(:wikidata_id)
         .only_integer
-        .allow_nil
         .is_greater_than(0)
     end
   end

--- a/spec/models/engine_spec.rb
+++ b/spec/models/engine_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Engine, type: :model do
     it { should validate_length_of(:name).is_at_most(120) }
 
     it { should validate_uniqueness_of(:wikidata_id) }
+    it { should validate_presence_of(:wikidata_id) }
     it 'validates numericality' do
       expect(engine).to validate_numericality_of(:wikidata_id)
         .only_integer
-        .allow_nil
         .is_greater_than(0)
     end
   end

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Genre, type: :model do
     it { should validate_length_of(:name).is_at_most(120) }
 
     it { should validate_uniqueness_of(:wikidata_id) }
+    it { should validate_presence_of(:wikidata_id) }
     it 'validates numericality' do
       expect(genre).to validate_numericality_of(:wikidata_id)
         .only_integer
-        .allow_nil
         .is_greater_than(0)
     end
   end

--- a/spec/models/platform_spec.rb
+++ b/spec/models/platform_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Platform, type: :model do
     it { should validate_length_of(:name).is_at_most(120) }
 
     it { should validate_uniqueness_of(:wikidata_id) }
+    it { should validate_presence_of(:wikidata_id) }
     it 'validates numericality' do
       expect(platform).to validate_numericality_of(:wikidata_id)
         .only_integer
-        .allow_nil
         .is_greater_than(0)
     end
   end

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Series, type: :model do
     it { should validate_length_of(:name).is_at_most(120) }
 
     it { should validate_uniqueness_of(:wikidata_id) }
+    it { should validate_presence_of(:wikidata_id) }
     it 'validates numericality' do
       expect(series).to validate_numericality_of(:wikidata_id)
         .only_integer
-        .allow_nil
         .is_greater_than(0)
     end
   end

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -8,14 +8,16 @@ RSpec.describe CompanyPolicy, type: :policy do
     let(:user) { create(:user) }
     let(:company) { create(:company) }
 
-    it "let's a user do everything except destroy the company" do
+    it "let's a normal user list, show, and search companies" do
       expect(company_policy).to permit_actions(
-        [:index, :show, :create, :new, :edit, :update, :search]
+        [:index, :show, :search]
       )
     end
 
-    it 'does not let a user destroy companies' do
-      expect(company_policy).to forbid_action(:destroy)
+    it "doesn't let a normal user create, update, or destroy companies" do
+      expect(company_policy).to forbid_actions(
+        [:create, :new, :edit, :update, :destroy]
+      )
     end
   end
 

--- a/spec/policies/engine_policy_spec.rb
+++ b/spec/policies/engine_policy_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe EnginePolicy, type: :policy do
     let(:user) { create(:user) }
     let(:engine) { create(:engine) }
 
-    it 'permits everything but deletion' do
+    it "let's a normal user list, show, and search engines" do
       expect(engine_policy).to permit_actions(
-        [:index, :show, :create, :new, :edit, :update, :search]
+        [:index, :show, :search]
       )
     end
 
-    it "doesn't allow deleting an engine" do
+    it "doesn't let a normal user create, update, or destroy engines" do
       expect(engine_policy).to forbid_actions(
-        [:destroy]
+        [:create, :new, :edit, :update, :destroy]
       )
     end
   end

--- a/spec/policies/series_policy_spec.rb
+++ b/spec/policies/series_policy_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe SeriesPolicy, type: :policy do
     let(:user) { create(:user) }
     let(:series) { create(:series) }
 
-    it 'permits everything but deletion' do
+    it "let's a normal user list, show, and search series'" do
       expect(series_policy).to permit_actions(
-        [:index, :show, :create, :new, :edit, :update, :search]
+        [:index, :show, :search]
       )
     end
 
-    it "doesn't allow deleting a series" do
+    it "doesn't let a normal user create, update, or destroy series'" do
       expect(series_policy).to forbid_actions(
-        [:destroy]
+        [:create, :new, :edit, :update, :destroy]
       )
     end
   end

--- a/spec/requests/api/mutations/companies/create_company_spec.rb
+++ b/spec/requests/api/mutations/companies/create_company_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "CreateCompany Mutation API", type: :request do
       GRAPHQL
     end
 
-    [:user, :moderator, :admin].each do |role|
+    [:moderator, :admin].each do |role|
       context "when the current user is a(n) #{role}" do
         let(:user) { create("confirmed_#{role}".to_sym) }
 
@@ -38,6 +38,17 @@ RSpec.describe "CreateCompany Mutation API", type: :request do
             }
           )
         end
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not create a new company" do
+        expect do
+          result = api_request(query_string, variables: { name: 'Electronic Arts', wikidata_id: 123 }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to create a company.")
+        end.not_to change(Company, :count)
       end
     end
   end

--- a/spec/requests/api/mutations/companies/update_company_spec.rb
+++ b/spec/requests/api/mutations/companies/update_company_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "UpdateCompany Mutation API", type: :request do
       GRAPHQL
     end
 
-    [:user, :moderator, :admin].each do |role|
+    [:moderator, :admin].each do |role|
       context "when the current user is a(n) #{role}" do
         let(:user) { create("confirmed_#{role}".to_sym) }
 
@@ -42,6 +42,17 @@ RSpec.describe "UpdateCompany Mutation API", type: :request do
           expect(company.reload.name).to eq('Nintendo')
           expect(company.reload.wikidata_id).to eq(123)
         end
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not update the company" do
+        expect do
+          result = api_request(query_string, variables: { company_id: company.id, name: 'Electronic Arts', wikidata_id: 123 }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to update this company.")
+        end.not_to change(company.reload, :name).from('Valve Corporation')
       end
     end
   end

--- a/spec/requests/api/mutations/engines/create_engine_spec.rb
+++ b/spec/requests/api/mutations/engines/create_engine_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "CreateEngine Mutation API", type: :request do
       GRAPHQL
     end
 
-    [:user, :moderator, :admin].each do |role|
+    [:moderator, :admin].each do |role|
       context "when the current user is a(n) #{role}" do
         let(:user) { create("confirmed_#{role}".to_sym) }
 
@@ -38,6 +38,17 @@ RSpec.describe "CreateEngine Mutation API", type: :request do
             }
           )
         end
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not create a new engine" do
+        expect do
+          result = api_request(query_string, variables: { name: 'GoldSrc', wikidata_id: 123 }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to create an engine.")
+        end.not_to change(Engine, :count)
       end
     end
   end

--- a/spec/requests/api/mutations/engines/update_engine_spec.rb
+++ b/spec/requests/api/mutations/engines/update_engine_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "UpdateEngine Mutation API", type: :request do
       GRAPHQL
     end
 
-    [:user, :moderator, :admin].each do |role|
+    [:moderator, :admin].each do |role|
       context "when the current user is a(n) #{role}" do
         let(:user) { create("confirmed_#{role}".to_sym) }
 
@@ -42,6 +42,17 @@ RSpec.describe "UpdateEngine Mutation API", type: :request do
           expect(engine.reload.name).to eq('GoldSrc')
           expect(engine.reload.wikidata_id).to eq(123)
         end
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not update the engine" do
+        expect do
+          result = api_request(query_string, variables: { engine_id: engine.id, name: 'GoldSrc', wikidata_id: 123 }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to update this engine.")
+        end.not_to change(engine.reload, :name).from('Source Engine')
       end
     end
   end

--- a/spec/requests/api/mutations/series/create_series_spec.rb
+++ b/spec/requests/api/mutations/series/create_series_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "CreateSeries Mutation API", type: :request do
       GRAPHQL
     end
 
-    [:user, :moderator, :admin].each do |role|
+    [:moderator, :admin].each do |role|
       context "when the current user is a(n) #{role}" do
         let(:user) { create("confirmed_#{role}".to_sym) }
 
@@ -38,6 +38,17 @@ RSpec.describe "CreateSeries Mutation API", type: :request do
             }
           )
         end
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not create a new series" do
+        expect do
+          result = api_request(query_string, variables: { name: 'Portal', wikidata_id: 123 }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to create a series.")
+        end.not_to change(Series, :count)
       end
     end
   end

--- a/spec/requests/api/mutations/series/update_series_spec.rb
+++ b/spec/requests/api/mutations/series/update_series_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "UpdateSeries Mutation API", type: :request do
       GRAPHQL
     end
 
-    [:user, :moderator, :admin].each do |role|
+    [:moderator, :admin].each do |role|
       context "when the current user is a(n) #{role}" do
         let(:user) { create("confirmed_#{role}".to_sym) }
 
@@ -42,6 +42,17 @@ RSpec.describe "UpdateSeries Mutation API", type: :request do
           expect(series.reload.name).to eq('Portal')
           expect(series.reload.wikidata_id).to eq(123)
         end
+      end
+    end
+
+    context 'when the current user is a normal member' do
+      let(:user) { create(:confirmed_user) }
+
+      it "does not update the series" do
+        expect do
+          result = api_request(query_string, variables: { series_id: series.id, name: 'Portal', wikidata_id: 123 }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to update this series.")
+        end.not_to change(series.reload, :name).from('Half-Life')
       end
     end
   end

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Companies", type: :request do
   end
 
   describe "GET new_company_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
 
     it "returns http success" do
       sign_in(user)
@@ -35,7 +35,7 @@ RSpec.describe "Companies", type: :request do
   end
 
   describe "GET edit_company_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let(:company) { create(:company) }
     let(:company_with_everything) { create(:company_with_everything) }
 
@@ -53,7 +53,7 @@ RSpec.describe "Companies", type: :request do
   end
 
   describe "POST companies_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let(:company_attributes) { attributes_for(:company) }
 
     it "creates a new company" do
@@ -73,7 +73,7 @@ RSpec.describe "Companies", type: :request do
   end
 
   describe "PUT company_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let!(:company) { create(:company) }
     let(:company_attributes) { attributes_for(:company) }
 

--- a/spec/requests/engines_spec.rb
+++ b/spec/requests/engines_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Engines", type: :request do
   end
 
   describe "GET new_engine_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
 
     it "returns http success" do
       sign_in(user)
@@ -36,7 +36,7 @@ RSpec.describe "Engines", type: :request do
   end
 
   describe "GET edit_engine_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let(:engine) { create(:engine) }
 
     it "returns http success" do
@@ -48,7 +48,7 @@ RSpec.describe "Engines", type: :request do
   end
 
   describe "POST engines_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let(:engine_attributes) { attributes_for(:engine) }
 
     it "creates a new engine" do
@@ -68,7 +68,7 @@ RSpec.describe "Engines", type: :request do
   end
 
   describe "PUT engine_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let!(:engine) { create(:engine) }
     let(:engine_attributes) { attributes_for(:engine) }
 

--- a/spec/requests/series_spec.rb
+++ b/spec/requests/series_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Series", type: :request do
   end
 
   describe "GET new_series_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
 
     it "returns http success" do
       sign_in(user)
@@ -35,7 +35,7 @@ RSpec.describe "Series", type: :request do
   end
 
   describe "GET edit_series_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let(:series) { create(:series) }
     let(:series_with_everything) { create(:series_with_everything) }
 
@@ -53,7 +53,7 @@ RSpec.describe "Series", type: :request do
   end
 
   describe "POST series_index_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let(:series_attributes) { attributes_for(:series) }
 
     it "creates a new series" do
@@ -73,7 +73,7 @@ RSpec.describe "Series", type: :request do
   end
 
   describe "PUT series_path" do
-    let(:user) { create(:confirmed_user) }
+    let(:user) { create(:confirmed_moderator) }
     let!(:series) { create(:series) }
     let(:series_attributes) { attributes_for(:series) }
 


### PR DESCRIPTION
Some of these already had restricted editing/creation, there's not really any reason to allow most of these to be editable.

Resolves most of #3733.