### PR TITLE
Add Claude Code skill file for Lucide icon usage

### DIFF
--- a/.claude/skills/icons.md
+++ b/.claude/skills/icons.md
@@ -1,0 +1,19 @@
+# Icons Skill
+
+When adding icons to the vglist frontend, follow these rules:
+
+## Rules
+
+1. **Always use Lucide icons** from `lucide-vue-next`. Never create custom SVG icon components or use inline `<svg>` elements for icons.
+2. **Import icons by name** directly from `lucide-vue-next`:
+   ```vue
+   import { Search, ChevronRight, Trash2 } from "lucide-vue-next";
+   ```
+3. **Use icons in templates** as Vue components:
+   ```vue
+   <Search :size="20" />
+   ```
+4. **Browse available icons** at https://lucide.dev/icons/ — search by concept (e.g. "delete", "settings", "user") to find the right icon name.
+5. **Allowed SVG exceptions**: The vglist logo files (`vglist-logo.svg`, `vglist-favicon.svg`, `safari-pinned-tab.svg`) are brand assets and should remain as SVGs. Custom data visualizations (like the rating circle in `GameDetailsSection.vue`) that use dynamic SVG with computed attributes are also fine.
+6. **Do not** use Font Awesome, Material Icons, Heroicons, or any other icon library.
+7. **Size and styling**: Pass `size` as a prop for pixel dimensions. Use CSS classes or Bulma utility classes for color/spacing.

--- a/.claude/skills/icons/SKILL.md
+++ b/.claude/skills/icons/SKILL.md
@@ -1,4 +1,9 @@
-# Icons Skill
+---
+name: icons
+description: How to add icons to the vglist frontend using Lucide via lucide-vue-next. Use when adding, replacing, or reviewing icon usage in Vue components.
+---
+
+# Icons
 
 When adding icons to the vglist frontend, follow these rules:
 


### PR DESCRIPTION
## Summary

Closes #4445. Audited the codebase for remaining custom SVGs — all UI icons already use `lucide-vue-next`. The only SVGs left are brand assets (logo/favicon) and the rating-circle data visualization, which are intentional exceptions.

Adds a `.claude/skills/icons.md` skill file that teaches Claude Code how to add icons following project conventions (import patterns, usage examples, allowed exceptions).

## Test plan

- [ ] Verify the skill file renders correctly and contains accurate guidance
- [ ] Confirm no custom SVG icons remain in the codebase (only brand assets and data visualizations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)