### PR TITLE
Minor fix for regex

### DIFF
--- a/spec/requests/api/mutations/users/connect_steam_spec.rb
+++ b/spec/requests/api/mutations/users/connect_steam_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "ConnectSteam Mutation API", type: :request do
     end
 
     before(:each) do
-      stub_request(:get, /api.steampowered.com/).to_return(
+      stub_request(:get, /api\.steampowered\.com/).to_return(
         status: 200,
         body: {
           'response': { 'steamid': '123' }


### PR DESCRIPTION
This is in a test file and so is pointless/not actually a vulnerability, but I'm fixing it anyway.

---

Potential fix for [https://github.com/connorshea/vglist/security/code-scanning/2](https://github.com/connorshea/vglist/security/code-scanning/2)

Use an escaped dot in the regex so the hostname is matched literally.

Best fix (without changing behavior): in `spec/requests/api/mutations/users/connect_steam_spec.rb`, update the `stub_request` pattern on line 27 from `/api.steampowered.com/` to `/api\.steampowered\.com/`. This keeps the same intent (matching Steam API calls) while removing regex wildcard behavior from dots.

No new methods/imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
