### PR TITLE
Delete downloaded cover tempfiles once they've been attached

### DIFF
--- a/app/services/remote_image_fetcher.rb
+++ b/app/services/remote_image_fetcher.rb
@@ -79,12 +79,25 @@ class RemoteImageFetcher
   # A downloaded image. `io` is a rewound binary Tempfile suitable for
   # `attach(io:)`, and `uri` is the URL it was ultimately fetched from (which
   # may differ from the requested one if redirects were followed).
+  #
+  # The tempfile is deleted when the Image is garbage collected, but callers
+  # should call `close` as soon as they're done with `io` instead of waiting
+  # for that: an import runs through thousands of covers in one process, and
+  # leaving each one to the finalizer means every cover downloaded so far is
+  # still open and still on disk.
   class Image
     attr_reader :io, :uri
 
     def initialize(io:, uri:)
       @io = io
       @uri = uri
+    end
+
+    # Close and delete the tempfile behind `io`. Safe to call more than once,
+    # and safe to call as soon as `attach` has returned — ActiveStorage has
+    # read the whole file and uploaded it by then.
+    def close
+      io.close!
     end
 
     # The last path segment of the URL, e.g. "cover.jpg". Falls back to
@@ -251,8 +264,7 @@ class RemoteImageFetcher
         tempfile.write(chunk)
       end
     rescue StandardError
-      tempfile.close
-      tempfile.unlink
+      tempfile.close!
       raise
     end
 

--- a/lib/tasks/import/igdb.rake
+++ b/lib/tasks/import/igdb.rake
@@ -161,9 +161,15 @@ namespace :import do
         next
       end
 
-      # Copy the image data to a file with ActiveStorage.
+      # Copy the image data to a file with ActiveStorage, then throw the
+      # downloaded tempfile away so an import doesn't accumulate one open file
+      # per game it processes.
       # Call the cover file "123_from_igdb.jpg", where 123 is the vglist game ID.
-      game.cover.attach(io: cover.io, filename: "#{game.id}_from_igdb.#{cover.extension.presence || 'jpg'}")
+      begin
+        game.cover.attach(io: cover.io, filename: "#{game.id}_from_igdb.#{cover.extension.presence || 'jpg'}")
+      ensure
+        cover.close
+      end
 
       # If the cover has any errors, they'll show up on the `Game` record.
       # Check for any errors and print them if they exist.

--- a/lib/tasks/import/mobygames.rake
+++ b/lib/tasks/import/mobygames.rake
@@ -168,7 +168,14 @@ namespace :import do
       end
 
       # Attach the cover and get the filename from the last fragment of the URL.
-      game.cover.attach(io: cover.io, filename: cover.filename)
+      # The downloaded tempfile is thrown away as soon as it's been attached,
+      # so an import doesn't accumulate one open file per game it processes.
+      begin
+        game.cover.attach(io: cover.io, filename: cover.filename)
+      ensure
+        cover.close
+      end
+
       attached_covers_count += 1
       progress_bar.log "Added cover for #{game[:name]}."
       progress_bar.increment

--- a/lib/tasks/import/pcgamingwiki.rake
+++ b/lib/tasks/import/pcgamingwiki.rake
@@ -165,8 +165,14 @@ namespace :import do
         next
       end
 
-      # Copy the image data to a file with ActiveStorage.
-      game.cover.attach(io: cover.io, filename: cover.filename)
+      # Copy the image data to a file with ActiveStorage, then throw the
+      # downloaded tempfile away so an import doesn't accumulate one open file
+      # per game it processes.
+      begin
+        game.cover.attach(io: cover.io, filename: cover.filename)
+      ensure
+        cover.close
+      end
 
       # If the cover has any errors, they'll show up on the `Game` record.
       # Check for any errors and print them if they exist.

--- a/spec/services/remote_image_fetcher_spec.rb
+++ b/spec/services/remote_image_fetcher_spec.rb
@@ -200,4 +200,30 @@ RSpec.describe RemoteImageFetcher, type: :service do
       end
     end
   end
+
+  describe '#close' do
+    let(:image) do
+      stub_request(:get, 'https://images.example.com/cover.png')
+        .to_return(status: 200, body: png, headers: { 'Content-Type' => 'image/png' })
+
+      described_class.fetch('https://images.example.com/cover.png')
+    end
+
+    it 'closes and deletes the tempfile' do
+      path = image.io.path
+
+      expect(File.exist?(path)).to be true
+
+      image.close
+
+      expect(image.io).to be_closed
+      expect(File.exist?(path)).to be false
+    end
+
+    it 'can be called more than once' do
+      image.close
+
+      expect { image.close }.not_to raise_error
+    end
+  end
 end

--- a/spec/tasks/import_covers_spec.rb
+++ b/spec/tasks/import_covers_spec.rb
@@ -84,4 +84,29 @@ RSpec.describe 'import:pcgamingwiki:covers', type: :task do
     expect(game.cover.filename.to_s).to eq('half-life.png')
     expect(game.cover.byte_size).to eq(png.bytesize)
   end
+
+  # An import runs through thousands of games in a single process, so a cover
+  # that stays open after it's been attached is a file descriptor and a copy of
+  # the image that the task holds onto until it exits.
+  it 'closes and deletes the downloaded tempfile once the cover is attached' do
+    allow(Addrinfo).to receive(:getaddrinfo).and_return([Addrinfo.ip('93.184.216.34')])
+    create(:game, pcgamingwiki_id: 'Some_Game')
+    stub_upstream('https://images.pcgamingwiki.com/covers/half-life.png')
+    stub_request(:get, 'https://images.pcgamingwiki.com/covers/half-life.png')
+      .to_return(status: 200, body: png, headers: { 'Content-Type' => 'image/png' })
+
+    image = nil
+    path = nil
+    allow(RemoteImageFetcher).to receive(:fetch).and_wrap_original do |original, *args|
+      image = original.call(*args)
+      # Tempfile#path goes nil once the file is unlinked, so remember it now.
+      path = image.io.path
+      image
+    end
+
+    run_task
+
+    expect(image.io).to be_closed
+    expect(File.exist?(path)).to be false
+  end
 end


### PR DESCRIPTION
`RemoteImageFetcher` buffers a download into a `Tempfile` and hands it back for `attach(io:)`. The error paths unlinked it, but the success path left it to the finalizer — so a cover import, which walks thousands of games in a single process, held an open file descriptor and an on-disk copy of every cover it had processed until the GC got round to them.

### Changes

- `RemoteImageFetcher::Image#close` closes and unlinks the tempfile (`Tempfile#close!`, so it's idempotent), with a note on the class telling callers to use it rather than leaning on the finalizer. The existing `close` + `unlink` error path collapses into the same call.
- The three import tasks (`igdb`, `mobygames`, `pcgamingwiki`) wrap the attach in `begin`/`ensure cover.close`.

Closing right after `attach` returns is safe: on a persisted record `attach` calls `record.save`, and ActiveStorage uploads the blob from an `after_commit` hook during that save, so the tempfile has been read in full by the time `attach` returns.

### Tests

- `spec/services/remote_image_fetcher_spec.rb` — `#close` closes and deletes the tempfile, and tolerates a second call.
- `spec/tasks/import_covers_spec.rb` — end-to-end check that the pcgamingwiki task leaves no open tempfile behind. Confirmed load-bearing: dropping the `ensure` from `pcgamingwiki.rake` fails it with `expected .closed? to be truthy, got false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)