### PR TITLE
Add Claude Code skill files for common codebase patterns

### DIFF
--- a/.claude/skills/codegen-sync/SKILL.md
+++ b/.claude/skills/codegen-sync/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: codegen-sync
+description: Regenerate GraphQL schema and TypeScript types after GraphQL changes. Claude invokes this automatically.
+user-invocable: false
+---
+
+# Codegen Sync
+
+When any of these files are created or modified during a conversation, run the codegen pipeline.
+
+## Trigger files
+
+- `app/graphql/types/**/*.rb` (GraphQL type definitions)
+- `app/graphql/mutations/**/*.rb` (GraphQL mutations)
+- `app/graphql/resolvers/**/*.rb` (GraphQL resolvers)
+- `frontend/src/graphql/queries/**/*.ts` (Frontend query documents)
+- `frontend/src/graphql/mutations/**/*.ts` (Frontend mutation documents)
+
+## Pipeline
+
+Run these steps in order:
+
+### Step 1: Regenerate schema.graphql from Ruby types
+
+```bash
+bundle exec rake graphql:schema:idl
+```
+
+This reads the Ruby GraphQL type/mutation/resolver definitions and outputs `schema.graphql` at the project root.
+
+### Step 2: Regenerate TypeScript types from schema + operations
+
+```bash
+cd frontend && yarn codegen
+```
+
+This runs `@graphql-codegen/cli` which reads `schema.graphql` and all `frontend/src/graphql/**/*.ts` operation documents, then writes `frontend/src/types/graphql.ts`.
+
+**IMPORTANT**: Never manually edit `frontend/src/types/graphql.ts` — it is fully auto-generated.
+
+### Step 3: Verify types compile
+
+```bash
+cd frontend && yarn typecheck
+```
+
+If typecheck fails, the frontend code likely references fields that were renamed or removed in the schema change. Fix the frontend code, not the generated types.
+
+## When to skip
+
+- If only frontend `.vue` component files changed (no GraphQL operation changes), skip this pipeline.
+- If the user explicitly says they'll run codegen themselves, skip it.
+
+## Notes
+
+- The codegen config is at `frontend/codegen.ts`.
+- Schema lint can be run separately: `cd frontend && yarn lint:schema`.
+- After codegen, `yarn fmt` runs automatically (configured in the codegen npm script) to format the generated file.

--- a/.claude/skills/graphql-scaffold/SKILL.md
+++ b/.claude/skills/graphql-scaffold/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: graphql-scaffold
+description: Scaffold GraphQL type and CRUD mutations for a Rails model, following vglist conventions.
+---
+
+# GraphQL Scaffold
+
+Generate a GraphQL type and Create/Update/Delete mutations for an existing Rails model.
+
+## Input
+
+The user provides a model name (e.g., "Publisher"). Read the model file at `app/models/<model>.rb` to discover columns, associations, and validations before generating anything.
+
+## What to generate
+
+### 1. Type file: `app/graphql/types/<model>_type.rb`
+
+Follow the pattern in existing types (CompanyType, PlatformType, GenreType):
+
+```ruby
+# frozen_string_literal: true
+
+module Types
+  class <Model>Type < Types::BaseObject
+    description "<Description of the entity>"
+
+    field :id, ID, null: false, description: "ID of the <model>."
+    field :name, String, null: false, description: "Name of the <model>."
+    # Add fields for each database column. Use these type mappings:
+    #   string/text  -> String
+    #   integer      -> Integer
+    #   float/decimal -> Float
+    #   boolean      -> Boolean
+    #   date         -> GraphQL::Types::ISO8601Date
+    #   datetime     -> GraphQL::Types::ISO8601DateTime
+    #   references   -> ID (for foreign keys)
+    # Every field MUST have a description.
+    field :wikidata_id, Integer, null: true, description: "Identifier for Wikidata."
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: "When this <model> was first created."
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false, description: "When this <model> was last updated."
+
+    # Associations: use ConnectionType for has_many
+    # field :games, GameType.connection_type, null: false, description: "Games associated with this <model>."
+    #
+    # If the association uses `with_attached_cover`, add a resolver method:
+    # def games
+    #   @object.games.with_attached_cover
+    # end
+  end
+end
+```
+
+### 2. Create mutation: `app/graphql/mutations/<models>/create_<model>.rb`
+
+```ruby
+# frozen_string_literal: true
+
+class Mutations::<Models>::Create<Model> < Mutations::BaseMutation
+  description "Create a new <model>. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  # Arguments: required fields from the model's validations.
+  # Use `required: true` for validated presence fields, `required: false` for optional.
+  argument :name, String, required: true, description: 'The name of the <model>.'
+  argument :wikidata_id, ID, required: true, description: 'The ID of the <model> item in Wikidata.'
+  # For has_many through associations, use array ID arguments:
+  # argument :game_ids, [ID], required: false, description: 'The ID(s) of associated games.'
+
+  field :<model>, Types::<Model>Type, null: true, description: "The <model> that was created."
+
+  def resolve(name:, wikidata_id:)
+    <model> = <Model>.new(name: name, wikidata_id: wikidata_id)
+
+    raise GraphQL::ExecutionError, <model>.errors.full_messages.join(", ") unless <model>.save
+
+    {
+      <model>: <model>
+    }
+  end
+
+  def authorized?(_object)
+    require_permissions!(:first_party)
+
+    raise GraphQL::ExecutionError, "You aren't allowed to create a <model>." unless <Model>Policy.new(@context[:current_user], nil).create?
+
+    return true
+  end
+end
+```
+
+### 3. Update mutation: `app/graphql/mutations/<models>/update_<model>.rb`
+
+- Takes `<model>_id` as required ID argument.
+- All other arguments are `required: false`.
+- Uses `**args` splat pattern to avoid nil-overwriting existing values.
+- In `authorized?`, fetches the record by ID and checks `<Model>Policy.new(@context[:current_user], <model>).update?`.
+
+```ruby
+# frozen_string_literal: true
+
+class Mutations::<Models>::Update<Model> < Mutations::BaseMutation
+  description "Update an existing <model>. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  argument :<model>_id, ID, required: true, description: 'The ID of the <model> record.'
+  argument :name, String, required: false, description: 'The name of the <model>.'
+  argument :wikidata_id, ID, required: false, description: 'The ID of the <model> item in Wikidata.'
+
+  field :<model>, Types::<Model>Type, null: false, description: "The <model> that was updated."
+
+  # Use **args so we don't replace existing fields that aren't provided with `nil`.
+  def resolve(<model>_id:, **args)
+    <model> = <Model>.find(<model>_id)
+
+    raise GraphQL::ExecutionError, <model>.errors.full_messages.join(", ") unless <model>.update(**args)
+
+    {
+      <model>: <model>
+    }
+  end
+
+  def authorized?(object)
+    require_permissions!(:first_party)
+
+    <model> = <Model>.find(object[:<model>_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to update this <model>." unless <Model>Policy.new(@context[:current_user], <model>).update?
+
+    return true
+  end
+end
+```
+
+### 4. Delete mutation: `app/graphql/mutations/<models>/delete_<model>.rb`
+
+```ruby
+# frozen_string_literal: true
+
+class Mutations::<Models>::Delete<Model> < Mutations::BaseMutation
+  description "Delete a <model>. **Only available to moderators and admins using a first-party OAuth Application.**"
+
+  argument :<model>_id, ID, required: true, description: 'The ID of the <model> to delete.'
+
+  field :deleted, Boolean, null: true, description: "Whether the <model> was successfully deleted."
+
+  def resolve(<model>_id:)
+    <model> = <Model>.find(<model>_id)
+
+    raise GraphQL::ExecutionError, <model>.errors.full_messages.join(", ") unless <model>.destroy
+
+    {
+      deleted: true
+    }
+  end
+
+  def authorized?(object)
+    require_permissions!(:first_party)
+
+    <model> = <Model>.find(object[:<model>_id])
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this <model>." unless <Model>Policy.new(@context[:current_user], <model>).destroy?
+
+    return true
+  end
+end
+```
+
+### 5. Register in `app/graphql/types/mutation_type.rb`
+
+Add three field lines in the appropriate alphabetical section:
+
+```ruby
+# <Model> mutations
+field :create_<model>, mutation: Mutations::<Models>::Create<Model>
+field :update_<model>, mutation: Mutations::<Models>::Update<Model>
+field :delete_<model>, mutation: Mutations::<Models>::Delete<Model>
+```
+
+## After generating
+
+Remind the user to:
+1. Verify a Pundit policy exists at `app/policies/<model>_policy.rb` with `create?`, `update?`, and `destroy?` methods.
+2. Run `bundle exec rake graphql:schema:idl` to regenerate `schema.graphql`.
+3. Run `cd frontend && yarn codegen` to regenerate TypeScript types.
+4. Add query resolvers to `app/graphql/types/query_type.rb` if the entity needs query access.
+
+## Rules
+
+- Every field and argument MUST have a `description:` string.
+- Use `frozen_string_literal: true` pragma on every Ruby file.
+- Pluralize the module name for mutations (e.g., `Mutations::Companies::CreateCompany`).
+- The create mutation's return field is `null: true`; update is `null: false`; delete returns `deleted` as `null: true`.
+- Do NOT use InputObject types — define arguments directly on the mutation.
+- For complex models with many associations (like Game), list each explicit keyword argument in `resolve()` with defaults instead of using `**args`.
+- For simpler models, the update mutation can use `def resolve(<model>_id:, **args)` with `<model>.update(**args)`.

--- a/.claude/skills/mutation-test/SKILL.md
+++ b/.claude/skills/mutation-test/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: mutation-test
+description: Scaffold RSpec request specs for GraphQL mutations, following vglist testing conventions.
+---
+
+# Mutation Test Scaffolder
+
+Generate RSpec request specs for GraphQL Create, Update, and/or Delete mutations.
+
+## Input
+
+The user provides a mutation name or model name (e.g., "CreateCompany" or "Company"). Read the corresponding mutation file(s) at `app/graphql/mutations/<models>/` to discover arguments, return fields, and authorization rules.
+
+## Output structure
+
+Create spec file(s) at `spec/requests/api/mutations/<models>/<mutation_name>_spec.rb`.
+
+## Conventions
+
+### File header and setup
+
+```ruby
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "<MutationName> Mutation API", type: :request do
+  describe "Mutation <action>s a <model> record" do
+    let(:user) { create(:confirmed_moderator) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+```
+
+### API request helper
+
+Use `api_request(query_string, variables: { ... }, token: access_token)`.
+
+- Variable keys are automatically camelCased by the helper — pass them as **snake_case** symbols in the `variables` hash.
+- The helper returns a `VglistApiRequestResponse` object.
+
+### Assertions
+
+- **Success data**: `result.graphql_dig(:create_<model>, :<model>, :name)` — symbols are auto-camelized.
+- **Connection fields**: `result.graphql_dig(:create_<model>, :<model>, :games)` returns `{ nodes: [{ id: "1" }] }` with symbolized keys.
+- **Errors**: `result.to_h['errors'].first['message']` — use `to_h`, not `graphql_dig`.
+- **IDs in responses** are always strings — use `.to_s` when comparing factory record IDs.
+
+### Create mutation spec pattern
+
+```ruby
+context 'when the current user is a moderator' do
+  let(:query_string) do
+    <<-GRAPHQL
+      mutation($name: String!, $wikidataId: ID!) {
+        create<Model>(name: $name, wikidataId: $wikidataId) {
+          <model> {
+            name
+            wikidataId
+          }
+        }
+      }
+    GRAPHQL
+  end
+
+  it "increases <Model> count by 1" do
+    expect do
+      api_request(query_string, variables: { name: 'Test', wikidata_id: 123 }, token: access_token)
+    end.to change(<Model>, :count).by(1)
+  end
+
+  it "returns basic data for <model> after creating it" do
+    result = api_request(query_string, variables: { name: 'Test', wikidata_id: 123 }, token: access_token)
+
+    expect(result.graphql_dig(:create_<model>, :<model>)).to eq({
+      name: 'Test',
+      wikidataId: 123
+    })
+  end
+end
+```
+
+### Update mutation spec pattern
+
+```ruby
+context 'when the current user is a moderator' do
+  let!(:<model>) { create(:<model>) }
+  let(:query_string) do
+    <<-GRAPHQL
+      mutation($<model>Id: ID!, $name: String) {
+        update<Model>(<model>Id: $<model>Id, name: $name) {
+          <model> {
+            name
+          }
+        }
+      }
+    GRAPHQL
+  end
+
+  it "does not change <Model> count" do
+    expect do
+      api_request(query_string, variables: { <model>_id: <model>.id, name: 'Updated' }, token: access_token)
+    end.not_to change(<Model>, :count)
+  end
+
+  it "returns updated data" do
+    result = api_request(query_string, variables: { <model>_id: <model>.id, name: 'Updated' }, token: access_token)
+
+    expect(result.graphql_dig(:update_<model>, :<model>, :name)).to eq('Updated')
+  end
+end
+```
+
+### Delete mutation spec pattern
+
+```ruby
+context "when the current user is an admin" do
+  let(:user) { create(:confirmed_admin) }
+  let!(:<model>) { create(:<model>) }
+  let(:query_string) do
+    <<-GRAPHQL
+      mutation($<model>Id: ID!) {
+        delete<Model>(<model>Id: $<model>Id) {
+          deleted
+        }
+      }
+    GRAPHQL
+  end
+
+  it "decreases <Model> count by 1" do
+    expect do
+      api_request(query_string, variables: { <model>_id: <model>.id }, token: access_token)
+    end.to change(<Model>, :count).by(-1)
+  end
+
+  it "returns true after deletion" do
+    result = api_request(query_string, variables: { <model>_id: <model>.id }, token: access_token)
+
+    expect(result.graphql_dig(:delete_<model>, :deleted)).to eq(true)
+  end
+end
+```
+
+### Authorization failure test (include for EACH mutation)
+
+```ruby
+context 'when the current user is a normal member' do
+  let(:user) { create(:confirmed_user) }
+
+  it "does not change <Model> count" do
+    expect do
+      result = api_request(query_string, variables: { ... }, token: access_token)
+      expect(result.to_h['errors'].first['message']).to eq("You aren't allowed to <action> a <model>.")
+    end.not_to change(<Model>, :count)
+  end
+end
+```
+
+### Role iteration shorthand
+
+For simpler entities where moderators AND admins can perform the action:
+
+```ruby
+[:moderator, :admin].each do |role|
+  context "when the current user is a(n) #{role}" do
+    let(:user) { create("confirmed_#{role}".to_sym) }
+    # ... tests
+  end
+end
+```
+
+## Rules
+
+- Use `frozen_string_literal: true` pragma.
+- GraphQL query strings use `<<-GRAPHQL` heredoc (not `<<~GRAPHQL`).
+- Variable names in the GraphQL string are camelCase; variable keys in the Ruby hash are snake_case.
+- Use `let!` (bang) for records that must exist before the request (update/delete targets).
+- Use `let` (no bang) for records created lazily (user, application, access_token).
+- Check the mutation's `authorized?` method to determine which roles can perform the action. Typically: moderator+ for create/update, admin-only for delete.
+- For complex models with associations, create associated records with factories and pass their IDs in variables.

--- a/.claude/skills/vue-page/SKILL.md
+++ b/.claude/skills/vue-page/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: vue-page
+description: Scaffold a Vue 3 page component with GraphQL integration, following vglist frontend conventions.
+---
+
+# Vue Page Scaffolder
+
+Generate a Vue 3 page component with GraphQL data fetching, following vglist patterns.
+
+## Input
+
+The user specifies:
+- The entity/resource name (e.g., "Publisher")
+- The page type: **list**, **show**, or **form**
+
+Read the relevant GraphQL type from `app/graphql/types/<entity>_type.rb` and any existing query/mutation operations in `frontend/src/graphql/` to understand available fields.
+
+## Page types
+
+### List page (`<Entity>ListPage.vue`)
+
+Location: `frontend/src/pages/<entities>/<Entity>ListPage.vue`
+
+```vue
+<template>
+  <div>
+    <section class="section">
+      <div class="container">
+        <h1 class="title"><Entities></h1>
+
+        <div v-if="loading && !data" class="has-text-centered py-6">
+          <p>Loading...</p>
+        </div>
+
+        <div v-if="error" class="notification is-danger">
+          <p>Failed to load <entities>: {{ error.message }}</p>
+        </div>
+
+        <div v-if="<entities>">
+          <!-- List content here -->
+        </div>
+
+        <!-- Cursor-based pagination controls -->
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
+import { useQuery } from "@/composables/useGraphQL";
+import { GET_<ENTITIES> } from "@/graphql/queries/resources";
+import type { Get<Entities>Query } from "@/types/graphql";
+
+const PAGE_SIZE = 25;
+const currentPage = ref(1);
+const pageCursors = ref<(string | null)[]>([null]);
+
+const { data, loading, error } = useQuery<Get<Entities>Query>(GET_<ENTITIES>, {
+  variables: () => ({
+    first: PAGE_SIZE,
+    after: pageCursors.value[currentPage.value - 1],
+  }),
+});
+
+const <entities> = computed(() => data.value?.<entities>?.nodes ?? []);
+const hasNextPage = computed(() => data.value?.<entities>?.pageInfo.hasNextPage ?? false);
+
+watch(data, (val) => {
+  if (val?.<entities>?.pageInfo.endCursor) {
+    pageCursors.value[currentPage.value] = val.<entities>.pageInfo.endCursor;
+  }
+});
+</script>
+```
+
+### Show page (`<Entity>ShowPage.vue`)
+
+Location: `frontend/src/pages/<entities>/<Entity>ShowPage.vue`
+
+```vue
+<template>
+  <div>
+    <div v-if="loading && !data" class="has-text-centered py-6">
+      <p>Loading <entity>...</p>
+    </div>
+
+    <div v-if="error" class="notification is-danger">
+      <p>Failed to load <entity>: {{ error.message }}</p>
+    </div>
+
+    <div v-if="<entity>">
+      <!-- Show content here -->
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from "vue";
+import { useRoute, useRouter } from "vue-router/auto";
+import { useQuery } from "@/composables/useGraphQL";
+import { GET_<ENTITY> } from "@/graphql/queries/resources";
+import type { Get<Entity>Query } from "@/types/graphql";
+
+const route = useRoute("<entity>");
+const router = useRouter();
+
+const { data, loading, error } = useQuery<Get<Entity>Query>(GET_<ENTITY>, {
+  variables: { id: route.params.id },
+});
+
+const <entity> = computed(() => data.value?.<entity> ?? null);
+
+// Redirect to 404 if entity not found
+watch([data, error, loading], () => {
+  if (!loading.value && (error.value || (data.value && !data.value.<entity>))) {
+    router.replace({ name: "notFound" });
+  }
+});
+</script>
+```
+
+### Form page (`<Entity>FormPage.vue`)
+
+Location: `frontend/src/pages/<entities>/<Entity>FormPage.vue`
+
+```vue
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router/auto";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { GET_<ENTITY> } from "@/graphql/queries/resources";
+import { CREATE_<ENTITY>, UPDATE_<ENTITY> } from "@/graphql/mutations/<entities>";
+import type { ... } from "@/types/graphql";
+
+const route = useRoute();
+const router = useRouter();
+
+const isEditing = computed(() => !!route.params.id);
+
+// Fetch existing data when editing
+const { data: entityData, loading: entityLoading } = useQuery<...>(GET_<ENTITY>, {
+  variables: () => ({ id: route.params.id as string }),
+  enabled: () => isEditing.value,
+});
+
+// Form state
+const form = reactive({
+  name: "",
+  // ... other fields
+});
+
+const submitError = ref("");
+
+// Populate form when editing
+watch(() => entityData.value?.<entity>, (<entity>) => {
+  if (!<entity>) return;
+  form.name = <entity>.name;
+  // ... populate other fields
+});
+
+// Mutations
+const { mutate: createEntity, loading: creating } = useMutation(CREATE_<ENTITY>);
+const { mutate: updateEntity, loading: updating } = useMutation(UPDATE_<ENTITY>);
+
+async function handleSubmit() {
+  submitError.value = "";
+  if (!form.name.trim()) {
+    submitError.value = "Name is required.";
+    return;
+  }
+  try {
+    if (isEditing.value) {
+      await updateEntity({ <entity>Id: route.params.id, ...form });
+    } else {
+      const result = await createEntity({ ...form });
+      // Navigate to new entity
+    }
+  } catch (e: unknown) {
+    submitError.value = e instanceof Error ? e.message : "An error occurred.";
+  }
+}
+</script>
+```
+
+## GraphQL operation files
+
+If the required query or mutation doesn't exist yet, also create it:
+
+- **Queries**: `frontend/src/graphql/queries/resources.ts` (add to existing file for standard entities)
+- **Mutations**: `frontend/src/graphql/mutations/<entities>.ts` (new file per entity domain)
+
+Use `gql` from `graphql-tag`:
+
+```typescript
+import gql from "graphql-tag";
+
+export const GET_<ENTITY> = gql`
+  query Get<Entity>($id: ID!) {
+    <entity>(id: $id) {
+      id
+      name
+      wikidataId
+      createdAt
+      updatedAt
+    }
+  }
+`;
+```
+
+## Router registration
+
+Add routes to `frontend/src/router/index.ts`:
+
+```typescript
+{
+  path: "/<entities>",
+  name: "<entities>",
+  component: () => import("@/pages/<entities>/<Entity>ListPage.vue"),
+},
+{
+  path: "/<entities>/:id",
+  name: "<entity>",
+  component: () => import("@/pages/<entities>/<Entity>ShowPage.vue"),
+},
+{
+  path: "/<entities>/new",
+  name: "<entity>New",
+  component: () => import("@/pages/<entities>/<Entity>FormPage.vue"),
+  meta: { requiresAuth: true, requiresModerator: true },
+},
+{
+  path: "/<entities>/:id/edit",
+  name: "<entity>Edit",
+  component: () => import("@/pages/<entities>/<Entity>FormPage.vue"),
+  meta: { requiresAuth: true, requiresModerator: true },
+},
+```
+
+## After generating
+
+Remind the user to:
+1. Run `cd frontend && yarn codegen` if new GraphQL operations were added.
+2. Run `cd frontend && yarn typecheck` to verify types.
+3. Run `cd frontend && yarn fmt` to format new files.
+
+## Rules
+
+- Always use `<script setup lang="ts">` — never Options API.
+- No `any` types — use generated types from `@/types/graphql`.
+- Use Bulma CSS classes for layout (`section`, `container`, `title`, `notification`, `columns`, `column`).
+- Use Lucide icons via `lucide-vue-next` — never custom SVG components.
+- Include loading and error states in every page template.
+- Use `useRoute` and `useRouter` from `vue-router/auto`.
+- Use semantic HTML and include ARIA attributes where appropriate (e.g., `aria-label` on icon buttons, `role` on dynamic regions).
+- Variables passed to `useQuery` should be a getter function `() => ({...})` when they depend on reactive state, or a plain object when static.
+- Use `computed()` to derive display values from query data, not direct template access to `data.value`.


### PR DESCRIPTION
## Summary

- Adds 4 Claude Code skills derived from analyzing repeated patterns in the codebase
- **graphql-scaffold** (`/graphql-scaffold`): Scaffolds GraphQL type + create/update/delete mutations from a model name, following existing conventions (BaseMutation, Pundit authorization, field descriptions)
- **mutation-test** (`/mutation-test`): Scaffolds RSpec request specs for GraphQL mutations with role-based authorization testing, using the `api_request`/`graphql_dig` helpers
- **vue-page** (`/vue-page`): Scaffolds Vue 3 list/show/form pages with `useQuery`/`useMutation` composables, cursor pagination, router registration, and Bulma styling
- **codegen-sync** (auto-invoked by Claude): Runs `rake graphql:schema:idl` + `yarn codegen` + `yarn typecheck` after GraphQL file changes

## Test plan

- [ ] Verify skills appear in Claude Code with `/graphql-scaffold`, `/mutation-test`, `/vue-page`
- [ ] Test each skill by invoking it for an existing entity (e.g., `/graphql-scaffold Engine`) and confirming output matches project conventions
- [ ] Verify `codegen-sync` is triggered automatically when editing GraphQL files

🤖 Generated with [Claude Code](https://claude.com/claude-code)