### PR TITLE
Set up Sentry SDK on the Vue 3 frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "codegen": "graphql-codegen && oxfmt && oxfmt"
   },
   "dependencies": {
+    "@sentry/vue": "^10.48.0",
     "bulma": "^1.0.4",
     "graphql": "^16.13.1",
     "graphql-request": "^7.4.0",

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -9,6 +9,7 @@ declare module "*.vue" {
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_APP_TITLE: string;
+  readonly VITE_SENTRY_DSN?: string;
 }
 
 interface ImportMeta {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,11 +1,19 @@
 import { createApp } from "vue";
 import { createPinia } from "pinia";
+import * as Sentry from "@sentry/vue";
 import App from "./App.vue";
 import router from "./router";
 
 import "./assets/stylesheets/application.scss";
 
 const app = createApp(App);
+
+Sentry.init({
+  app,
+  dsn: import.meta.env.VITE_SENTRY_DSN,
+  integrations: [Sentry.browserTracingIntegration({ router })],
+  enabled: !!import.meta.env.VITE_SENTRY_DSN
+});
 
 app.use(createPinia());
 app.use(router);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1370,6 +1370,60 @@
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz#10324e74cb3396cb7b616042ea7e9e6aa7d8d458"
   integrity sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==
 
+"@sentry-internal/browser-utils@10.48.0":
+  version "10.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-10.48.0.tgz#e3901479410580a5eaf117232da2191edcb7ea38"
+  integrity sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA==
+  dependencies:
+    "@sentry/core" "10.48.0"
+
+"@sentry-internal/feedback@10.48.0":
+  version "10.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-10.48.0.tgz#9c34bf39a41fad49f88a8f4d33009df019b9d609"
+  integrity sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ==
+  dependencies:
+    "@sentry/core" "10.48.0"
+
+"@sentry-internal/replay-canvas@10.48.0":
+  version "10.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-10.48.0.tgz#5156b40f9df7e520eb1cef789725ef30d46246d4"
+  integrity sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q==
+  dependencies:
+    "@sentry-internal/replay" "10.48.0"
+    "@sentry/core" "10.48.0"
+
+"@sentry-internal/replay@10.48.0":
+  version "10.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-10.48.0.tgz#09794a7a6b1127829fae02cad58428b547d14131"
+  integrity sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA==
+  dependencies:
+    "@sentry-internal/browser-utils" "10.48.0"
+    "@sentry/core" "10.48.0"
+
+"@sentry/browser@10.48.0":
+  version "10.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-10.48.0.tgz#45896eb9176ad0ad0a0281674db3db994f614bee"
+  integrity sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==
+  dependencies:
+    "@sentry-internal/browser-utils" "10.48.0"
+    "@sentry-internal/feedback" "10.48.0"
+    "@sentry-internal/replay" "10.48.0"
+    "@sentry-internal/replay-canvas" "10.48.0"
+    "@sentry/core" "10.48.0"
+
+"@sentry/core@10.48.0":
+  version "10.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.48.0.tgz#ee5ab1aa5bbc3f96fe675af3b929c9446d1ee298"
+  integrity sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==
+
+"@sentry/vue@^10.48.0":
+  version "10.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/vue/-/vue-10.48.0.tgz#b9793d74cafb011fb92217dcfaeae9744a75e847"
+  integrity sha512-gZa3i3lLe0nqkSI2Nbh16nDxRHvkZS8x8p9+doVhtRNb1PQ8CQke/tzOYbyUk1iec+HNkT5hPyieVjFk683eCQ==
+  dependencies:
+    "@sentry/browser" "10.48.0"
+    "@sentry/core" "10.48.0"
+
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"


### PR DESCRIPTION
## Summary
- Adds `@sentry/vue` (v10.48.0) and initializes Sentry in `frontend/src/main.ts` with `browserTracingIntegration` wired to Vue Router for automatic route-change performance tracking.
- Sentry is configured via the `VITE_SENTRY_DSN` environment variable and stays disabled when the DSN is not set, so local dev is unaffected.
- Adds the `VITE_SENTRY_DSN` type to `ImportMetaEnv` in `env.d.ts`.

Closes #4449

## Test plan
- [ ] Verify `yarn run typecheck`, `yarn run lint`, `yarn run fmt:check`, and `yarn run test` all pass
- [ ] Confirm the app starts normally in dev without `VITE_SENTRY_DSN` set (Sentry should be disabled)
- [ ] Set `VITE_SENTRY_DSN` to a valid DSN and verify errors are reported to Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)