### PR TITLE
Add Cloudflare R2 ActiveStorage service for the Railway migration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,12 +33,11 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # We actually use DigitalOcean for this, but the key is called Amazon because
-  # DigitalOcean Spaces is S3-compatible.
-  # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  # Store uploaded files in Cloudflare R2, served publicly from
+  # files.vglist.co (see config/storage.yml for options).
+  config.active_storage.service = :r2
 
-  # Proxy storage requests directly to DigitalOcean rather than using a redirect.
+  # Proxy storage requests directly to the storage provider rather than using a redirect.
   # config.active_storage.resolve_model_to_route = :rails_storage_proxy
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,8 +6,24 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use DigitalOcean Spaces (which is S3-compatible) for ActiveStorage in production.
-# Use rails credentials:edit to set the AWS secrets (as digitalocean:access_key_id|secret_access_key)
+# Cloudflare R2 (S3-compatible) for ActiveStorage in production. Uploads go
+# through the account's S3 API endpoint; objects are served publicly from the
+# custom domain connected to the bucket (public_host). See
+# ActiveStorage::Service::R2Service (lib/active_storage/service/r2_service.rb).
+r2:
+  service: R2
+  access_key_id: <%= ENV["R2_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["R2_SECRET_ACCESS_KEY"] %>
+  endpoint: <%= ENV["R2_ENDPOINT"] %>
+  region: auto
+  bucket: <%= ENV.fetch("R2_BUCKET", "vglist") %>
+  public: true
+  public_host: <%= ENV.fetch("R2_PUBLIC_HOST", "https://files.vglist.co") %>
+
+# Legacy: DigitalOcean Spaces (also S3-compatible), used for ActiveStorage in
+# production before the migration to Cloudflare R2. Remove once the migration
+# is complete and the Spaces bucket has been decommissioned.
+# Secrets are in encrypted credentials (digitalocean:access_key_id|secret_access_key).
 amazon:
   service: S3
   access_key_id: <%= Rails.application.credentials.dig(:digitalocean, :access_key_id) %>

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -49,8 +49,9 @@
 		#   'unsafe-inline' on style-src-attr covers those; style-src stays
 		#   strict apart from Vite's build-time CSS injection which also needs
 		#   it. We never render untrusted HTML, so this is low-risk.
-		# - img-src includes the Digital Ocean Spaces bucket that serves game
-		#   covers and user avatars.
+		# - img-src includes the Cloudflare R2 custom domain that serves game
+		#   covers and user avatars, plus the legacy Digital Ocean Spaces
+		#   bucket (drop the Spaces host once the R2 migration is complete).
 		# - connect-src uses {$API_ORIGIN} (set per-environment on the service)
 		#   so the cutover from vglist-production.up.railway.app to
 		#   api.vglist.co is a one-variable change. *.sentry.io is whitelisted
@@ -59,7 +60,7 @@
 		#   (only works as a real header, not via <meta>).
 		# - upgrade-insecure-requests auto-upgrades any stray http:// asset
 		#   URLs (e.g. from older cached data) to https://.
-		Content-Security-Policy "default-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: https://vglist.sfo2.digitaloceanspaces.com; font-src 'self' data:; connect-src 'self' {$API_ORIGIN:https://vglist-production.up.railway.app} https://*.sentry.io; upgrade-insecure-requests"
+		Content-Security-Policy "default-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: https://files.vglist.co https://vglist.sfo2.digitaloceanspaces.com; font-src 'self' data:; connect-src 'self' {$API_ORIGIN:https://vglist-production.up.railway.app} https://*.sentry.io; upgrade-insecure-requests"
 	}
 
 	root * /app/dist

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -50,7 +50,7 @@
 		#   strict apart from Vite's build-time CSS injection which also needs
 		#   it. We never render untrusted HTML, so this is low-risk.
 		# - img-src includes the Cloudflare R2 custom domain that serves game
-		#   covers and user avatars, plus the legacy Digital Ocean Spaces
+		#   covers and user avatars, plus the legacy DigitalOcean Spaces
 		#   bucket (drop the Spaces host once the R2 migration is complete).
 		# - connect-src uses {$API_ORIGIN} (set per-environment on the service)
 		#   so the cutover from vglist-production.up.railway.app to

--- a/lib/active_storage/service/r2_service.rb
+++ b/lib/active_storage/service/r2_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'active_storage/service/s3_service'
+
+module ActiveStorage
+  # ActiveStorage service for Cloudflare R2, which is S3-compatible but
+  # diverges from S3 in ways that matter here:
+  #
+  # - R2 rejects the streaming checksums that aws-sdk-s3 >= 1.178 sends by
+  #   default, so checksum calculation/validation is restricted to
+  #   "when_required".
+  # - Objects aren't publicly reachable via the S3 API endpoint. Public access
+  #   goes through the custom domain connected to the bucket, so public URLs
+  #   are built from +public_host+ instead of asking the SDK.
+  # - R2 ignores S3 ACLs, so the "public-read" ACL that the stock S3Service
+  #   adds to uploads when `public: true` is stripped.
+  #
+  # Configured via the `r2` entry in config/storage.yml.
+  class Service::R2Service < Service::S3Service
+    attr_reader :public_host
+
+    def initialize(public_host:, **options)
+      super(
+        force_path_style: true,
+        request_checksum_calculation: 'when_required',
+        response_checksum_validation: 'when_required',
+        **options
+      )
+      @public_host = public_host.chomp('/')
+      upload_options.delete(:acl)
+    end
+
+    private
+
+    def public_url(key, **)
+      "#{public_host}/#{key}"
+    end
+  end
+end

--- a/spec/lib/active_storage/service/r2_service_spec.rb
+++ b/spec/lib/active_storage/service/r2_service_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'active_storage/service/r2_service'
+
+RSpec.describe ActiveStorage::Service::R2Service do
+  let(:config) do
+    {
+      r2: {
+        service: 'R2',
+        access_key_id: 'test-key',
+        secret_access_key: 'test-secret',
+        endpoint: 'https://example-account.r2.cloudflarestorage.com',
+        region: 'auto',
+        bucket: 'vglist-test-bucket',
+        public: true,
+        public_host: 'https://files.example.com/'
+      }
+    }
+  end
+
+  let(:service) { ActiveStorage::Service.configure(:r2, config) }
+
+  it 'resolves from a storage.yml-style configuration' do
+    expect(service).to be_a(described_class)
+  end
+
+  it 'builds public URLs from the custom domain rather than the S3 endpoint' do
+    expect(service.url('some-blob-key')).to eq('https://files.example.com/some-blob-key')
+  end
+
+  it 'does not send an ACL on uploads since R2 ignores S3 ACLs' do
+    expect(service.upload_options).not_to have_key(:acl)
+  end
+
+  it 'uses path-style addressing against the account endpoint' do
+    expect(service.client.client.config.force_path_style).to be(true)
+  end
+
+  it 'restricts request checksums to when_required for R2 compatibility' do
+    expect(service.client.client.config.request_checksum_calculation).to eq('when_required')
+  end
+
+  it 'restricts response checksum validation to when_required for R2 compatibility' do
+    expect(service.client.client.config.response_checksum_validation).to eq('when_required')
+  end
+end


### PR DESCRIPTION
## Summary

Part of the DigitalOcean → Railway migration: moves ActiveStorage from DigitalOcean Spaces to Cloudflare R2.

- Adds `ActiveStorage::Service::R2Service` (S3Service subclass) handling R2's divergences from S3:
  - checksum calculation/validation restricted to `when_required` (R2 rejects the streaming checksums aws-sdk-s3 ≥ 1.178 sends by default)
  - public URLs built from the bucket's connected custom domain (`files.vglist.co`) instead of the S3 API endpoint (R2 has no public S3-endpoint URLs)
  - upload ACLs stripped (R2 ignores S3 ACLs)
- Adds an `r2` service to `config/storage.yml`, configured via `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_ENDPOINT` / `R2_BUCKET` / `R2_PUBLIC_HOST` env vars
- Switches `production.rb` to `config.active_storage.service = :r2`
- Frontend Caddyfile CSP: adds `https://files.vglist.co` to `img-src`
- Keeps the legacy `amazon` (Spaces) service entry + Spaces CSP host until decommission

## Deployment ordering

⚠️ Before merging: the R2 bucket must exist with `files.vglist.co` connected, and `R2_*` env vars must be set on the Railway backend service. Existing blobs also need `UPDATE active_storage_blobs SET service_name = 'r2' WHERE service_name = 'amazon';` after the rclone sync from Spaces.

The first commit is intended to be cherry-picked onto the DO-production backport branch (off `ab26bc52`) so storage can migrate to R2 before the Railway cutover.

## Test plan

- New spec `spec/lib/active_storage/service/r2_service_spec.rb` covers service resolution from config, custom-domain public URLs, ACL stripping, path-style addressing, and checksum settings (6 examples, all passing)
- Manual verification once the bucket exists: upload + variant generation + public URL fetch through `files.vglist.co`

🤖 Generated with [Claude Code](https://claude.com/claude-code)