### PR TITLE
Fix wrong policy check in AddToWikidataBlocklist mutation

### DIFF
--- a/app/graphql/mutations/admin/add_to_wikidata_blocklist.rb
+++ b/app/graphql/mutations/admin/add_to_wikidata_blocklist.rb
@@ -26,7 +26,7 @@ class Mutations::Admin::AddToWikidataBlocklist < Mutations::BaseMutation
   def authorized?(_object)
     require_permissions!(:first_party)
 
-    raise GraphQL::ExecutionError, "You aren't allowed to add this game to the Wikidata Blocklist." unless AdminPolicy.new(@context[:current_user], nil).remove_from_wikidata_blocklist?
+    raise GraphQL::ExecutionError, "You aren't allowed to add this game to the Wikidata Blocklist." unless AdminPolicy.new(@context[:current_user], nil).add_to_wikidata_blocklist?
 
     return true
   end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -20,6 +20,10 @@ class AdminPolicy < ApplicationPolicy
     user&.admin?
   end
 
+  def add_to_wikidata_blocklist?
+    user&.admin?
+  end
+
   def remove_from_wikidata_blocklist?
     user&.admin?
   end

--- a/spec/policies/admin_policy_spec.rb
+++ b/spec/policies/admin_policy_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe AdminPolicy, type: :policy do
         [
           :dashboard,
           :wikidata_blocklist,
+          :add_to_wikidata_blocklist,
           :remove_from_wikidata_blocklist,
           :steam_blocklist,
           :new_steam_blocklist,
@@ -34,6 +35,7 @@ RSpec.describe AdminPolicy, type: :policy do
         [
           :dashboard,
           :wikidata_blocklist,
+          :add_to_wikidata_blocklist,
           :remove_from_wikidata_blocklist,
           :steam_blocklist,
           :new_steam_blocklist,
@@ -54,6 +56,7 @@ RSpec.describe AdminPolicy, type: :policy do
         [
           :dashboard,
           :wikidata_blocklist,
+          :add_to_wikidata_blocklist,
           :remove_from_wikidata_blocklist,
           :steam_blocklist,
           :new_steam_blocklist,
@@ -74,6 +77,7 @@ RSpec.describe AdminPolicy, type: :policy do
         [
           :dashboard,
           :wikidata_blocklist,
+          :add_to_wikidata_blocklist,
           :remove_from_wikidata_blocklist,
           :steam_blocklist,
           :new_steam_blocklist,


### PR DESCRIPTION
## Summary
- `AddToWikidataBlocklist` was calling `AdminPolicy#remove_from_wikidata_blocklist?` for its authorization check — almost certainly a copy-paste from the remove mutation.
- No security impact (both methods resolve to `user&.admin?`), but the semantics are wrong and inconsistent with the Steam blocklist, which has separate `add_to_steam_blocklist?` / `remove_from_steam_blocklist?` policy methods.
- Added `AdminPolicy#add_to_wikidata_blocklist?` and pointed the add mutation at it. Updated the policy spec accordingly.

## Test plan
- [ ] `bundle exec rspec spec/policies/admin_policy_spec.rb`
- [ ] `bundle exec rspec spec/requests/api/mutations/admin/add_to_wikidata_blocklist_spec.rb`
- [ ] `bundle exec rubocop app/policies/admin_policy.rb app/graphql/mutations/admin/add_to_wikidata_blocklist.rb`

https://claude.ai/code/session_01RxJih4DmwAEFsZv3mUvReZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxJih4DmwAEFsZv3mUvReZ)_