### PR TITLE
Update CI Dockerfile to Ruby 3.3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ FROM ruby:3.3.9
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg > /dev/null
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /usr/share/keyrings/google.gpg > /dev/null && echo "deb [signed-by=/usr/share/keyrings/google.gpg] https://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list
+RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /usr/share/keyrings/chrome.gpg > /dev/null
+RUN echo "deb [signed-by=/usr/share/keyrings/chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update -qqy && apt-get install -qqyy google-chrome-stable yarn nodejs postgresql postgresql-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Dockerfile for running the application in a CI environment.
-FROM ruby:3.3.1
+FROM ruby:3.3.9
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg > /dev/null
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && echo "deb https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+RUN echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /usr/share/keyrings/google.gpg > /dev/null && echo "deb [signed-by=/usr/share/keyrings/google.gpg] https://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update -qqy && apt-get install -qqyy google-chrome-stable yarn nodejs postgresql postgresql-client

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -122,6 +122,7 @@ Capybara.register_driver :ci_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
   options.add_argument('--headless')
   options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
 
   Capybara::Selenium::Driver.new app,
     browser: :chrome,


### PR DESCRIPTION
This updates the Dockerfile to Ruby 3.3.9 and Debian Trixie.

Also needed to add this command line flag to Chrome when running it in CI: `options.add_argument('--disable-dev-shm-usage')`

I guess we were running out of disk space or something, no idea why it wasn't a problem with the old docker image ¯\_(ツ)_/¯