### PR TITLE
Fix factory lint failure.

### DIFF
--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
     end
 
     trait :giantbomb_id do
-      giantbomb_id { "3030-#{Faker::Number.unique.number(digits: rand(1..4))}" }
+      sequence(:giantbomb_id) { |n| "3030-#{n}" }
     end
 
     trait :epic_games_store_id do


### PR DESCRIPTION
When `rand(1)` happened this would occasionally fail due to the lack of unique possible values.