### PR TITLE
Replace lucide-vue-next with @lucide/vue for icons.

### DIFF
--- a/.claude/skills/icons/SKILL.md
+++ b/.claude/skills/icons/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: icons
-description: How to add icons to the vglist frontend using Lucide via lucide-vue-next. Use when adding, replacing, or reviewing icon usage in Vue components.
+description: How to add icons to the vglist frontend using Lucide via @lucide/vue. Use when adding, replacing, or reviewing icon usage in Vue components.
 ---
 
 # Icons
@@ -9,10 +9,10 @@ When adding icons to the vglist frontend, follow these rules:
 
 ## Rules
 
-1. **Always use Lucide icons** from `lucide-vue-next`. Never create custom SVG icon components or use inline `<svg>` elements for icons.
-2. **Import icons by name** directly from `lucide-vue-next`:
+1. **Always use Lucide icons** from `@lucide/vue`. Never create custom SVG icon components or use inline `<svg>` elements for icons.
+2. **Import icons by name** directly from `@lucide/vue`:
    ```vue
-   import { Search, ChevronRight, Trash2 } from "lucide-vue-next";
+   import { Search, ChevronRight, Trash2 } from "@lucide/vue";
    ```
 3. **Use icons in templates** as Vue components:
    ```vue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ bundle exec rake graphql:schema:idl   # Regenerate schema.graphql
 - **TypeScript**: Strict mode enforced. No `any` types.
 - **Database schema**: Uses `structure.sql` (not `schema.rb`) because of SQL views.
 - **Accessibility**: Pages should be accessible and keyboard-navigable wherever possible. Use semantic HTML, ARIA attributes (e.g. `role="dialog"`, `aria-modal`, `aria-label`), visible focus styles (`:focus-visible`), focus trapping in modals/overlays, and ensure all interactive elements are reachable via Tab.
-- **Icons**: Use [Lucide](https://lucide.dev/icons/) icons via `lucide-vue-next`. Do not create custom SVG icon components — import icons directly from `lucide-vue-next` instead.
+- **Icons**: Use [Lucide](https://lucide.dev/icons/) icons via `@lucide/vue`. Do not create custom SVG icon components — import icons directly from `@lucide/vue` instead.
 - **CI checks**: Rubocop, Oxlint, Oxfmt, TypeScript (tsc + vue-tsc), GraphQL schema lint, RSpec (unit + feature separately).
 
 ## Parallel Worktrees

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,13 +18,13 @@
     "codegen": "graphql-codegen && oxfmt && oxfmt"
   },
   "dependencies": {
+    "@lucide/vue": "^1.23.0",
     "@sentry/vue": "^10.63.0",
     "bulma": "^1.0.4",
     "graphql": "^16.14.2",
     "graphql-request": "^7.4.0",
     "graphql-tag": "^2.12.7",
     "lodash-es": "^4.18.1",
-    "lucide-vue-next": "^0.577.0",
     "pinia": "^3.0.4",
     "sass-embedded": "^1.100.0",
     "vue": "^3.5.39",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@lucide/vue':
+        specifier: ^1.23.0
+        version: 1.23.0(vue@3.5.39(typescript@6.0.3))
       '@sentry/vue':
         specifier: ^10.63.0
         version: 10.63.0(pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
@@ -26,9 +29,6 @@ importers:
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
-      lucide-vue-next:
-        specifier: ^0.577.0
-        version: 0.577.0(vue@3.5.39(typescript@6.0.3))
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
@@ -707,6 +707,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lucide/vue@1.23.0':
+    resolution: {integrity: sha512-9SIYeY5K+R1iv8F8JUKMGSL7Pck/86BJ8djtZz/lnYsoHtKFUj1H2z6+PvKnC/8blZ8tqTDeDXAoTKobuX80hg==}
+    peerDependencies:
+      vue: '>=3.0.1'
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -2213,12 +2218,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lucide-vue-next@0.577.0:
-    resolution: {integrity: sha512-py05bAfv9SHVJqscbiOnjcnLlEmOffA58a+7XhZuFxrs6txe1E8VoR1ngWGTYO+9aVKABAz8l3ee3PqiQN9QPA==}
-    deprecated: Package deprecated. Please use @lucide/vue instead.
-    peerDependencies:
-      vue: '>=3.0.1'
 
   magic-string-ast@1.0.3:
     resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
@@ -3959,6 +3958,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lucide/vue@1.23.0(vue@3.5.39(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.39(typescript@6.0.3)
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -5266,10 +5269,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lucide-vue-next@0.577.0(vue@3.5.39(typescript@6.0.3)):
-    dependencies:
-      vue: 3.5.39(typescript@6.0.3)
 
   magic-string-ast@1.0.3:
     dependencies:

--- a/frontend/src/components/ConfirmDialog.vue
+++ b/frontend/src/components/ConfirmDialog.vue
@@ -37,7 +37,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onBeforeUnmount } from "vue";
-import { Trash2 } from "lucide-vue-next";
+import { Trash2 } from "@lucide/vue";
 
 const props = withDefaults(
   defineProps<{

--- a/frontend/src/components/PaginationNav.vue
+++ b/frontend/src/components/PaginationNav.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { ChevronLeft, ChevronRight } from "lucide-vue-next";
+import { ChevronLeft, ChevronRight } from "@lucide/vue";
 
 defineProps<{
   currentPage: number;

--- a/frontend/src/components/SearchOverlay.vue
+++ b/frontend/src/components/SearchOverlay.vue
@@ -227,7 +227,7 @@ import { gqlClient } from "@/graphql/client";
 import { GLOBAL_SEARCH } from "@/graphql/queries/resources";
 import { useSearchOverlay } from "@/composables/useSearchOverlay";
 import type { GameSearchResult, SearchResultUnion, UserSearchResult } from "@/types/graphql";
-import { Search, X, Gamepad2, Briefcase, Monitor, Users } from "lucide-vue-next";
+import { Search, X, Gamepad2, Briefcase, Monitor, Users } from "@lucide/vue";
 
 const router = useRouter();
 const { isOpen, close } = useSearchOverlay();

--- a/frontend/src/components/SearchableMultiSelect.vue
+++ b/frontend/src/components/SearchableMultiSelect.vue
@@ -54,7 +54,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from "vue";
-import { X, Check } from "lucide-vue-next";
+import { X, Check } from "@lucide/vue";
 
 interface Option {
   id: string;

--- a/frontend/src/components/SearchableSelect.vue
+++ b/frontend/src/components/SearchableSelect.vue
@@ -56,7 +56,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from "vue";
-import { X } from "lucide-vue-next";
+import { X } from "@lucide/vue";
 
 interface Option {
   id: string;

--- a/frontend/src/components/UserCard.vue
+++ b/frontend/src/components/UserCard.vue
@@ -17,7 +17,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { Lock } from "lucide-vue-next";
+import { Lock } from "@lucide/vue";
 
 const GRADIENTS = [
   "linear-gradient(135deg, var(--p-400), var(--p-600))",

--- a/frontend/src/components/navbar/MobileNavSheet.vue
+++ b/frontend/src/components/navbar/MobileNavSheet.vue
@@ -116,7 +116,7 @@ import { ref, watch, computed, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import { useAuthStore } from "@/stores/auth";
 import { useAuth } from "@/composables/useAuth";
-import { Activity, Gamepad2, User, ChevronRight, LogOut, Settings } from "lucide-vue-next";
+import { Activity, Gamepad2, User, ChevronRight, LogOut, Settings } from "@lucide/vue";
 
 const props = defineProps<{ isOpen: boolean }>();
 const emit = defineEmits<{ (e: "close"): void }>();

--- a/frontend/src/components/navbar/NavBar.vue
+++ b/frontend/src/components/navbar/NavBar.vue
@@ -140,7 +140,7 @@ import { useRoute } from "vue-router";
 import { useAuthStore } from "@/stores/auth";
 import { useAuth } from "@/composables/useAuth";
 import { useSearchOverlay } from "@/composables/useSearchOverlay";
-import { Search } from "lucide-vue-next";
+import { Search } from "@lucide/vue";
 import NavSearch from "./NavSearch.vue";
 import MobileNavSheet from "./MobileNavSheet.vue";
 

--- a/frontend/src/pages/activity/ActivityPage.vue
+++ b/frontend/src/pages/activity/ActivityPage.vue
@@ -163,7 +163,7 @@ import { DELETE_EVENT } from "@/graphql/mutations/events";
 import type { GetActivityQuery, GamePurchaseCompletionStatus, DeleteEventMutation } from "@/types/graphql";
 import PaginationNav from "@/components/PaginationNav.vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
-import { Trash2 } from "lucide-vue-next";
+import { Trash2 } from "@lucide/vue";
 import { useAuthStore } from "@/stores/auth";
 import { useSnackbar } from "@/composables/useSnackbar";
 

--- a/frontend/src/pages/games/GameShowPage.vue
+++ b/frontend/src/pages/games/GameShowPage.vue
@@ -266,11 +266,10 @@ import {
 } from "@/graphql/mutations/games";
 import { ADD_TO_WIKIDATA_BLOCKLIST } from "@/graphql/mutations/admin";
 import type { GetGameQuery, GetStoresQuery } from "@/types/graphql";
-import { Heart, CircleAlert, ChevronDown } from "lucide-vue-next";
+import { Heart, CircleAlert, ChevronDown } from "@lucide/vue";
 import { extractGqlError } from "@/utils/graphql-errors";
 import { useSnackbar } from "@/composables/useSnackbar";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
-// oxlint-disable typescript/consistent-type-imports
 import GameLibraryForm from "@/components/game/GameLibraryForm.vue";
 import GameDetailsSection from "@/components/game/GameDetailsSection.vue";
 import GameSidebar from "@/components/game/GameSidebar.vue";

--- a/frontend/src/pages/settings/AccountSettings.vue
+++ b/frontend/src/pages/settings/AccountSettings.vue
@@ -144,7 +144,7 @@ import { gqlClient } from "@/graphql/client";
 import { DELETE_USER, RESET_USER_LIBRARY, UPDATE_EMAIL, UPDATE_PASSWORD } from "@/graphql/mutations/users-settings";
 import { extractGqlError } from "@/utils/graphql-errors";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
-import { CircleAlert } from "lucide-vue-next";
+import { CircleAlert } from "@lucide/vue";
 
 interface MutationResult {
   updateEmail?: { user?: { id: string } | null; errors: string[] } | null;

--- a/frontend/src/pages/settings/ApiTokenSettings.vue
+++ b/frontend/src/pages/settings/ApiTokenSettings.vue
@@ -41,7 +41,7 @@ import { useMutation } from "@/composables/useGraphQL";
 import { RESET_API_TOKEN } from "@/graphql/mutations/users-settings";
 import { extractGqlError } from "@/utils/graphql-errors";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
-import { KeyRound } from "lucide-vue-next";
+import { KeyRound } from "@lucide/vue";
 interface ResetApiTokenResult {
   resetApiToken?: {
     apiToken?: string | null;

--- a/frontend/src/pages/users/UserActivityPage.vue
+++ b/frontend/src/pages/users/UserActivityPage.vue
@@ -153,7 +153,7 @@ import { DELETE_EVENT } from "@/graphql/mutations/events";
 import type { GamePurchaseCompletionStatus, DeleteEventMutation } from "@/types/graphql";
 import PaginationNav from "@/components/PaginationNav.vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
-import { Trash2 } from "lucide-vue-next";
+import { Trash2 } from "@lucide/vue";
 import { useAuthStore } from "@/stores/auth";
 import { useSnackbar } from "@/composables/useSnackbar";
 

--- a/frontend/src/pages/users/UserShowPage.vue
+++ b/frontend/src/pages/users/UserShowPage.vue
@@ -339,7 +339,7 @@ import {
 } from "@/graphql/mutations/users";
 import type { GetUserQuery } from "@/types/graphql";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
-import { CircleAlert, ShieldCheck, UserMinus } from "lucide-vue-next";
+import { CircleAlert, ShieldCheck, UserMinus } from "@lucide/vue";
 
 const route = useRoute("user");
 const router = useRouter();


### PR DESCRIPTION
Fixes #4473. The old package was deprecated.