### PR TITLE
Adjust a regex

### DIFF
--- a/spec/services/steam_import_service_spec.rb
+++ b/spec/services/steam_import_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SteamImportService, type: :service do
   end
 
   before(:each) do
-    stub_request(:get, /api.steampowered.com/).to_return(
+    stub_request(:get, /api\.steampowered\.com/).to_return(
       status: 200,
       body: response.to_json,
       headers: {}


### PR DESCRIPTION
This is a goofy "vulnerability" that does not actually exist because it's in _the rspec suite, stupid_.

Slop below.

----

Potential fix for [https://github.com/connorshea/vglist/security/code-scanning/3](https://github.com/connorshea/vglist/security/code-scanning/3)

Use an escaped hostname in the regex so dots are treated literally.  
Best fix (minimal behavior change): update the regex on line 40 from `/api.steampowered.com/` to `/api\.steampowered\.com/`.

This keeps the same “contains this host fragment” matching behavior, but removes wildcard behavior from dots. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
