### PR TITLE
Remove Faker::Image (unsplash no longer works)

### DIFF
--- a/config/initializers/faker.rb
+++ b/config/initializers/faker.rb
@@ -18,16 +18,5 @@ if defined?(Faker)
         fetch('game.store')
       end
     end
-
-    # Add a custom image faker.
-    class Image < Faker::Base
-      def self.unsplash(category: nil, width: 400, height: 400, keyword: nil)
-        url = 'https://source.unsplash.com'
-        url += "/category/#{category}" unless category.nil?
-        url += "/#{width}x#{height}"
-        url += "?#{keyword}" unless keyword.nil?
-        url
-      end
-    end
   end
 end


### PR DESCRIPTION
## Summary
- Removes the custom `Faker::Image` class from `config/initializers/faker.rb` that generated URLs using `source.unsplash.com`, which is no longer available.
- The class was defined but not referenced anywhere else in the codebase.

Fixes #4439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)