### PR TITLE
Add RSpec tests for event models

### DIFF
--- a/spec/models/events/favorite_game_event_spec.rb
+++ b/spec/models/events/favorite_game_event_spec.rb
@@ -19,10 +19,9 @@ RSpec.describe Events::FavoriteGameEvent, type: :model do
   end
 
   describe "Enums" do
-    it {
-      should define_enum_for(:event_category).with_values(
-        favorite_game: 2
-      )
-    }
+    it 'has an event_category enum' do
+      expect(favorite_game_event).to define_enum_for(:event_category)
+        .with_values(favorite_game: 2)
+    end
   end
 end

--- a/spec/models/events/favorite_game_event_spec.rb
+++ b/spec/models/events/favorite_game_event_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::FavoriteGameEvent, type: :model do
+  subject(:favorite_game_event) { build(:favorite_game_event) }
+
+  describe "Validations" do
+    it "is valid with valid attributes" do
+      expect(favorite_game_event).to be_valid
+    end
+
+    it { should validate_presence_of(:event_category) }
+  end
+
+  describe "Associations" do
+    it { should belong_to(:eventable).class_name('FavoriteGame') }
+    it { should belong_to(:user) }
+  end
+
+  describe "Enums" do
+    it {
+      should define_enum_for(:event_category).with_values(
+        favorite_game: 2
+      )
+    }
+  end
+end

--- a/spec/models/events/game_purchase_event_spec.rb
+++ b/spec/models/events/game_purchase_event_spec.rb
@@ -19,11 +19,9 @@ RSpec.describe Events::GamePurchaseEvent, type: :model do
   end
 
   describe "Enums" do
-    it {
-      should define_enum_for(:event_category).with_values(
-        add_to_library: 0,
-        change_completion_status: 1
-      )
-    }
+    it 'has an event_category enum' do
+      expect(game_purchase_event).to define_enum_for(:event_category)
+        .with_values(add_to_library: 0, change_completion_status: 1)
+    end
   end
 end

--- a/spec/models/events/game_purchase_event_spec.rb
+++ b/spec/models/events/game_purchase_event_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::GamePurchaseEvent, type: :model do
+  subject(:game_purchase_event) { build(:game_purchase_library_event) }
+
+  describe "Validations" do
+    it "is valid with valid attributes" do
+      expect(game_purchase_event).to be_valid
+    end
+
+    it { should validate_presence_of(:event_category) }
+  end
+
+  describe "Associations" do
+    it { should belong_to(:eventable).class_name('GamePurchase') }
+    it { should belong_to(:user) }
+  end
+
+  describe "Enums" do
+    it {
+      should define_enum_for(:event_category).with_values(
+        add_to_library: 0,
+        change_completion_status: 1
+      )
+    }
+  end
+end

--- a/spec/models/events/relationship_event_spec.rb
+++ b/spec/models/events/relationship_event_spec.rb
@@ -19,10 +19,9 @@ RSpec.describe Events::RelationshipEvent, type: :model do
   end
 
   describe "Enums" do
-    it {
-      should define_enum_for(:event_category).with_values(
-        following: 4
-      )
-    }
+    it 'has an event_category enum' do
+      expect(relationship_event).to define_enum_for(:event_category)
+        .with_values(following: 4)
+    end
   end
 end

--- a/spec/models/events/relationship_event_spec.rb
+++ b/spec/models/events/relationship_event_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::RelationshipEvent, type: :model do
+  subject(:relationship_event) { build(:following_event) }
+
+  describe "Validations" do
+    it "is valid with valid attributes" do
+      expect(relationship_event).to be_valid
+    end
+
+    it { should validate_presence_of(:event_category) }
+  end
+
+  describe "Associations" do
+    it { should belong_to(:eventable).class_name('Relationship') }
+    it { should belong_to(:user) }
+  end
+
+  describe "Enums" do
+    it {
+      should define_enum_for(:event_category).with_values(
+        following: 4
+      )
+    }
+  end
+end

--- a/spec/models/events/user_event_spec.rb
+++ b/spec/models/events/user_event_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::UserEvent, type: :model do
+  subject(:user_event) { build(:new_user_event) }
+
+  describe "Validations" do
+    it "is valid with valid attributes" do
+      expect(user_event).to be_valid
+    end
+
+    it { should validate_presence_of(:event_category) }
+  end
+
+  describe "Associations" do
+    it { should belong_to(:eventable).class_name('User') }
+    it { should belong_to(:user) }
+  end
+
+  describe "Enums" do
+    it {
+      should define_enum_for(:event_category).with_values(
+        new_user: 3
+      )
+    }
+  end
+end

--- a/spec/models/events/user_event_spec.rb
+++ b/spec/models/events/user_event_spec.rb
@@ -19,10 +19,9 @@ RSpec.describe Events::UserEvent, type: :model do
   end
 
   describe "Enums" do
-    it {
-      should define_enum_for(:event_category).with_values(
-        new_user: 3
-      )
-    }
+    it 'has an event_category enum' do
+      expect(user_event).to define_enum_for(:event_category)
+        .with_values(new_user: 3)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Adds unit tests for all four event models that previously had no test coverage: `FavoriteGameEvent`, `GamePurchaseEvent`, `RelationshipEvent`, and `UserEvent`
- Each spec covers validations (presence of `event_category`), associations (`eventable` and `user`), and enum definitions with their integer values
- All 20 new examples pass

## Test plan
- [x] `bundle exec rspec spec/models/events/` — all 20 examples pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)