### PR TITLE
Fix N+1 queries in GraphQL resolvers and types

### DIFF
--- a/app/graphql/resolvers/game_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/game_resolvers/search_resolver.rb
@@ -11,6 +11,8 @@ module Resolvers
 
       def resolve(query:)
         Game.search(query)
+            .includes(:series, :developers, :publishers, :engines, :genres, :platforms, :steam_app_ids)
+            .with_attached_cover
       end
     end
   end

--- a/app/graphql/resolvers/user_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/user_resolvers/list_resolver.rb
@@ -11,7 +11,7 @@ module Resolvers
 
       def resolve(sort_by: nil)
         # Exclude banned users from the results.
-        users = User.all.where(banned: false)
+        users = User.all.where(banned: false).with_attached_avatar
 
         sort_by.nil? ? users.order(:id) : users.public_send(sort_by.to_sym)
       end

--- a/app/graphql/resolvers/user_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/user_resolvers/search_resolver.rb
@@ -10,7 +10,7 @@ module Resolvers
       argument :query, String, required: true, description: "Username to search by."
 
       def resolve(query:)
-        User.search(query)
+        User.search(query).with_attached_avatar
       end
     end
   end

--- a/app/graphql/types/game_type.rb
+++ b/app/graphql/types/game_type.rb
@@ -40,7 +40,7 @@ module Types
 
     # Get the number of purchases for the game where rating is not nil.
     def rating_count
-      @object.game_purchases.where.not(rating: nil).count
+      rating_count_map[@object.id] || 0
     end
 
     # Get the Steam App ID values as an array.
@@ -86,6 +86,13 @@ module Types
     def favorited_game_ids
       @context[:current_user_favorited_game_ids] ||=
         @context[:current_user].favorite_games.pluck(:game_id).to_set
+    end
+
+    # Cache rating counts for all games in a single GROUP BY query so
+    # rating_count doesn't fire a separate COUNT per game.
+    def rating_count_map
+      @context[:game_rating_count_map] ||=
+        GamePurchase.where.not(rating: nil).group(:game_id).count
     end
   end
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -75,10 +75,17 @@ module Types
     def followed?
       return nil if @context[:current_user].nil? || @context[:current_user].id == @object.id
 
-      @context[:current_user].following.exists?(id: @object.id)
+      followed_user_ids.include?(@object.id)
     end
 
     private
+
+    # Cache the current user's followed user IDs for the duration of the
+    # request, so isFollowed doesn't fire a separate EXISTS query per user.
+    def followed_user_ids
+      @context[:current_user_followed_user_ids] ||=
+        @context[:current_user].following.pluck(:id).to_set
+    end
 
     def user_visible?
       # Short-circuit if the user has a public account, to prevent instantiating


### PR DESCRIPTION
## Summary
- Add eager loading (`.includes` + `.with_attached_cover`) to `GameResolvers::SearchResolver` to match `ListResolver`, preventing N+1 queries for game associations
- Add `.with_attached_avatar` to `UserResolvers::ListResolver` and `SearchResolver` to prevent N+1 for avatar URLs
- Replace per-object `EXISTS` query in `UserType#followed?` with a request-scoped `Set` of followed user IDs
- Replace per-object `COUNT` query in `GameType#rating_count` with a request-scoped `GROUP BY` cache

## Test plan
- [x] All 103 affected GraphQL API tests pass (games, users, activity, global search, game purchases, companies, engines, genres, platforms, series, stores)
- [x] Rubocop passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)