### PR TITLE
Enforce ban and follow authorization in the GraphQL API

### DIFF
--- a/app/graphql/mutations/games/favorite_game.rb
+++ b/app/graphql/mutations/games/favorite_game.rb
@@ -18,4 +18,14 @@ class Mutations::Games::FavoriteGame < Mutations::BaseMutation
       game: game
     }
   end
+
+  def authorized?(object)
+    game = Game.find_by(id: object[:game_id])
+
+    return false if game.nil?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to favorite this game." unless GamePolicy.new(@context[:current_user], game).favorite?
+
+    return true
+  end
 end

--- a/app/graphql/mutations/games/unfavorite_game.rb
+++ b/app/graphql/mutations/games/unfavorite_game.rb
@@ -18,4 +18,14 @@ class Mutations::Games::UnfavoriteGame < Mutations::BaseMutation
       game: game
     }
   end
+
+  def authorized?(object)
+    game = Game.find_by(id: object[:game_id])
+
+    return false if game.nil?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to unfavorite this game." unless GamePolicy.new(@context[:current_user], game).unfavorite?
+
+    return true
+  end
 end

--- a/app/graphql/mutations/users/follow_user.rb
+++ b/app/graphql/mutations/users/follow_user.rb
@@ -18,4 +18,14 @@ class Mutations::Users::FollowUser < Mutations::BaseMutation
       user: user
     }
   end
+
+  def authorized?(object)
+    user = User.find_by(id: object[:user_id])
+
+    return false if user.nil?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to follow this user." unless RelationshipPolicy.new(@context[:current_user], user).create?
+
+    return true
+  end
 end

--- a/app/graphql/mutations/users/unfollow_user.rb
+++ b/app/graphql/mutations/users/unfollow_user.rb
@@ -18,4 +18,14 @@ class Mutations::Users::UnfollowUser < Mutations::BaseMutation
       user: user
     }
   end
+
+  def authorized?(object)
+    user = User.find_by(id: object[:user_id])
+
+    return false if user.nil?
+
+    raise GraphQL::ExecutionError, "You aren't allowed to unfollow this user." unless RelationshipPolicy.new(@context[:current_user], user).destroy?
+
+    return true
+  end
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -81,9 +81,13 @@ module Types
     private
 
     def user_visible?
-      # Short-circuit if the user has a public account, to prevent instantiating
-      # a UserPolicy and all that.
-      return @object.public_account? || UserPolicy.new(@context[:current_user], @object).show?
+      # Short-circuit if the user has a public account and hasn't been banned,
+      # to prevent instantiating a UserPolicy and all that. This condition must
+      # stay identical to the first clause of UserPolicy#user_profile_is_visible?,
+      # otherwise the fast path can expose profiles the policy would hide.
+      return true if @object.public_account? && !@object.banned?
+
+      UserPolicy.new(@context[:current_user], @object).show?
     end
   end
 end

--- a/app/policies/game_purchase_policy.rb
+++ b/app/policies/game_purchase_policy.rb
@@ -42,8 +42,11 @@ class GamePurchasePolicy < ApplicationPolicy
     user && game_purchase&.user_id == user&.id
   end
 
+  # Game purchases are only visible to other users if their owner has a public
+  # account and hasn't been banned, matching UserPolicy#user_profile_is_visible?.
   def user_profile_is_visible?
-    game_purchase&.user&.public_account? || game_purchase_belongs_to_user? || user&.admin?
+    owner = game_purchase&.user
+    (owner&.public_account? && !owner&.banned?) || game_purchase_belongs_to_user? || user&.admin?
   end
 
   def user_signed_in?

--- a/app/policies/relationship_policy.rb
+++ b/app/policies/relationship_policy.rb
@@ -10,7 +10,7 @@ class RelationshipPolicy < ApplicationPolicy
   end
 
   def create?
-    follower_is_not_followed? && !follower.nil? && followed.public_account?
+    follower_is_not_followed? && !follower.nil? && followed.public_account? && !followed.banned?
   end
 
   # Unlike following, unfollowing doesn't require a public account: a user who

--- a/app/policies/relationship_policy.rb
+++ b/app/policies/relationship_policy.rb
@@ -13,8 +13,11 @@ class RelationshipPolicy < ApplicationPolicy
     follower_is_not_followed? && !follower.nil? && followed.public_account?
   end
 
+  # Unlike following, unfollowing doesn't require a public account: a user who
+  # follows a public account that later becomes private still needs to be able
+  # to remove themselves from its follower list.
   def destroy?
-    follower_is_not_followed? && !follower.nil? && followed.public_account?
+    follower_is_not_followed? && !follower.nil?
   end
 
   protected

--- a/spec/policies/game_purchase_policy_spec.rb
+++ b/spec/policies/game_purchase_policy_spec.rb
@@ -129,6 +129,74 @@ RSpec.describe GamePurchasePolicy, type: :policy do
     end
   end
 
+  describe 'A normal user when the user that is being viewed is banned' do
+    let(:banned_user) { create(:banned_user) }
+    let(:user) { create(:confirmed_user) }
+    let(:game_purchase) { create(:game_purchase, user: banned_user) }
+
+    it "is allowed to see and do nothing" do
+      # It can create because create only allows you to create for the logged-in user.
+      expect(game_purchase_policy).to permit_action(:create)
+      expect(game_purchase_policy).to forbid_actions(
+        [
+          :index,
+          :show,
+          :update,
+          :bulk_update,
+          :destroy
+        ]
+      )
+    end
+  end
+
+  describe 'A user that is not logged in when the user that is being viewed is banned' do
+    let(:banned_user) { create(:banned_user) }
+    let(:user) { nil }
+    let(:game_purchase) { create(:game_purchase, user: banned_user) }
+
+    it "is allowed to see and do nothing" do
+      expect(game_purchase_policy).to forbid_actions(
+        [
+          :index,
+          :show,
+          :create,
+          :update,
+          :bulk_update,
+          :destroy
+        ]
+      )
+    end
+  end
+
+  describe 'An admin user when the user that is being viewed is banned' do
+    let(:banned_user) { create(:banned_user) }
+    let(:user) { create(:confirmed_admin) }
+    let(:game_purchase) { create(:game_purchase, user: banned_user) }
+
+    it "is allowed to see the game purchases but not modify them" do
+      expect(game_purchase_policy).to permit_actions([:index, :show, :create])
+      expect(game_purchase_policy).to forbid_actions([:update, :bulk_update, :destroy])
+    end
+  end
+
+  describe 'A banned user viewing their own game purchases' do
+    let(:user) { create(:banned_user) }
+    let(:game_purchase) { create(:game_purchase, user: user) }
+
+    it "is allowed to see and modify them" do
+      expect(game_purchase_policy).to permit_actions(
+        [
+          :index,
+          :show,
+          :create,
+          :update,
+          :bulk_update,
+          :destroy
+        ]
+      )
+    end
+  end
+
   describe 'A user that is not logged in when the user that is being viewed is private' do
     let(:private_user) { create(:private_user) }
     let(:user) { nil }

--- a/spec/policies/relationship_policy_spec.rb
+++ b/spec/policies/relationship_policy_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe RelationshipPolicy, type: :policy do
 
     it { should forbid_actions([:create, :destroy]) }
   end
+
+  describe 'A logged-in user and a private account' do
+    let(:current_user) { build_stubbed(:confirmed_user) }
+    let(:followed) { build_stubbed(:private_user) }
+
+    it "can't follow them, but can unfollow them" do
+      # Unfollowing has to stay allowed, otherwise anyone who followed the
+      # account before it went private would be stuck following it.
+      expect(relationship_policy).to forbid_action(:create)
+      expect(relationship_policy).to permit_action(:destroy)
+    end
+  end
 end

--- a/spec/policies/relationship_policy_spec.rb
+++ b/spec/policies/relationship_policy_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe RelationshipPolicy, type: :policy do
     it { should forbid_actions([:create, :destroy]) }
   end
 
+  describe 'A logged-in user and a banned account' do
+    let(:current_user) { build_stubbed(:confirmed_user) }
+    let(:followed) { build_stubbed(:banned_user) }
+
+    it "can't follow them, but can unfollow them" do
+      expect(relationship_policy).to forbid_action(:create)
+      expect(relationship_policy).to permit_action(:destroy)
+    end
+  end
+
   describe 'A logged-in user and a private account' do
     let(:current_user) { build_stubbed(:confirmed_user) }
     let(:followed) { build_stubbed(:private_user) }

--- a/spec/requests/api/game_purchases_spec.rb
+++ b/spec/requests/api/game_purchases_spec.rb
@@ -57,4 +57,29 @@ RSpec.describe "GamePurchase API", type: :request do
       expect(result.graphql_dig(:game_purchase)).to eq(nil)
     end
   end
+
+  describe "Query for data on game_purchase owned by banned user" do
+    let(:user) { create(:confirmed_user) }
+    let(:banned_user) { create(:banned_user) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:game_purchase) { create(:game_purchase_with_comments_and_rating, user: banned_user) }
+
+    it "returns null data" do
+      game_purchase
+      query_string = <<-GRAPHQL
+        query($id: ID!) {
+          gamePurchase(id: $id) {
+            id
+            rating
+            comments
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
+
+      expect(result.graphql_dig(:game_purchase)).to eq(nil)
+    end
+  end
 end

--- a/spec/requests/api/mutations/users/follow_user_spec.rb
+++ b/spec/requests/api/mutations/users/follow_user_spec.rb
@@ -41,5 +41,23 @@ RSpec.describe "FollowUser Mutation API", type: :request do
         }
       )
     end
+
+    it "returns an error when trying to follow a private user" do
+      private_user = create(:private_user)
+
+      expect do
+        result = api_request(query_string, variables: { id: private_user.id }, token: access_token)
+
+        expect(api_result_errors(result)).to include("You aren't allowed to follow this user.")
+      end.not_to change(Relationship, :count)
+    end
+
+    it "returns an error when trying to follow yourself" do
+      expect do
+        result = api_request(query_string, variables: { id: user.id }, token: access_token)
+
+        expect(api_result_errors(result)).to include("You aren't allowed to follow this user.")
+      end.not_to change(Relationship, :count)
+    end
   end
 end

--- a/spec/requests/api/mutations/users/follow_user_spec.rb
+++ b/spec/requests/api/mutations/users/follow_user_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe "FollowUser Mutation API", type: :request do
       end.not_to change(Relationship, :count)
     end
 
+    it "returns an error when trying to follow a banned user" do
+      banned_user = create(:banned_user)
+
+      expect do
+        result = api_request(query_string, variables: { id: banned_user.id }, token: access_token)
+
+        expect(api_result_errors(result)).to include("You aren't allowed to follow this user.")
+      end.not_to change(Relationship, :count)
+    end
+
     it "returns an error when trying to follow yourself" do
       expect do
         result = api_request(query_string, variables: { id: user.id }, token: access_token)

--- a/spec/requests/api/mutations/users/unfollow_user_spec.rb
+++ b/spec/requests/api/mutations/users/unfollow_user_spec.rb
@@ -42,5 +42,14 @@ RSpec.describe "UnfollowUser Mutation API", type: :request do
         }
       )
     end
+
+    it "unfollows a user that has since made their account private" do
+      relationship
+      user2.update!(privacy: :private_account)
+
+      expect do
+        api_request(query_string, variables: { id: user2.id }, token: access_token)
+      end.to change(Relationship, :count).by(-1)
+    end
   end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe "Users API", type: :request do
     let(:application_for_user_with_avatar) { build(:application, owner: user_with_avatar) }
     let(:access_token_for_user_with_avatar) { create(:access_token, resource_owner_id: user_with_avatar.id, application: application_for_user_with_avatar) }
     let(:private_user) { create(:private_user) }
+    let(:banned_user) { create(:banned_user) }
+    let(:admin) { create(:confirmed_admin) }
+    let(:application_for_admin) { build(:application, owner: admin) }
+    let(:admin_access_token) { create(:access_token, resource_owner_id: admin.id, application: application_for_admin) }
 
     it "returns basic data for user" do
       query_string = <<-GRAPHQL
@@ -182,6 +186,86 @@ RSpec.describe "Users API", type: :request do
           favoritedGames: { nodes: [] }
         }
       )
+    end
+
+    it "returns only public data for banned user" do
+      create(:game_purchase, user: banned_user)
+      create(:favorite_game, user: banned_user)
+
+      query_string = <<-GRAPHQL
+        query($id: ID!) {
+          user(id: $id) {
+            id
+            username
+            banned
+            bio
+            gamePurchases {
+              nodes {
+                id
+              }
+            }
+            activity {
+              nodes {
+                id
+              }
+            }
+            followers {
+              nodes {
+                id
+              }
+            }
+            following {
+              nodes {
+                id
+              }
+            }
+            favoritedGames {
+              nodes {
+                id
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, variables: { id: banned_user.id }, token: access_token)
+
+      expect(result.graphql_dig(:user)).to eq(
+        {
+          id: banned_user.id.to_s,
+          username: banned_user.username,
+          banned: true,
+          bio: nil,
+          gamePurchases: { nodes: [] },
+          activity: { nodes: [] },
+          followers: { nodes: [] },
+          following: { nodes: [] },
+          favoritedGames: { nodes: [] }
+        }
+      )
+    end
+
+    it "returns a banned user's data to an admin" do
+      create(:game_purchase, user: banned_user)
+
+      query_string = <<-GRAPHQL
+        query($id: ID!) {
+          user(id: $id) {
+            id
+            bio
+            gamePurchases {
+              nodes {
+                id
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, variables: { id: banned_user.id }, token: admin_access_token)
+
+      expect(result.graphql_dig(:user, :bio)).to eq(banned_user.bio)
+      expect(result.graphql_dig(:user, :gamePurchases, :nodes).length).to eq(1)
     end
 
     it "returns activity for user" do


### PR DESCRIPTION
Fixes two authorization gaps found by a scrutineer scan (findings #663 and #664).

## Banned users' data stayed readable

`Types::UserType#user_visible?` short-circuited on `public_account?` as a "fast path" for `UserPolicy#show?`, but the policy's `user_profile_is_visible?` checks `public_account? && !banned?`. For a public account that had been banned, the fast path returned true and the policy never ran, so `bio`, `followers`, `following`, `favoritedGames`, `gamePurchases` and `activity` stayed readable by anonymous callers. The short-circuit now matches the policy's first clause exactly.

`GamePurchasePolicy#user_profile_is_visible?` was missing the same `!banned?` check, so `gamePurchase(id:)` returned a banned user's library rows — comments, ratings and all — to anyone. It now matches `UserPolicy`.

Banned users still see their own profile and library, and admins still see both, via the policies' other clauses.

## followUser / unfollowUser / favoriteGame / unfavoriteGame were unauthorized

These four mutations defined no `authorized?` hook, and `BaseMutation` only gates the OAuth write scope, so `RelationshipPolicy` and `GamePolicy#favorite?`/`#unfavorite?` were dead code — nothing instantiated them. The only thing stopping an anonymous caller was the required `belongs_to` on `Relationship` and `FavoriteGame`, and the `public_account?` rule had no such backstop: any signed-in user could follow a private account.

Each mutation now has an `authorized?` hook that resolves the target record and consults its policy, following the idiom the other mutations use.

Two policy changes came with that:

- `RelationshipPolicy#destroy?` also required `public_account?`. Nothing drops followers when an account switches to private, so enforcing that as written would have trapped anyone who followed an account that later went private. Unfollowing now only requires a follower who isn't the followed user.
- `RelationshipPolicy#create?` now also refuses banned accounts, for the same reason their profiles are hidden. Unfollowing stays allowed so anyone who followed before the ban can still remove themselves.

## Tests

New specs cover each case, and each was confirmed to fail against the unpatched code:

- a banned user's profile returns `bio: nil` and empty connections, while an admin still sees them
- `gamePurchase(id:)` on a banned user's row returns `null`
- `GamePurchasePolicy` for banned owners: normal user, anonymous, admin, and the banned owner themselves
- `followUser` on a private account, a banned account, or yourself errors and creates no `Relationship`
- `unfollowUser` still works on an account that has since gone private

The full suite passed locally before the branch was rebased onto current `main`; the rebase only changed dependency versions, and the new `Gemfile.lock` pins gems I couldn't install locally, so CI is the authority on the post-rebase run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)