### PR TITLE
Remove spec:fast rake task

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-namespace :spec do
-  desc "Run the rspec test suite without the feature specs."
-  task fast: :environment do
-    puts 'bundle exec rspec --exclude-pattern "spec/features/**/*_spec.rb"'
-    system('bundle exec rspec --exclude-pattern "spec/features/**/*_spec.rb"')
-  end
-end


### PR DESCRIPTION
## Summary

Removes the `spec:fast` rake task (`lib/tasks/spec.rake`), which simply ran `rspec --exclude-pattern "spec/features/**/*_spec.rb"`. This can be run directly without a wrapper task, making it unnecessary.

Fixes #4444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)