### PR TITLE
De-dupe game cards: use GameCard component in UserFavoritesPage

### DIFF
--- a/frontend/src/pages/activity/ActivityPage.vue
+++ b/frontend/src/pages/activity/ActivityPage.vue
@@ -518,12 +518,14 @@ async function confirmDeleteEvent() {
 
 .a-verb {
   color: var(--color-text-secondary);
+  vertical-align: middle;
 }
 
 .a-game-link {
   color: var(--color-accent);
   text-decoration: none;
   font-weight: 500;
+  vertical-align: middle;
 }
 
 .a-game-link:hover {

--- a/frontend/src/pages/users/UserFavoritesPage.vue
+++ b/frontend/src/pages/users/UserFavoritesPage.vue
@@ -18,21 +18,7 @@
 
       <div class="columns is-multiline">
         <div v-for="game in favoritedGames" :key="game.id" class="column is-2">
-          <div class="card">
-            <div v-if="game.coverUrl" class="card-image">
-              <figure class="image is-3by4">
-                <img :src="game.coverUrl" :alt="game.name" />
-              </figure>
-            </div>
-            <div v-else class="card-image">
-              <div class="game-cover-placeholder">
-                <span>{{ gameInitials(game.name) }}</span>
-              </div>
-            </div>
-            <div class="card-content p-3">
-              <p class="has-text-centered">{{ game.name }}</p>
-            </div>
-          </div>
+          <GameCard :id="game.id" :name="game.name" :cover-url="game.coverUrl ?? null" />
         </div>
       </div>
     </div>
@@ -45,6 +31,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useQuery } from "@/composables/useGraphQL";
 import { GET_USER } from "@/graphql/queries/users";
 import type { GetUserQuery } from "@/types/graphql";
+import GameCard from "@/components/GameCard.vue";
 
 const route = useRoute("userFavorites");
 const router = useRouter();
@@ -61,32 +48,4 @@ watch([data, error, loading], () => {
 
 const user = computed(() => data.value?.user ?? null);
 const favoritedGames = computed(() => user.value?.favoritedGames?.nodes ?? []);
-
-function gameInitials(name: string): string {
-  return name
-    .split(/[\s:]+/)
-    .filter((w) => w.length > 0)
-    .slice(0, 3)
-    .map((w) => w[0].toUpperCase())
-    .join("");
-}
 </script>
-
-<style scoped>
-.game-cover-placeholder {
-  aspect-ratio: 3 / 4;
-  background: linear-gradient(135deg, #e879a0 0%, #c266d6 50%, #7c5ce7 100%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  user-select: none;
-  cursor: default;
-}
-
-.game-cover-placeholder span {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: #fff;
-  letter-spacing: 0.05em;
-}
-</style>


### PR DESCRIPTION
## Summary
- Replace inline card HTML in `UserFavoritesPage` with the existing `GameCard` component, removing duplicate markup, a duplicate `gameInitials()` function, and duplicate placeholder styles (-43 lines, +2 lines)
- Favorite games are now clickable and link to their game pages, matching every other page that uses `GameCard`

Closes #4450

## Test plan
- [ ] Visit a user's favorites page (`/users/:slug/favorites`) and verify game cards render correctly with cover images and placeholders
- [ ] Click a game card and verify it navigates to the correct game page
- [ ] Verify hover effects (lift + shadow) match other pages using `GameCard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)