### PR TITLE
Cache apt packages in CI to avoid reinstalling libvips/imagemagick each run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libvips-tools imagemagick
+      - name: Install system dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+        with:
+          packages: libvips-tools imagemagick
+          version: "1.0"
       - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: "3.4.9"
@@ -208,8 +211,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libvips-tools imagemagick
+      - name: Install system dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+        with:
+          packages: libvips-tools imagemagick
+          version: "1.0"
       - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: "3.4.9"


### PR DESCRIPTION
## Summary

The `rspec` and `factory_bot_lint` jobs install `libvips-tools` and `imagemagick` via `apt-get update && apt-get install` on **every** run — ~14.5s each, 45 packages, 33.7MB of downloads ([example run](https://github.com/connorshea/vglist/actions/runs/28748639445/job/85243794016)).

This replaces those raw `apt-get` steps with [`awalsh128/cache-apt-pkgs-action`](https://github.com/awalsh128/cache-apt-pkgs-action) (SHA-pinned to v1.6.3, per repo convention). The action caches the resolved `.deb` set and install state, so on a cache hit subsequent runs restore from cache and skip both the `apt-get update` and the download.

## Notes

- **Same packages installed.** `libvips-tools` is kept intentionally — we plan to migrate ActiveStorage from `mini_magick` to vips.
- `version: "1.0"` is a manual cache-busting key; bump it if the package list changes.
- Caching works fine under the top-level `permissions: {}` — the Actions cache service uses a separate runtime token, not the scoped `GITHUB_TOKEN`.
- **First run after merge is a cache miss** (it populates the cache), so the speedup shows up on the *second* run onward. Worth confirming the wall-clock actually drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)