### PR TITLE
Fix SPARQL queries to support mul labels

### DIFF
--- a/lib/tasks/import/update.rake
+++ b/lib/tasks/import/update.rake
@@ -122,7 +122,7 @@ namespace :import do
       {
         ?item wdt:P31 wd:Q7889; # instance of video game
               wdt:P179 ?series. # in a series
-        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en,mul". }
       }
     SPARQL
 
@@ -182,7 +182,7 @@ namespace :import do
         include %i
         ?item wdt:#{property} ?p1.
         bind(strafter(str(?p1), "http://www.wikidata.org/entity/") as ?prop)
-        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en,mul". }
       } GROUP BY ?item ?itemLabel
     SPARQL
 

--- a/lib/tasks/import/wikidata_import.rake
+++ b/lib/tasks/import/wikidata_import.rake
@@ -295,10 +295,10 @@ namespace 'import:wikidata' do
       start_from = index * 48
       wikidata_labels = WikidataHelper.get_labels(
         ids: wikidata_ids[start_from..start_from + 48],
-        languages: 'en'
+        languages: ['en', 'mul']
       )
       wikidata_labels.each do |id, wikidata_label|
-        name = wikidata_label.dig('labels', 'en', 'value')
+        name = wikidata_label.dig('labels', 'en', 'value') || wikidata_label.dig('labels', 'mul', 'value')
         # Skip items with no labels or no English label.
         wikidata_item = { wikidata_id: id, name: name } unless name.nil?
         items << wikidata_item if wikidata_item

--- a/lib/tasks/import/wikidata_import_games.rake
+++ b/lib/tasks/import/wikidata_import_games.rake
@@ -344,14 +344,17 @@ namespace 'import:wikidata' do
     progress_bar.finish unless progress_bar.finished?
   end
 
-  # The SPARQL query for getting all video games with English labels on Wikidata.
+  # The SPARQL query for getting all video games with English or mul labels on Wikidata.
   def games_query
     <<-SPARQL
       SELECT ?item WHERE {
         VALUES ?videoGameTypes { wd:Q7889 wd:Q21125433 }.
         ?item wdt:P31 ?videoGameTypes; # Instances of 'video games' or 'free or open source video games'.
-              rdfs:label ?label filter(lang(?label) = "en"). # with a label
+              rdfs:label ?label .
+          FILTER(lang(?label) = "en" || lang(?label) = "mul") # with a mul or en label
       }
+      GROUP BY ?item
+      HAVING (COUNT(?label) > 0)
     SPARQL
   end
 
@@ -363,10 +366,11 @@ namespace 'import:wikidata' do
         VALUES ?videoGameTypes { wd:Q7889 wd:Q21125433 }.
         ?item wdt:P31 ?videoGameTypes; # items that are video games
               p:P577 ?releaseDateStatement; # items with a publication date.
-              rdfs:label ?label filter(lang(?label) = "en"). # with a label
+              rdfs:label ?label .
+        FILTER(lang(?label) = "en" || lang(?label) = "mul") # with a mul or en label
         ?releaseDateStatement a wikibase:BestRank; # ... of best rank (instead of wdt:P577)
             psv:P577 / wikibase:timePrecision 11 . # Precision is "day" (encoded as integer 11)
-        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en,mul". }
       }
     SPARQL
   end


### PR DESCRIPTION
`mul` is for multi-language labels, and some items will have `mul` labels but not english labels. As such, we should support mul. Fixes #3978