### PR TITLE
Enable most Rails 7.2 framework defaults.

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -32,15 +32,7 @@
 # backends that use the same database as Active Record as a queue, hence they
 # don't need this feature.
 #++
-# Rails.application.config.active_job.enqueue_after_transaction_commit = :default
-
-###
-# Adds image/webp to the list of content types Active Storage considers as an image
-# Prevents automatic conversion to a fallback PNG, and assumes clients support WebP, as they support gif, jpeg, and png.
-# This is possible due to broad browser support for WebP, but older browsers and email clients may still not support
-# WebP. Requires imagemagick/libvips built with WebP support.
-#++
-# Rails.application.config.active_storage.web_image_content_types = %w[image/png image/jpeg image/gif image/webp]
+Rails.application.config.active_job.enqueue_after_transaction_commit = :default
 
 ###
 # Enable validation of migration timestamps. When set, an ActiveRecord::InvalidMigrationTimestampError
@@ -51,7 +43,7 @@
 # Applications with existing timestamped migrations that do not adhere to the
 # expected format can disable validation by setting this config to `false`.
 #++
-# Rails.application.config.active_record.validate_migration_timestamps = true
+Rails.application.config.active_record.validate_migration_timestamps = true
 
 ###
 # Controls whether the PostgresqlAdapter should decode dates automatically with manual queries.
@@ -61,10 +53,12 @@
 #
 # This query used to return a `String`.
 #++
-# Rails.application.config.active_record.postgresql_adapter_decode_dates = true
+Rails.application.config.active_record.postgresql_adapter_decode_dates = true
 
 ###
 # Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are
 # deploying to a memory constrained environment you may want to set this to `false`.
 #++
+# NOTE: May not want to do this on DigitalOcean? It doesn't have tons of memory.
+# May need to explicitly disable this in application.rb.
 # Rails.application.config.yjit = true


### PR DESCRIPTION
Remove webp config upgrade. We already have this configured as disabled, as ImageMagick has not been built to support it on production at present.

I am going to leave YJIT disabled both because I don't believe we've been building ruby with it _and_ the production server doesn't have tons of memory.