### PR TITLE
Implement JSON file download on Export settings page

### DIFF
--- a/frontend/src/pages/settings/ExportSettings.vue
+++ b/frontend/src/pages/settings/ExportSettings.vue
@@ -39,7 +39,16 @@ const exportError = ref("");
 const { mutate, loading: exporting } = useMutation<ExportLibraryResult>(EXPORT_LIBRARY);
 
 function downloadJson(jsonString: string) {
-  const date = new Date().toISOString().slice(0, 10);
+  const now = new Date();
+  const dateParts = new Intl.DateTimeFormat("en", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  }).formatToParts(now);
+  const year = dateParts.find((part) => part.type === "year")?.value;
+  const month = dateParts.find((part) => part.type === "month")?.value;
+  const day = dateParts.find((part) => part.type === "day")?.value;
+  const date = `${year}-${month}-${day}`;
   const username = authStore.user?.username ?? "user";
   const filename = `vglist-export-${username}-${date}.json`;
 
@@ -67,7 +76,9 @@ function downloadJson(jsonString: string) {
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 0);
 
   return games.length;
 }
@@ -85,7 +96,7 @@ async function exportLibrary() {
     } else if (result?.libraryJson) {
       const gameCount = downloadJson(result.libraryJson);
       if (gameCount !== null) {
-        exportSuccess.value = `Your library export (${gameCount} ${gameCount === 1 ? "game" : "games"}) has been downloaded.`;
+        exportSuccess.value = `Your library export (${gameCount} ${gameCount === 1 ? "game" : "games"}) download has started.`;
       }
     }
   } catch (e) {

--- a/frontend/src/pages/settings/ExportSettings.vue
+++ b/frontend/src/pages/settings/ExportSettings.vue
@@ -2,17 +2,14 @@
   <div>
     <h2 class="title is-4">Export Library</h2>
 
-    <p class="mb-4">Export your game library as JSON.</p>
+    <p class="mb-4">Export your game library as a JSON file.</p>
 
     <div v-if="exportError" class="notification is-danger">
       <p>{{ exportError }}</p>
     </div>
 
-    <div v-if="exportData" class="mb-4">
-      <div class="notification is-success">
-        <p>Export complete. Copy the JSON below or download it.</p>
-      </div>
-      <pre class="box" style="max-height: 400px; overflow: auto">{{ exportData }}</pre>
+    <div v-if="exportSuccess" class="notification is-success">
+      <p>{{ exportSuccess }}</p>
     </div>
 
     <button class="button is-primary" :class="{ 'is-loading': exporting }" :disabled="exporting" @click="exportLibrary">
@@ -26,6 +23,7 @@ import { ref } from "vue";
 import { useMutation } from "@/composables/useGraphQL";
 import { EXPORT_LIBRARY } from "@/graphql/mutations/users-settings";
 import { extractGqlError } from "@/utils/graphql-errors";
+import { useAuthStore } from "@/stores/auth";
 
 interface ExportLibraryResult {
   exportLibrary?: {
@@ -34,14 +32,49 @@ interface ExportLibraryResult {
   } | null;
 }
 
-const exportData = ref("");
+const authStore = useAuthStore();
+const exportSuccess = ref("");
 const exportError = ref("");
 
 const { mutate, loading: exporting } = useMutation<ExportLibraryResult>(EXPORT_LIBRARY);
 
+function downloadJson(jsonString: string) {
+  const date = new Date().toISOString().slice(0, 10);
+  const username = authStore.user?.username ?? "user";
+  const filename = `vglist-export-${username}-${date}.json`;
+
+  let games: unknown[];
+  try {
+    games = JSON.parse(jsonString) as unknown[];
+  } catch {
+    exportError.value = "The server returned invalid JSON. Please try again.";
+    return null;
+  }
+
+  const exportPayload = {
+    exportedAt: new Date().toISOString(),
+    source: "vglist",
+    version: 1,
+    games
+  };
+
+  const formatted = JSON.stringify(exportPayload, null, 2);
+  const blob = new Blob([formatted], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+
+  return games.length;
+}
+
 async function exportLibrary() {
   exportError.value = "";
-  exportData.value = "";
+  exportSuccess.value = "";
 
   try {
     const response = await mutate();
@@ -50,7 +83,10 @@ async function exportLibrary() {
     if (result?.errors && result.errors.length > 0) {
       exportError.value = result.errors.join(", ");
     } else if (result?.libraryJson) {
-      exportData.value = result.libraryJson;
+      const gameCount = downloadJson(result.libraryJson);
+      if (gameCount !== null) {
+        exportSuccess.value = `Your library export (${gameCount} ${gameCount === 1 ? "game" : "games"}) has been downloaded.`;
+      }
     }
   } catch (e) {
     exportError.value = extractGqlError(e);


### PR DESCRIPTION
## Summary
- Replace the raw JSON `<pre>` display on the Export settings page with a proper browser file download
- The exported JSON file includes metadata (`exportedAt`, `source`, `version`) wrapping the game library data
- Files are named `vglist-export-{username}-{YYYY-MM-DD}.json`
- Shows a success notification with game count after download completes

Closes #4459

## Test plan
- [ ] Log in, go to `/settings/export`, click "Export Library", verify a `.json` file downloads
- [ ] Verify the downloaded JSON contains `exportedAt`, `source`, `version`, and `games` fields
- [ ] Verify the filename includes the username and current date
- [ ] Test with an empty library — should still download a valid JSON file with an empty `games` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)