### PR TITLE
Fix terminal logging theme for GraphQL.

### DIFF
--- a/config/initializers/graphql_rails_logger.rb
+++ b/config/initializers/graphql_rails_logger.rb
@@ -4,7 +4,5 @@
 if Rails.env.development?
   GraphQL::RailsLogger.configure do |config|
     config.skip_introspection_query = true
-    # Use a theme that actually works on a light terminal background.
-    config.theme = Rouge::Themes::Github.new
   end
 end


### PR DESCRIPTION
I use a dark theme now so I guess we can remove the custom theme.