### PR TITLE
Fix favicon not showing in the Vite frontend site

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vglist-favicon.svg" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>vglist</title>
   </head>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig(({ mode }) => {
   const vitePort = Number(env.VITE_PORT ?? 5173);
 
   return {
+    // Serve files from the root public/ directory (favicons, manifest, etc.)
+    // so they're available at / in both dev and production builds.
+    publicDir: resolve(__dirname, "../public"),
     plugins: [vue()],
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- Configure Vite's `publicDir` to point at the root `public/` directory, where all the favicon files already live. Previously it defaulted to `frontend/public/` which doesn't exist, so the favicon was never served.
- Add PNG fallback icons, apple-touch-icon, and webmanifest links to `index.html` for broader browser compatibility.

Closes #4458

## Test plan
- [ ] Start the Vite dev server and verify the favicon appears in Firefox and Chrome
- [ ] Run `yarn build` and confirm favicon files are present in `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)