### PR TITLE
Fetch import cover URLs through an SSRF-safe downloader

### DIFF
--- a/app/services/remote_image_fetcher.rb
+++ b/app/services/remote_image_fetcher.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+require 'net/http'
+require 'resolv'
+require 'tempfile'
+
+# Downloads a remote image (a game cover) over HTTP(S).
+#
+# Cover URLs come out of third-party API responses (PCGamingWiki, MobyGames,
+# IGDB) rather than from an operator, and at least one of those is a wiki that
+# anyone can edit, so the URLs have to be treated as attacker-controlled.
+# Fetching one naively (e.g. `URI.parse(cover_url).open`) turns the import
+# tasks into a server-side request forgery primitive: the request is made from
+# inside the deployment network, where cloud metadata endpoints and
+# unauthenticated internal services live.
+#
+# Every request made here is therefore checked before a connection is opened:
+#
+# - the scheme must be http or https,
+# - the host must resolve only to public IP addresses,
+# - the connection is pinned to the address that was checked, so a DNS record
+#   that flips to a private address right after the check (DNS rebinding)
+#   can't be used to reach it,
+# - redirects are followed by hand, with every hop checked the same way,
+# - the response must claim to be an image, and is capped in size.
+#
+# Anything that goes wrong — a rejected URL, a connection failure, a non-image
+# response — raises RemoteImageFetcher::Error, so callers only need to rescue
+# the one class.
+class RemoteImageFetcher
+  class Error < StandardError; end
+
+  # Raised when a URL is rejected without a request being made.
+  class UnsafeUrlError < Error; end
+
+  ALLOWED_SCHEMES = ['http', 'https'].freeze
+
+  # Address ranges a cover must never be fetched from: loopback, RFC 1918 and
+  # other private space, link-local (which is where the cloud metadata
+  # endpoints live), and the various reserved/special-use blocks. The
+  # IPv4-mapped IPv6 range is blocked wholesale so `::ffff:127.0.0.1` can't
+  # sneak a private IPv4 address past the IPv4 checks.
+  BLOCKED_RANGES = [
+    '0.0.0.0/8',          # "this network"
+    '10.0.0.0/8',         # private
+    '100.64.0.0/10',      # carrier-grade NAT
+    '127.0.0.0/8',        # loopback
+    '169.254.0.0/16',     # link-local, incl. the 169.254.169.254 metadata endpoint
+    '172.16.0.0/12',      # private
+    '192.0.0.0/24',       # IETF protocol assignments
+    '192.0.2.0/24',       # TEST-NET-1
+    '192.88.99.0/24',     # 6to4 relay anycast
+    '192.168.0.0/16',     # private
+    '198.18.0.0/15',      # benchmarking
+    '198.51.100.0/24',    # TEST-NET-2
+    '203.0.113.0/24',     # TEST-NET-3
+    '224.0.0.0/4',        # multicast
+    '240.0.0.0/4',        # reserved, incl. 255.255.255.255
+    '::/128',             # unspecified
+    '::1/128',            # loopback
+    '::ffff:0:0/96',      # IPv4-mapped
+    '64:ff9b::/96',       # NAT64
+    '100::/64',           # discard-only
+    '2001:db8::/32',      # documentation
+    '2002::/16',          # 6to4
+    'fc00::/7',           # unique local
+    'fe80::/10',          # link-local
+    'ff00::/8'            # multicast
+  ].map { |range| IPAddr.new(range) }.freeze
+
+  MAX_REDIRECTS = 5
+  # Covers larger than this are rejected by the `Game#cover` size validation
+  # anyway; the cap here just stops us buffering an unbounded response.
+  MAX_SIZE = 8.megabytes
+  OPEN_TIMEOUT = 10
+  READ_TIMEOUT = 30
+
+  # A downloaded image. `io` is a rewound binary Tempfile suitable for
+  # `attach(io:)`, and `uri` is the URL it was ultimately fetched from (which
+  # may differ from the requested one if redirects were followed).
+  class Image
+    attr_reader :io, :uri
+
+    def initialize(io:, uri:)
+      @io = io
+      @uri = uri
+    end
+
+    # The last path segment of the URL, e.g. "cover.jpg". Falls back to
+    # "cover" for URLs that don't end in a filename.
+    def filename
+      name = File.basename(uri.path.to_s)
+      name.presence || 'cover'
+    end
+
+    # The file extension without the leading dot, e.g. "jpg". Empty when the
+    # URL has none.
+    def extension
+      File.extname(uri.path.to_s).delete_prefix('.')
+    end
+  end
+
+  # A URL that has passed validation, paired with the addresses the connection
+  # may be pinned to, in the order the resolver preferred them.
+  Target = Struct.new(:uri, :ips)
+  private_constant :Target
+
+  # @param url [String] the image URL, from an untrusted upstream response.
+  # @return [RemoteImageFetcher::Image]
+  # @raise [RemoteImageFetcher::Error]
+  def self.fetch(url)
+    new(url).fetch
+  end
+
+  def initialize(url)
+    @url = url
+  end
+
+  # @return [RemoteImageFetcher::Image]
+  # @raise [RemoteImageFetcher::Error]
+  def fetch
+    target = validated_target(@url)
+
+    (MAX_REDIRECTS + 1).times do
+      image = nil
+      location = nil
+
+      with_response(target) do |response|
+        case response
+        when Net::HTTPSuccess
+          image = Image.new(io: buffer(response), uri: target.uri)
+        when Net::HTTPRedirection
+          location = response['location']
+        else
+          raise Error, "Unexpected response: #{response.code} #{response.message}."
+        end
+      end
+
+      return image if image
+      raise Error, "Redirected without a Location header." if location.nil?
+
+      target = validated_target(location, relative_to: target.uri)
+    end
+
+    raise Error, "Too many redirects (more than #{MAX_REDIRECTS})."
+  end
+
+  private
+
+  # Parse and check a URL, resolving its host so the connection can be pinned
+  # to an address we've verified is public.
+  def validated_target(url, relative_to: nil)
+    uri = begin
+      relative_to.nil? ? URI.parse(url.to_s) : URI.join(relative_to, url.to_s)
+    rescue URI::Error => e
+      raise UnsafeUrlError, "Invalid URL: #{e.message}."
+    end
+
+    raise UnsafeUrlError, "URL scheme must be http or https, got #{uri.scheme.inspect}." unless ALLOWED_SCHEMES.include?(uri.scheme)
+
+    host = uri.hostname
+    raise UnsafeUrlError, "URL has no host." if host.blank?
+
+    Target.new(uri, public_addresses_for(host))
+  end
+
+  # Resolve a host and reject it unless *every* address it resolves to is
+  # public — a host with one public and one private address is still a way to
+  # reach the private one.
+  def public_addresses_for(host)
+    addresses = resolve(host)
+    raise UnsafeUrlError, "#{host} did not resolve to any addresses." if addresses.empty?
+
+    blocked = addresses.find { |address| blocked?(address) }
+    raise UnsafeUrlError, "#{host} resolves to a non-public address (#{blocked})." if blocked
+
+    addresses
+  end
+
+  def resolve(host)
+    # The URL may name an address directly, in which case there's nothing to
+    # look up.
+    begin
+      return [IPAddr.new(host)]
+    rescue IPAddr::InvalidAddressError
+      # Not a literal address, so fall through to DNS.
+    end
+
+    Addrinfo.getaddrinfo(host, nil, nil, :STREAM).map { |addrinfo| IPAddr.new(addrinfo.ip_address) }
+  rescue SocketError => e
+    raise Error, "Could not resolve #{host}: #{e.message}."
+  end
+
+  def blocked?(address)
+    BLOCKED_RANGES.any? { |range| range.include?(address) }
+  end
+
+  # Make the request, trying each of the host's addresses in turn the way
+  # Net::HTTP would if it were doing the resolving itself.
+  def with_response(target, &block)
+    last_error = nil
+
+    target.ips.each do |ip|
+      return request_from(target, ip, &block)
+    rescue Net::HTTPBadResponse, Net::ProtocolError, OpenSSL::SSL::SSLError, SocketError, SystemCallError, IOError, Timeout::Error => e
+      last_error = e
+    end
+
+    raise Error, "#{last_error.class}: #{last_error.message}"
+  end
+
+  def request_from(target, ip, &block)
+    http = Net::HTTP.new(target.uri.host, target.uri.port)
+    # Connect to the address we checked rather than resolving the host again.
+    # Net::HTTP still uses the hostname for the Host header, SNI and
+    # certificate verification, so this only closes the rebinding window.
+    http.ipaddr = ip.to_s
+    http.use_ssl = target.uri.scheme == 'https'
+    http.open_timeout = OPEN_TIMEOUT
+    http.read_timeout = READ_TIMEOUT
+
+    request = Net::HTTP::Get.new(target.uri)
+    request['Accept'] = 'image/*'
+    # Stream the bytes as-is so the size cap counts what we actually store.
+    request['Accept-Encoding'] = 'identity'
+
+    http.start do
+      http.request(request, &block)
+    end
+  end
+
+  # Stream the response body into a tempfile, refusing anything that isn't an
+  # image or is over the size cap.
+  def buffer(response)
+    content_type = response['content-type'].to_s.split(';').first.to_s.strip
+    raise Error, "Expected an image, got #{content_type.presence || 'no content type'}." unless content_type.start_with?('image/')
+
+    declared_size = response['content-length']&.to_i
+    raise Error, "Image is larger than #{MAX_SIZE} bytes (#{declared_size})." if declared_size && declared_size > MAX_SIZE
+
+    tempfile = Tempfile.new('vglist-cover')
+    tempfile.binmode
+    size = 0
+
+    begin
+      response.read_body do |chunk|
+        size += chunk.bytesize
+        raise Error, "Image is larger than #{MAX_SIZE} bytes." if size > MAX_SIZE
+
+        tempfile.write(chunk)
+      end
+    rescue StandardError
+      tempfile.close
+      tempfile.unlink
+      raise
+    end
+
+    tempfile.rewind
+    tempfile
+  end
+end

--- a/lib/tasks/import/igdb.rake
+++ b/lib/tasks/import/igdb.rake
@@ -146,24 +146,24 @@ namespace :import do
         next
       end
 
-      # Catch the error if the IGDB cover image doesn't actually exist.
+      # The cover URL comes out of the IGDB API response, so it's fetched
+      # through RemoteImageFetcher, which refuses non-public addresses. This
+      # also catches the case where the cover image doesn't actually exist.
       begin
         # Sleep between each attempt at pulling down the game cover, to avoid
         # hitting the IGDB website with a lot of load.
         sleep 0.25
-        cover_blob = URI.parse(igdb_game.dig('cover', 'url')).open
-      rescue OpenURI::HTTPError, URI::InvalidURIError, SocketError => e
+        cover = RemoteImageFetcher.fetch(igdb_game.dig('cover', 'url'))
+      rescue RemoteImageFetcher::Error => e
         progress_bar.log "#{game[:name].ljust(40)} | Error: #{e}"
         progress_bar.increment
         cover_not_found_or_errored_count += 1
         next
       end
 
-      # Incredibly stupid way to get the file extension from the IGDB cover URL.
-      file_ext = cover_blob.base_uri.to_s.split(%r{[/.]})[-1].to_s
       # Copy the image data to a file with ActiveStorage.
       # Call the cover file "123_from_igdb.jpg", where 123 is the vglist game ID.
-      game.cover.attach(io: cover_blob, filename: "#{game.id}_from_igdb.#{file_ext}")
+      game.cover.attach(io: cover.io, filename: "#{game.id}_from_igdb.#{cover.extension.presence || 'jpg'}")
 
       # If the cover has any errors, they'll show up on the `Game` record.
       # Check for any errors and print them if they exist.

--- a/lib/tasks/import/mobygames.rake
+++ b/lib/tasks/import/mobygames.rake
@@ -155,10 +155,12 @@ namespace :import do
         next
       end
 
-      # Catch the error if the MobyGames cover image doesn't actually exist.
+      # The cover URL comes out of the MobyGames API response, so it's fetched
+      # through RemoteImageFetcher, which refuses non-public addresses. This
+      # also catches the case where the cover image doesn't actually exist.
       begin
-        cover_blob = URI.parse(cover_url).open
-      rescue OpenURI::HTTPError => e
+        cover = RemoteImageFetcher.fetch(cover_url)
+      rescue RemoteImageFetcher::Error => e
         progress_bar.log "Error: #{e}"
         progress_bar.increment
         no_cover_url_count += 1
@@ -166,7 +168,7 @@ namespace :import do
       end
 
       # Attach the cover and get the filename from the last fragment of the URL.
-      game.cover.attach(io: cover_blob, filename: cover_blob.base_uri.to_s.split('/')[-1].to_s)
+      game.cover.attach(io: cover.io, filename: cover.filename)
       attached_covers_count += 1
       progress_bar.log "Added cover for #{game[:name]}."
       progress_bar.increment

--- a/lib/tasks/import/pcgamingwiki.rake
+++ b/lib/tasks/import/pcgamingwiki.rake
@@ -153,10 +153,12 @@ namespace :import do
         next
       end
 
-      # Catch the error if the PCGamingWiki cover image doesn't actually exist.
+      # The cover URL comes from a wiki anyone can edit, so it's fetched
+      # through RemoteImageFetcher, which refuses non-public addresses. This
+      # also catches the case where the cover image doesn't actually exist.
       begin
-        cover_blob = URI.parse(cover_url).open
-      rescue OpenURI::HTTPError, URI::InvalidURIError, SocketError => e
+        cover = RemoteImageFetcher.fetch(cover_url)
+      rescue RemoteImageFetcher::Error => e
         progress_bar.log "#{game[:name].ljust(40)} | Error: #{e}"
         progress_bar.increment
         cover_not_found_or_errored_count += 1
@@ -164,7 +166,7 @@ namespace :import do
       end
 
       # Copy the image data to a file with ActiveStorage.
-      game.cover.attach(io: cover_blob, filename: cover_blob.base_uri.to_s.split('/')[-1].to_s)
+      game.cover.attach(io: cover.io, filename: cover.filename)
 
       # If the cover has any errors, they'll show up on the `Game` record.
       # Check for any errors and print them if they exist.

--- a/spec/services/remote_image_fetcher_spec.rb
+++ b/spec/services/remote_image_fetcher_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RemoteImageFetcher, type: :service do
+  # A 1x1 PNG, so the fetched bytes are a real image.
+  let(:png) do
+    [137, 80, 78, 71, 13, 10, 26, 10].pack('C*') +
+      ['0000000d49484452000000010000000108060000001f15c489' \
+       '0000000a49444154789c6360000002000100ffff03000006000557bfabd4' \
+       '0000000049454e44ae426082'].pack('H*')
+  end
+
+  # Keep DNS out of the specs: every host that isn't an IP literal resolves to
+  # a public address unless a specific example says otherwise.
+  before(:each) do
+    allow(Addrinfo).to receive(:getaddrinfo).and_return([Addrinfo.ip('93.184.216.34')])
+  end
+
+  def resolves_to(host, *ips)
+    allow(Addrinfo).to receive(:getaddrinfo).with(host, any_args).and_return(ips.map { |ip| Addrinfo.ip(ip) })
+  end
+
+  describe '.fetch' do
+    it 'downloads an image from a public host' do
+      stub_request(:get, 'https://images.example.com/covers/half-life.png')
+        .to_return(status: 200, body: png, headers: { 'Content-Type' => 'image/png' })
+
+      image = described_class.fetch('https://images.example.com/covers/half-life.png')
+
+      expect(image.io.read).to eq(png)
+      expect(image.filename).to eq('half-life.png')
+      expect(image.extension).to eq('png')
+    end
+
+    it 'ignores the query string when deriving the filename' do
+      stub_request(:get, 'https://images.example.com/covers/half-life.png?width=500')
+        .to_return(status: 200, body: png, headers: { 'Content-Type' => 'image/png' })
+
+      image = described_class.fetch('https://images.example.com/covers/half-life.png?width=500')
+
+      expect(image.filename).to eq('half-life.png')
+    end
+
+    context 'with a URL that points somewhere internal' do
+      # The URLs in these examples are the shapes an attacker would use after
+      # editing a cover URL into an upstream service's data.
+      [
+        'http://127.0.0.1/latest/meta-data/',
+        'http://localhost:3000/admin',
+        'http://169.254.169.254/latest/meta-data/iam/security-credentials',
+        'http://10.0.0.5/internal',
+        'http://192.168.1.1/',
+        'http://172.16.0.1/',
+        'http://[::1]:8080/',
+        'http://[fd00::1]/',
+        'http://[::ffff:127.0.0.1]/'
+      ].each do |url|
+        it "refuses to request #{url}" do
+          resolves_to('localhost', '127.0.0.1')
+
+          expect { described_class.fetch(url) }.to raise_error(described_class::UnsafeUrlError, /non-public address/)
+          expect(a_request(:get, /.*/)).not_to have_been_made
+        end
+      end
+
+      it 'refuses a public hostname that resolves to a private address' do
+        resolves_to('rebind.example.com', '10.1.2.3')
+
+        expect { described_class.fetch('https://rebind.example.com/cover.png') }
+          .to raise_error(described_class::UnsafeUrlError, /non-public address/)
+        expect(a_request(:get, /.*/)).not_to have_been_made
+      end
+
+      it 'refuses a hostname that resolves to both a public and a private address' do
+        resolves_to('mixed.example.com', '93.184.216.34', '127.0.0.1')
+
+        expect { described_class.fetch('https://mixed.example.com/cover.png') }
+          .to raise_error(described_class::UnsafeUrlError, /non-public address/)
+      end
+
+      it 'refuses a redirect into private address space' do
+        stub_request(:get, 'https://images.example.com/cover.png')
+          .to_return(status: 302, headers: { 'Location' => 'http://169.254.169.254/latest/meta-data/' })
+
+        expect { described_class.fetch('https://images.example.com/cover.png') }
+          .to raise_error(described_class::UnsafeUrlError, /non-public address/)
+        expect(a_request(:get, 'http://169.254.169.254/latest/meta-data/')).not_to have_been_made
+      end
+    end
+
+    context 'with a URL that is not fetchable at all' do
+      it 'refuses a non-HTTP scheme' do
+        expect { described_class.fetch('file:///etc/passwd') }
+          .to raise_error(described_class::UnsafeUrlError, /scheme/)
+      end
+
+      it 'refuses a URL with no host' do
+        expect { described_class.fetch('https:///cover.png') }
+          .to raise_error(described_class::UnsafeUrlError, /no host/)
+      end
+
+      it 'refuses an unparseable URL' do
+        expect { described_class.fetch('http://exa mple.com/cover.png') }
+          .to raise_error(described_class::UnsafeUrlError, /Invalid URL/)
+      end
+
+      it 'refuses a nil URL' do
+        expect { described_class.fetch(nil) }.to raise_error(described_class::UnsafeUrlError)
+      end
+    end
+
+    context 'with a response that is not a usable image' do
+      it 'rejects a non-image content type' do
+        stub_request(:get, 'https://images.example.com/cover.png')
+          .to_return(status: 200, body: '{"token":"secret"}', headers: { 'Content-Type' => 'application/json' })
+
+        expect { described_class.fetch('https://images.example.com/cover.png') }
+          .to raise_error(described_class::Error, /Expected an image/)
+      end
+
+      it 'rejects a response whose declared size is over the cap' do
+        stub_request(:get, 'https://images.example.com/cover.png').to_return(
+          status: 200,
+          body: png,
+          headers: { 'Content-Type' => 'image/png', 'Content-Length' => (described_class::MAX_SIZE + 1).to_s }
+        )
+
+        expect { described_class.fetch('https://images.example.com/cover.png') }
+          .to raise_error(described_class::Error, /larger than/)
+      end
+
+      it 'rejects a response whose body exceeds the cap while streaming' do
+        stub_request(:get, 'https://images.example.com/cover.png')
+          .to_return(status: 200, body: 'a' * (described_class::MAX_SIZE + 1), headers: { 'Content-Type' => 'image/png' })
+
+        expect { described_class.fetch('https://images.example.com/cover.png') }
+          .to raise_error(described_class::Error, /larger than/)
+      end
+
+      it 'raises on an error response' do
+        stub_request(:get, 'https://images.example.com/cover.png').to_return(status: 404)
+
+        expect { described_class.fetch('https://images.example.com/cover.png') }
+          .to raise_error(described_class::Error, /404/)
+      end
+
+      it 'falls back to the host\'s other addresses when a connection fails' do
+        resolves_to('images.example.com', '93.184.216.34', '93.184.216.35')
+        stub_request(:get, 'https://images.example.com/cover.png')
+          .to_raise(Errno::ECONNREFUSED)
+          .then.to_return(status: 200, body: png, headers: { 'Content-Type' => 'image/png' })
+
+        expect(described_class.fetch('https://images.example.com/cover.png').io.read).to eq(png)
+      end
+
+      it 'raises when the connection fails' do
+        stub_request(:get, 'https://images.example.com/cover.png').to_raise(SocketError.new('getaddrinfo failed'))
+
+        expect { described_class.fetch('https://images.example.com/cover.png') }
+          .to raise_error(described_class::Error, /getaddrinfo failed/)
+      end
+    end
+
+    context 'with redirects' do
+      it 'follows a redirect to another public host' do
+        stub_request(:get, 'https://images.example.com/cover')
+          .to_return(status: 301, headers: { 'Location' => 'https://cdn.example.net/covers/final.jpg' })
+        stub_request(:get, 'https://cdn.example.net/covers/final.jpg')
+          .to_return(status: 200, body: png, headers: { 'Content-Type' => 'image/jpeg' })
+
+        image = described_class.fetch('https://images.example.com/cover')
+
+        expect(image.io.read).to eq(png)
+        expect(image.filename).to eq('final.jpg')
+      end
+
+      it 'follows a relative redirect' do
+        stub_request(:get, 'https://images.example.com/cover')
+          .to_return(status: 302, headers: { 'Location' => '/covers/final.png' })
+        stub_request(:get, 'https://images.example.com/covers/final.png')
+          .to_return(status: 200, body: png, headers: { 'Content-Type' => 'image/png' })
+
+        expect(described_class.fetch('https://images.example.com/cover').filename).to eq('final.png')
+      end
+
+      it 'gives up after too many redirects' do
+        stub_request(:get, 'https://images.example.com/cover')
+          .to_return(status: 302, headers: { 'Location' => 'https://images.example.com/cover' })
+
+        expect { described_class.fetch('https://images.example.com/cover') }
+          .to raise_error(described_class::Error, /Too many redirects/)
+      end
+
+      it 'raises when a redirect has no Location header' do
+        stub_request(:get, 'https://images.example.com/cover').to_return(status: 302)
+
+        expect { described_class.fetch('https://images.example.com/cover') }
+          .to raise_error(described_class::Error, /Location/)
+      end
+    end
+  end
+end

--- a/spec/tasks/import_covers_spec.rb
+++ b/spec/tasks/import_covers_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'socket'
+
+# The cover URL these tasks download comes out of an upstream API response
+# rather than from the operator running the task, and PCGamingWiki is a wiki
+# anyone can edit, so it has to be treated as attacker-controlled. See
+# RemoteImageFetcher for the checks applied to it.
+RSpec.describe 'import:pcgamingwiki:covers', type: :task do
+  # A 1x1 PNG, so the attached bytes are a real image.
+  let(:png) do
+    [137, 80, 78, 71, 13, 10, 26, 10].pack('C*') +
+      ['0000000d49484452000000010000000108060000001f15c489' \
+       '0000000a49444154789c6360000002000100ffff03000006000557bfabd4' \
+       '0000000049454e44ae426082'].pack('H*')
+  end
+
+  before(:each) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('import:pcgamingwiki:covers')
+    Rake::Task['import:pcgamingwiki:covers'].reenable
+  end
+
+  # Stand in for a PCGamingWiki page whose Cover URL an attacker has edited.
+  def stub_upstream(cover_url)
+    stub_request(:get, %r{www\.pcgamingwiki\.com/w/api\.php}).to_return(
+      status: 200,
+      headers: { 'Content-Type' => 'application/json' },
+      body: { cargoquery: [{ title: { 'Cover URL' => cover_url } }] }.to_json
+    )
+  end
+
+  # The task narrates itself with `puts` and a progress bar; keep that out of
+  # the spec output.
+  def run_task
+    original = $stdout
+    $stdout = StringIO.new
+    Rake::Task['import:pcgamingwiki:covers'].invoke
+  ensure
+    $stdout = original
+  end
+
+  it 'does not request an internal URL supplied by the upstream response' do
+    # A stand-in for a service inside the deployment network that the internet
+    # can't reach — a metadata endpoint, an admin port, an internal API.
+    requests = []
+    server = TCPServer.new('127.0.0.1', 0)
+    port = server.addr[1]
+    listener = Thread.new do
+      loop do
+        connection = server.accept
+        requests << connection.gets.to_s.strip
+        connection.print("HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        connection.close
+      end
+    end
+
+    create(:game, pcgamingwiki_id: 'Some_Game')
+    stub_upstream("http://127.0.0.1:#{port}/latest/meta-data/iam/security-credentials")
+
+    run_task
+
+    # Give the listener a moment to record a request, so an unblocked fetch
+    # can't pass by finishing after the assertion.
+    sleep 0.3
+    expect(requests).to be_empty
+    expect(Game.joins(:cover_attachment).count).to eq(0)
+  ensure
+    listener&.kill
+    server&.close
+  end
+
+  it 'attaches a cover from a public URL' do
+    # Resolution is stubbed so the spec doesn't depend on DNS.
+    allow(Addrinfo).to receive(:getaddrinfo).and_return([Addrinfo.ip('93.184.216.34')])
+    game = create(:game, pcgamingwiki_id: 'Some_Game')
+    stub_upstream('https://images.pcgamingwiki.com/covers/half-life.png')
+    stub_request(:get, 'https://images.pcgamingwiki.com/covers/half-life.png')
+      .to_return(status: 200, body: png, headers: { 'Content-Type' => 'image/png' })
+
+    run_task
+
+    expect(game.reload.cover).to be_attached
+    expect(game.cover.filename.to_s).to eq('half-life.png')
+    expect(game.cover.byte_size).to eq(png.bytesize)
+  end
+end


### PR DESCRIPTION
The cover-import tasks fetched a URL taken verbatim out of an upstream API response with `URI.parse(cover_url).open`. PCGamingWiki's `Cover_URL` is an ordinary wiki field any registered editor can set, so running `rake import:pcgamingwiki:covers` would issue an attacker-chosen GET from inside the deployment network, where cloud metadata endpoints and unauthenticated internal services live. The only guards on the value were `nil?` and `ascii_only?`. `import:mobygames:covers` and `import:igdb:covers` had the same shape.

## The fix

New `RemoteImageFetcher` service, with all three tasks routed through it:

- scheme must be `http` or `https`;
- the host is resolved up front and refused unless *every* address it resolves to is public (loopback, RFC 1918, link-local/`169.254.169.254`, CGNAT, ULA, IPv4-mapped IPv6 and the other reserved blocks);
- the connection is pinned to the address that was checked, via `Net::HTTP#ipaddr=` — which leaves the `Host` header, SNI and certificate verification on the hostname — so a DNS record that flips to a private address right after the check can't be used. Hosts with several addresses are tried in resolver order, keeping Net::HTTP's usual fallback;
- redirects are followed by hand (max 5) with every hop checked the same way, so a 302 into `169.254.169.254` is refused before a socket opens;
- the response has to declare an `image/*` content type and is streamed to a tempfile under a size cap;
- everything that fails raises `RemoteImageFetcher::Error`, so callers rescue one class.

Incidental improvements: cover filenames now come from the URL *path* rather than the whole URL, so a query string no longer ends up in them, and the IGDB task falls back to `jpg` when the URL has no extension.

## Testing

- `spec/services/remote_image_fetcher_spec.rb` — internal URL shapes, hostnames resolving to private space (including mixed public/private), private redirects, non-image responses, size caps, redirect limits, address fallback.
- `spec/tasks/import_covers_spec.rb` — runs the real `import:pcgamingwiki:covers` against a hostile stubbed upstream pointing at a live loopback listener. The listener receives zero requests, where before it recorded `GET /latest/meta-data/iam/security-credentials`. A second example confirms a legitimate public cover still attaches.
- Full suite: 977 examples, 0 failures. Rubocop clean.

## Note

If `http_proxy` is set in the environment, Net::HTTP connects through the proxy and the IP pinning no longer applies — the proxy does the resolving. URL validation still runs. vglist's deploy doesn't set one, but worth knowing if that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)