### PR TITLE
Only accept OAuth access tokens from the Authorization header

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -38,14 +38,20 @@ class GraphqlController < ApplicationController
 
   # Check whether the user is using OAuth based on whether a Doorkeeper token exists.
   def user_using_oauth?
-    return false unless request.headers.key?('Authorization')
+    # If the token is a JWT (contains dots), it's not OAuth.
+    return false if user_using_jwt?
 
-    # If the token is a JWT (contains dots), it's not OAuth
-    auth_header = request.headers['Authorization']
-    token = auth_header&.sub(/^Bearer\s+/i, '')
-    return false if token&.count('.') == 2
+    # An `Authorization` header that isn't a JWT is an OAuth attempt, even if the
+    # token turns out to be bogus — those still need to fail via
+    # `doorkeeper_authorize!` rather than silently falling through as anonymous.
+    return true if request.headers.key?('Authorization')
 
-    true
+    # Defence in depth: Doorkeeper is configured to only accept tokens from the
+    # `Authorization` header (see `access_token_methods` in
+    # config/initializers/doorkeeper.rb), but if that ever changes, any token
+    # Doorkeeper does resolve must still go through the scope/expiry/revocation
+    # checks in `doorkeeper_authorize!` instead of skipping them.
+    doorkeeper_token.present?
   end
 
   # Check whether the user is using JWT authentication.

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -260,7 +260,13 @@ Doorkeeper.configure do
   # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
   # for more information on customization
   #
-  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+  # Only accept access tokens from the `Authorization` header. The parameter
+  # forms (`?access_token=`/`?bearer_token=` and the equivalent body fields) are
+  # deliberately disabled: RFC 6750 §2.3/§5.3 discourages them (tokens leak into
+  # logs, referrers and browser history), and GraphqlController only routes
+  # requests through `doorkeeper_authorize!` — the check for scopes, expiry and
+  # revocation — when the token arrives in that header.
+  access_token_methods :from_bearer_authorization
 
   # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
   # by default in non-development environments). OAuth2 delegates security in

--- a/spec/requests/api/token_transport_spec.rb
+++ b/spec/requests/api/token_transport_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression coverage for the OAuth token transport. Doorkeeper's default
+# `access_token_methods` also accepts `?access_token=`/`?bearer_token=` and the
+# equivalent body fields, but GraphqlController only routes a request through
+# `doorkeeper_authorize!` when the token arrives in the `Authorization` header.
+# A parameter-borne token therefore used to authenticate its resource owner
+# while skipping the scope, expiry and revocation checks entirely.
+RSpec.describe "API token transport", type: :request do
+  let(:user) { create(:confirmed_user) }
+  let(:application) { build(:application, owner: user) }
+  let(:game) { create(:game) }
+
+  let(:query) do
+    <<-GRAPHQL
+      query {
+        currentUser {
+          id
+          username
+        }
+      }
+    GRAPHQL
+  end
+
+  let(:mutation) do
+    <<-GRAPHQL
+      mutation($gameId: ID!) {
+        addGameToLibrary(gameId: $gameId) {
+          gamePurchase {
+            id
+          }
+        }
+      }
+    GRAPHQL
+  end
+
+  def graphql_post(params)
+    post graphql_path, params: params
+    JSON.parse(response.body)
+  end
+
+  context 'with a read-only token' do
+    let(:read_only_token) do
+      create(:access_token, resource_owner_id: user.id, application: application, scopes: 'read')
+    end
+
+    it "rejects a mutation when the token is in the Authorization header" do
+      result = api_request(mutation, variables: { game_id: game.id }, token: read_only_token)
+
+      expect(result.to_h['errors'].first['message'])
+        .to eq("Your token must have the 'write' scope to perform a mutation.")
+      expect(GamePurchase.count).to eq(0)
+    end
+
+    it "does not authenticate a mutation when the token is a query parameter" do
+      body = graphql_post(
+        query: mutation,
+        variables: { gameId: game.id }.to_json,
+        access_token: read_only_token.token
+      )
+
+      expect(body.dig('data', 'addGameToLibrary')).to be_nil
+      expect(body['errors']).to be_present
+      expect(GamePurchase.count).to eq(0)
+    end
+  end
+
+  context 'with a revoked token' do
+    let(:revoked_token) do
+      create(:access_token, resource_owner_id: user.id, application: application).tap(&:revoke)
+    end
+
+    it "rejects a query when the token is in the Authorization header" do
+      result = api_request(query, token: revoked_token)
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(result.to_h.dig('data', 'currentUser')).to be_nil
+    end
+
+    it "does not authenticate a query when the token is a query parameter" do
+      body = graphql_post(query: query, access_token: revoked_token.token)
+
+      expect(body.dig('data', 'currentUser')).to be_nil
+    end
+
+    it "does not authenticate a query when the token is a bearer_token parameter" do
+      body = graphql_post(query: query, bearer_token: revoked_token.token)
+
+      expect(body.dig('data', 'currentUser')).to be_nil
+    end
+  end
+
+  context 'with a valid token passed as a parameter' do
+    let(:access_token) do
+      create(:access_token, resource_owner_id: user.id, application: application)
+    end
+
+    it "does not authenticate via the access_token parameter" do
+      body = graphql_post(query: query, access_token: access_token.token)
+
+      expect(body.dig('data', 'currentUser')).to be_nil
+    end
+
+    it "does not authenticate via the bearer_token parameter" do
+      body = graphql_post(query: query, bearer_token: access_token.token)
+
+      expect(body.dig('data', 'currentUser')).to be_nil
+    end
+
+    it "still authenticates via the Authorization header" do
+      result = api_request(query, token: access_token)
+
+      expect(result.graphql_dig(:current_user, :username)).to eq(user.username)
+    end
+  end
+end


### PR DESCRIPTION
## The problem

Doorkeeper's default `access_token_methods` accepts `?access_token=`, `?bearer_token=` and the equivalent POST body fields, and our initializer left that default in place. `GraphqlController` only routes a request through `doorkeeper_authorize!` — the sole check for scope, expiry and revocation — when `user_using_oauth?` is true, and that method gated entirely on the presence of an `Authorization` header.

So a token supplied as a parameter skipped that branch, while `execute`'s `graphql_current_user = @jwt_user || @api_token_user || doorkeeper_user` still resolved its resource owner. `token_auth` (`!user_using_oauth?`) then came out true, which short-circuits the scope guards in `Types::BaseObject.authorized?` and `Mutations::BaseMutation#ready?`.

Net effect: any row in `oauth_access_tokens` — read-only, expired or revoked — authenticated its owner over `POST /graphql?access_token=…` with unscoped read+write, including `resetApiToken`.

Introduced in 90bf2552 ("Convert Rails app to API-only mode for Vue SPA frontend"), which replaced the blocking `before_action` chain with a non-blocking `authenticate_user_if_possible` and turned the auth branch into an unconditional `|| doorkeeper_user` fallback.

## The fix

Two layers:

- **`config/initializers/doorkeeper.rb`** — set `access_token_methods :from_bearer_authorization` so the parameter forms are not accepted at all. RFC 6750 §2.3/§5.3 discourages them anyway, since tokens leak into logs, referrers and browser history.
- **`app/controllers/graphql_controller.rb`** — base `user_using_oauth?` on whether Doorkeeper actually resolved a token rather than on the header alone, so the scope/expiry/revocation check can't be routed around if the transport config ever changes. The header short-circuit is kept so a bogus non-JWT bearer token still gets a 401 instead of silently falling through as anonymous.

Anonymous requests pay no extra query — with header-only methods, `doorkeeper_token` returns nil without a `by_token` lookup.

## Verification

New spec `spec/requests/api/token_transport_spec.rb` (8 examples). Confirmed it's a real regression test by reverting the source and re-running:

| Source state | Result |
|---|---|
| Before the fix | **5 failures** — read-only token writes, revoked token authenticates, both param forms work |
| Controller fix only | 2 failures — a *valid* token still authenticates via param |
| Initializer fix only | 0 failures |
| Both fixes | 0 failures |

The two layers aren't redundant: the initializer closes the transport, the controller closes the authorization gate behind it. Either alone stops the privilege escalation; both together also stop unintended parameter-based authentication.

Full suite passes (934 examples, 0 failures); rubocop clean.

## Out of scope

Two things noted while working on this, deliberately left alone:

- `config/routes.rb:23-29` points `use_doorkeeper` at `oauth/applications`, `oauth/authorized_applications` and `oauth/authorizations`, none of which exist — those routes raise `uninitialized constant`. Users can't revoke tokens through the UI. `POST /settings/oauth/revoke` on Doorkeeper's built-in controller is unaffected by this change and still works.
- The `TODO: MAKE SURE TO UNDO THIS BEFORE PRODUCTION RELEASE` on `first_party?` (`app/controllers/graphql_controller.rb:109`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)