### PR TITLE
Add moderator CRUD pages for platforms, companies, engines, genres, series, and stores

### DIFF
--- a/frontend/src/components/ResourceForm.test.ts
+++ b/frontend/src/components/ResourceForm.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import ResourceForm from "./ResourceForm.vue";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────
+
+const { mockAuthStore } = vi.hoisted(() => ({
+  mockAuthStore: { isModerator: true }
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: () => mockAuthStore
+}));
+
+const baseProps = {
+  name: "",
+  wikidataId: "",
+  label: "Platform",
+  pluralLabel: "platforms",
+  isEditing: false,
+  cancelTo: "/platforms"
+};
+
+function mountForm(props: Partial<typeof baseProps> & Record<string, unknown> = {}) {
+  return mount(ResourceForm, {
+    props: { ...baseProps, ...props },
+    global: {
+      stubs: {
+        RouterLink: true
+      }
+    }
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("ResourceForm", () => {
+  beforeEach(() => {
+    mockAuthStore.isModerator = true;
+  });
+
+  it("renders a create heading and button when not editing", () => {
+    const wrapper = mountForm();
+
+    expect(wrapper.find("h1").text()).toBe("New Platform");
+    expect(wrapper.find("button[type='submit']").text()).toBe("Create Platform");
+  });
+
+  it("renders an edit heading and button when editing", () => {
+    const wrapper = mountForm({ isEditing: true });
+
+    expect(wrapper.find("h1").text()).toBe("Edit Platform");
+    expect(wrapper.find("button[type='submit']").text()).toBe("Save Changes");
+  });
+
+  it("populates the fields from its props", () => {
+    const wrapper = mountForm({ name: "Nintendo Switch", wikidataId: "19610114" });
+
+    expect(wrapper.find<HTMLInputElement>("#platform-name").element.value).toBe("Nintendo Switch");
+    expect(wrapper.find<HTMLInputElement>("#platform-wikidata-id").element.value).toBe("19610114");
+  });
+
+  it("emits update events when the fields change", async () => {
+    const wrapper = mountForm();
+
+    await wrapper.find("#platform-name").setValue("Xbox");
+    await wrapper.find("#platform-wikidata-id").setValue("13361286");
+
+    expect(wrapper.emitted("update:name")).toEqual([["Xbox"]]);
+    expect(wrapper.emitted("update:wikidataId")).toEqual([["13361286"]]);
+  });
+
+  it("emits submit when the form is submitted", async () => {
+    const wrapper = mountForm();
+
+    await wrapper.find("form").trigger("submit");
+
+    expect(wrapper.emitted("submit")).toHaveLength(1);
+  });
+
+  it("shows a loading message instead of the form while fetching", () => {
+    const wrapper = mountForm({ isEditing: true, loading: true });
+
+    expect(wrapper.text()).toContain("Loading platform...");
+    expect(wrapper.find("form").exists()).toBeFalsy();
+  });
+
+  it("shows the submit error when one is given", () => {
+    const wrapper = mountForm({ submitError: "Wikidata has already been taken" });
+
+    expect(wrapper.find(".notification.is-danger").text()).toBe("Wikidata has already been taken");
+  });
+
+  it("disables the submit button while submitting", () => {
+    const wrapper = mountForm({ submitting: true });
+
+    expect(wrapper.find("button[type='submit']").attributes("disabled")).toBeDefined();
+  });
+
+  it("hides the Wikidata field for resources that don't have one", () => {
+    const wrapper = mountForm({ label: "Store", pluralLabel: "stores", withWikidataId: false });
+
+    expect(wrapper.find("#store-name").exists()).toBeTruthy();
+    expect(wrapper.find("#store-wikidata-id").exists()).toBeFalsy();
+  });
+
+  it("hides the form from users who aren't moderators", () => {
+    mockAuthStore.isModerator = false;
+    const wrapper = mountForm();
+
+    expect(wrapper.find("form").exists()).toBeFalsy();
+    expect(wrapper.find(".notification.is-warning").text()).toContain(
+      "You must be a moderator or admin to create or edit platforms."
+    );
+  });
+});

--- a/frontend/src/components/ResourceForm.vue
+++ b/frontend/src/components/ResourceForm.vue
@@ -1,0 +1,120 @@
+<template>
+  <section class="section">
+    <div class="columns is-centered">
+      <div class="column is-6">
+        <div v-if="!authStore.isModerator" class="notification is-warning">
+          <p>You must be a moderator or admin to create or edit {{ pluralLabel }}.</p>
+        </div>
+
+        <template v-else>
+          <h1 class="title">{{ isEditing ? `Edit ${label}` : `New ${label}` }}</h1>
+
+          <div v-if="loading" class="has-text-centered py-5">
+            <p>Loading {{ lowerLabel }}...</p>
+          </div>
+
+          <form v-else @submit.prevent="emit('submit')">
+            <div class="field">
+              <label class="label" :for="`${slug}-name`">Name <span class="has-text-danger">*</span></label>
+              <div class="control">
+                <input
+                  :id="`${slug}-name`"
+                  :value="name"
+                  class="input"
+                  type="text"
+                  required
+                  maxlength="120"
+                  :placeholder="`${label} name`"
+                  @input="emit('update:name', ($event.target as HTMLInputElement).value)"
+                />
+              </div>
+            </div>
+
+            <div v-if="withWikidataId" class="field">
+              <label class="label" :for="`${slug}-wikidata-id`">
+                Wikidata ID <span class="has-text-danger">*</span>
+              </label>
+              <div class="control">
+                <input
+                  :id="`${slug}-wikidata-id`"
+                  :value="wikidataId"
+                  class="input"
+                  type="text"
+                  required
+                  inputmode="numeric"
+                  placeholder="e.g. 12345"
+                  @input="emit('update:wikidataId', ($event.target as HTMLInputElement).value)"
+                />
+              </div>
+              <p class="help">The numeric portion of the Wikidata item ID, without the leading "Q".</p>
+            </div>
+
+            <div v-if="submitError" class="notification is-danger mt-4">
+              <p>{{ submitError }}</p>
+            </div>
+
+            <div class="field is-grouped mt-5">
+              <div class="control">
+                <button
+                  type="submit"
+                  class="button is-primary"
+                  :class="{ 'is-loading': submitting }"
+                  :disabled="submitting"
+                >
+                  {{ isEditing ? "Save Changes" : `Create ${label}` }}
+                </button>
+              </div>
+              <div class="control">
+                <router-link :to="cancelTo" class="button is-light">Cancel</router-link>
+              </div>
+            </div>
+          </form>
+        </template>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useAuthStore } from "@/stores/auth";
+
+const props = withDefaults(
+  defineProps<{
+    name: string;
+    wikidataId?: string;
+    /** Singular, capitalized resource name, e.g. "Platform". */
+    label: string;
+    /** Plural, lowercase resource name, e.g. "platforms". */
+    pluralLabel: string;
+    isEditing: boolean;
+    /** Whether this resource has a Wikidata ID. Stores, for example, don't. */
+    withWikidataId?: boolean;
+    /** True while an existing record is being fetched for editing. */
+    loading?: boolean;
+    submitting?: boolean;
+    submitError?: string;
+    /** Where the Cancel button links to. */
+    cancelTo: string;
+  }>(),
+  {
+    wikidataId: "",
+    withWikidataId: true,
+    loading: false,
+    submitting: false,
+    submitError: ""
+  }
+);
+
+const emit = defineEmits<{
+  "update:name": [value: string];
+  "update:wikidataId": [value: string];
+  submit: [];
+}>();
+
+const authStore = useAuthStore();
+
+const lowerLabel = computed(() => props.label.toLowerCase());
+// Used to keep the `for`/`id` pairs unique and readable, e.g. "platform-name".
+const slug = computed(() => props.label.toLowerCase().replace(/\s+/g, "-"));
+</script>

--- a/frontend/src/graphql/mutations/resources.ts
+++ b/frontend/src/graphql/mutations/resources.ts
@@ -1,0 +1,181 @@
+import gql from "graphql-tag";
+
+export const CREATE_PLATFORM = gql`
+  mutation CreatePlatform($name: String!, $wikidataId: ID!) {
+    createPlatform(name: $name, wikidataId: $wikidataId) {
+      platform {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const UPDATE_PLATFORM = gql`
+  mutation UpdatePlatform($platformId: ID!, $name: String, $wikidataId: ID) {
+    updatePlatform(platformId: $platformId, name: $name, wikidataId: $wikidataId) {
+      platform {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const DELETE_PLATFORM = gql`
+  mutation DeletePlatform($platformId: ID!) {
+    deletePlatform(platformId: $platformId) {
+      deleted
+    }
+  }
+`;
+
+export const CREATE_COMPANY = gql`
+  mutation CreateCompany($name: String!, $wikidataId: ID!) {
+    createCompany(name: $name, wikidataId: $wikidataId) {
+      company {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const UPDATE_COMPANY = gql`
+  mutation UpdateCompany($companyId: ID!, $name: String, $wikidataId: ID) {
+    updateCompany(companyId: $companyId, name: $name, wikidataId: $wikidataId) {
+      company {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const DELETE_COMPANY = gql`
+  mutation DeleteCompany($companyId: ID!) {
+    deleteCompany(companyId: $companyId) {
+      deleted
+    }
+  }
+`;
+
+export const CREATE_ENGINE = gql`
+  mutation CreateEngine($name: String!, $wikidataId: ID!) {
+    createEngine(name: $name, wikidataId: $wikidataId) {
+      engine {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const UPDATE_ENGINE = gql`
+  mutation UpdateEngine($engineId: ID!, $name: String, $wikidataId: ID) {
+    updateEngine(engineId: $engineId, name: $name, wikidataId: $wikidataId) {
+      engine {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const DELETE_ENGINE = gql`
+  mutation DeleteEngine($engineId: ID!) {
+    deleteEngine(engineId: $engineId) {
+      deleted
+    }
+  }
+`;
+
+export const CREATE_GENRE = gql`
+  mutation CreateGenre($name: String!, $wikidataId: ID!) {
+    createGenre(name: $name, wikidataId: $wikidataId) {
+      genre {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const UPDATE_GENRE = gql`
+  mutation UpdateGenre($genreId: ID!, $name: String, $wikidataId: ID) {
+    updateGenre(genreId: $genreId, name: $name, wikidataId: $wikidataId) {
+      genre {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const DELETE_GENRE = gql`
+  mutation DeleteGenre($genreId: ID!) {
+    deleteGenre(genreId: $genreId) {
+      deleted
+    }
+  }
+`;
+
+export const CREATE_SERIES = gql`
+  mutation CreateSeries($name: String!, $wikidataId: ID!) {
+    createSeries(name: $name, wikidataId: $wikidataId) {
+      series {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const UPDATE_SERIES = gql`
+  mutation UpdateSeries($seriesId: ID!, $name: String, $wikidataId: ID) {
+    updateSeries(seriesId: $seriesId, name: $name, wikidataId: $wikidataId) {
+      series {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const DELETE_SERIES = gql`
+  mutation DeleteSeries($seriesId: ID!) {
+    deleteSeries(seriesId: $seriesId) {
+      deleted
+    }
+  }
+`;
+
+export const CREATE_STORE = gql`
+  mutation CreateStore($name: String!) {
+    createStore(name: $name) {
+      store {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const UPDATE_STORE = gql`
+  mutation UpdateStore($storeId: ID!, $name: String) {
+    updateStore(storeId: $storeId, name: $name) {
+      store {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const DELETE_STORE = gql`
+  mutation DeleteStore($storeId: ID!) {
+    deleteStore(storeId: $storeId) {
+      deleted
+    }
+  }
+`;

--- a/frontend/src/graphql/queries/resources.ts
+++ b/frontend/src/graphql/queries/resources.ts
@@ -32,6 +32,16 @@ export const GET_PLATFORM = gql`
   }
 `;
 
+export const GET_PLATFORM_FOR_EDIT = gql`
+  query GetPlatformForEdit($id: ID!) {
+    platform(id: $id) {
+      id
+      name
+      wikidataId
+    }
+  }
+`;
+
 export const GET_COMPANIES = gql`
   query GetCompanies($first: Int, $after: String) {
     companies(first: $first, after: $after) {
@@ -71,6 +81,16 @@ export const GET_COMPANY = gql`
   }
 `;
 
+export const GET_COMPANY_FOR_EDIT = gql`
+  query GetCompanyForEdit($id: ID!) {
+    company(id: $id) {
+      id
+      name
+      wikidataId
+    }
+  }
+`;
+
 export const GET_GENRES = gql`
   query GetGenres($first: Int, $after: String) {
     genres(first: $first, after: $after) {
@@ -99,6 +119,16 @@ export const GET_GENRE = gql`
           coverUrl(size: SMALL)
         }
       }
+    }
+  }
+`;
+
+export const GET_GENRE_FOR_EDIT = gql`
+  query GetGenreForEdit($id: ID!) {
+    genre(id: $id) {
+      id
+      name
+      wikidataId
     }
   }
 `;
@@ -135,6 +165,16 @@ export const GET_ENGINE = gql`
   }
 `;
 
+export const GET_ENGINE_FOR_EDIT = gql`
+  query GetEngineForEdit($id: ID!) {
+    engine(id: $id) {
+      id
+      name
+      wikidataId
+    }
+  }
+`;
+
 export const GET_SERIES_LIST = gql`
   query GetSeriesList($first: Int, $after: String) {
     seriesList(first: $first, after: $after) {
@@ -167,6 +207,16 @@ export const GET_SERIES = gql`
   }
 `;
 
+export const GET_SERIES_FOR_EDIT = gql`
+  query GetSeriesForEdit($id: ID!) {
+    series(id: $id) {
+      id
+      name
+      wikidataId
+    }
+  }
+`;
+
 export const GET_STORES = gql`
   query GetStores($first: Int, $after: String) {
     stores(first: $first, after: $after) {
@@ -184,6 +234,15 @@ export const GET_STORES = gql`
 
 export const GET_STORE = gql`
   query GetStore($id: ID!) {
+    store(id: $id) {
+      id
+      name
+    }
+  }
+`;
+
+export const GET_STORE_FOR_EDIT = gql`
+  query GetStoreForEdit($id: ID!) {
     store(id: $id) {
       id
       name

--- a/frontend/src/pages/companies/CompanyFormPage.vue
+++ b/frontend/src/pages/companies/CompanyFormPage.vue
@@ -52,6 +52,16 @@ watch(
   { immediate: true }
 );
 
+// The "new" and "edit" routes resolve to this same component, so vue-router
+// reuses the instance when navigating between them. Clear any values carried
+// over from an edit when we land on "new".
+watch(isEditing, (editing) => {
+  if (editing) return;
+  name.value = "";
+  wikidataId.value = "";
+  submitError.value = "";
+});
+
 // Redirect to 404 when editing a company that doesn't exist.
 watch([data, error, loading], () => {
   if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.company))) {

--- a/frontend/src/pages/companies/CompanyFormPage.vue
+++ b/frontend/src/pages/companies/CompanyFormPage.vue
@@ -1,0 +1,106 @@
+<template>
+  <ResourceForm
+    v-model:name="name"
+    v-model:wikidata-id="wikidataId"
+    label="Company"
+    plural-label="companies"
+    :is-editing="isEditing"
+    :loading="isEditing && loading && !data"
+    :submitting="submitting"
+    :submit-error="submitError"
+    :cancel-to="isEditing ? `/companies/${companyId}` : '/companies'"
+    @submit="handleSubmit"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
+import { GET_COMPANY_FOR_EDIT } from "@/graphql/queries/resources";
+import { CREATE_COMPANY, UPDATE_COMPANY } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetCompanyForEditQuery, CreateCompanyMutation, UpdateCompanyMutation } from "@/types/graphql";
+import ResourceForm from "@/components/ResourceForm.vue";
+
+// The edit route is used for typing because it is the superset of the two —
+// on the "new" route there is simply no `id` param.
+const route = useRoute("companyEdit");
+const router = useRouter();
+const { show: showSnackbar } = useSnackbar();
+
+const isEditing = computed(() => !!route.params.id);
+const companyId = computed(() => route.params.id);
+
+const name = ref("");
+const wikidataId = ref("");
+const submitError = ref("");
+
+const { data, loading, error } = useQuery<GetCompanyForEditQuery>(GET_COMPANY_FOR_EDIT, {
+  variables: () => ({ id: companyId.value }),
+  enabled: () => isEditing.value
+});
+
+watch(
+  () => data.value?.company,
+  (company) => {
+    if (!company) return;
+    name.value = company.name;
+    wikidataId.value = company.wikidataId != null ? String(company.wikidataId) : "";
+  },
+  { immediate: true }
+);
+
+// Redirect to 404 when editing a company that doesn't exist.
+watch([data, error, loading], () => {
+  if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.company))) {
+    router.replace({ name: "notFound" });
+  }
+});
+
+const { mutate: createCompany, loading: creating } = useMutation<CreateCompanyMutation>(CREATE_COMPANY);
+const { mutate: updateCompany, loading: updating } = useMutation<UpdateCompanyMutation>(UPDATE_COMPANY);
+const submitting = computed(() => creating.value || updating.value);
+
+async function handleSubmit() {
+  submitError.value = "";
+
+  const trimmedName = name.value.trim();
+  const trimmedWikidataId = wikidataId.value.trim();
+
+  if (!trimmedName) {
+    submitError.value = "Name is required.";
+    return;
+  }
+
+  if (!/^\d+$/.test(trimmedWikidataId) || Number(trimmedWikidataId) <= 0) {
+    submitError.value = "Wikidata ID must be a positive number.";
+    return;
+  }
+
+  try {
+    if (isEditing.value) {
+      const result = await updateCompany({
+        companyId: companyId.value,
+        name: trimmedName,
+        wikidataId: trimmedWikidataId
+      });
+      const company = result?.updateCompany?.company;
+      if (company) {
+        showSnackbar(`${company.name} has been updated.`);
+        router.push(`/companies/${company.id}`);
+      }
+    } else {
+      const result = await createCompany({ name: trimmedName, wikidataId: trimmedWikidataId });
+      const company = result?.createCompany?.company;
+      if (company) {
+        showSnackbar(`${company.name} has been created.`);
+        router.push(`/companies/${company.id}`);
+      }
+    }
+  } catch (e) {
+    submitError.value = extractGqlError(e);
+  }
+}
+</script>

--- a/frontend/src/pages/companies/CompanyListPage.vue
+++ b/frontend/src/pages/companies/CompanyListPage.vue
@@ -2,6 +2,10 @@
   <section class="section">
     <h1 class="title">Companies</h1>
 
+    <div v-if="authStore.isModerator" class="buttons">
+      <router-link to="/companies/new" class="button is-small is-primary">New Company</router-link>
+    </div>
+
     <div v-if="loading && !data" class="has-text-centered">
       <p>Loading companies...</p>
     </div>
@@ -31,10 +35,13 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
+import { useAuthStore } from "@/stores/auth";
 import { useQuery } from "@/composables/useGraphQL";
 import { GET_COMPANIES } from "@/graphql/queries/resources";
 import type { GetCompaniesQuery } from "@/types/graphql";
 import PaginationNav from "@/components/PaginationNav.vue";
+
+const authStore = useAuthStore();
 
 const PAGE_SIZE = 25;
 const currentPage = ref(1);

--- a/frontend/src/pages/companies/CompanyShowPage.vue
+++ b/frontend/src/pages/companies/CompanyShowPage.vue
@@ -18,6 +18,11 @@
         >
       </p>
 
+      <div v-if="authStore.isModerator" class="buttons">
+        <router-link :to="`/companies/${data.company.id}/edit`" class="button is-small">Edit</router-link>
+        <button class="button is-small is-danger is-light" @click="showDeleteConfirm = true">Delete</button>
+      </div>
+
       <div v-if="data.company.developedGames.nodes.length" class="mb-6">
         <h2 class="title is-4">Developed Games</h2>
 
@@ -38,20 +43,43 @@
           </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        v-model="showDeleteConfirm"
+        title="Delete company?"
+        confirm-label="Delete company"
+        loading-label="Deleting…"
+        :loading="deleting"
+        @confirm="confirmDelete"
+      >
+        <template #icon>
+          <CircleAlert :size="22" :stroke-width="1.8" />
+        </template>
+        <strong>{{ data.company.name }}</strong> will be permanently deleted, and removed from every game it developed
+        or published. This cannot be undone.
+      </ConfirmDialog>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { watch } from "vue";
+import { ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { useQuery } from "@/composables/useGraphQL";
+import { CircleAlert } from "@lucide/vue";
+import { useAuthStore } from "@/stores/auth";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
 import { GET_COMPANY } from "@/graphql/queries/resources";
-import type { GetCompanyQuery } from "@/types/graphql";
+import { DELETE_COMPANY } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetCompanyQuery, DeleteCompanyMutation } from "@/types/graphql";
 import GameCard from "@/components/GameCard.vue";
+import ConfirmDialog from "@/components/ConfirmDialog.vue";
 
 const route = useRoute("company");
 const router = useRouter();
+const authStore = useAuthStore();
+const { show: showSnackbar } = useSnackbar();
 
 const { data, loading, error } = useQuery<GetCompanyQuery>(GET_COMPANY, {
   variables: { id: route.params.id }
@@ -62,4 +90,19 @@ watch([data, error, loading], () => {
     router.replace({ name: "notFound" });
   }
 });
+
+const showDeleteConfirm = ref(false);
+const { mutate: deleteCompany, loading: deleting } = useMutation<DeleteCompanyMutation>(DELETE_COMPANY);
+
+async function confirmDelete() {
+  try {
+    await deleteCompany({ companyId: route.params.id });
+    showSnackbar(`${data.value?.company?.name ?? "Company"} has been deleted.`);
+    showDeleteConfirm.value = false;
+    router.replace({ name: "companies" });
+  } catch (e) {
+    showSnackbar(`Failed to delete company: ${extractGqlError(e)}`, "error");
+    showDeleteConfirm.value = false;
+  }
+}
 </script>

--- a/frontend/src/pages/engines/EngineFormPage.vue
+++ b/frontend/src/pages/engines/EngineFormPage.vue
@@ -52,6 +52,16 @@ watch(
   { immediate: true }
 );
 
+// The "new" and "edit" routes resolve to this same component, so vue-router
+// reuses the instance when navigating between them. Clear any values carried
+// over from an edit when we land on "new".
+watch(isEditing, (editing) => {
+  if (editing) return;
+  name.value = "";
+  wikidataId.value = "";
+  submitError.value = "";
+});
+
 // Redirect to 404 when editing an engine that doesn't exist.
 watch([data, error, loading], () => {
   if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.engine))) {

--- a/frontend/src/pages/engines/EngineFormPage.vue
+++ b/frontend/src/pages/engines/EngineFormPage.vue
@@ -1,0 +1,106 @@
+<template>
+  <ResourceForm
+    v-model:name="name"
+    v-model:wikidata-id="wikidataId"
+    label="Engine"
+    plural-label="engines"
+    :is-editing="isEditing"
+    :loading="isEditing && loading && !data"
+    :submitting="submitting"
+    :submit-error="submitError"
+    :cancel-to="isEditing ? `/engines/${engineId}` : '/engines'"
+    @submit="handleSubmit"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
+import { GET_ENGINE_FOR_EDIT } from "@/graphql/queries/resources";
+import { CREATE_ENGINE, UPDATE_ENGINE } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetEngineForEditQuery, CreateEngineMutation, UpdateEngineMutation } from "@/types/graphql";
+import ResourceForm from "@/components/ResourceForm.vue";
+
+// The edit route is used for typing because it is the superset of the two —
+// on the "new" route there is simply no `id` param.
+const route = useRoute("engineEdit");
+const router = useRouter();
+const { show: showSnackbar } = useSnackbar();
+
+const isEditing = computed(() => !!route.params.id);
+const engineId = computed(() => route.params.id);
+
+const name = ref("");
+const wikidataId = ref("");
+const submitError = ref("");
+
+const { data, loading, error } = useQuery<GetEngineForEditQuery>(GET_ENGINE_FOR_EDIT, {
+  variables: () => ({ id: engineId.value }),
+  enabled: () => isEditing.value
+});
+
+watch(
+  () => data.value?.engine,
+  (engine) => {
+    if (!engine) return;
+    name.value = engine.name;
+    wikidataId.value = engine.wikidataId != null ? String(engine.wikidataId) : "";
+  },
+  { immediate: true }
+);
+
+// Redirect to 404 when editing an engine that doesn't exist.
+watch([data, error, loading], () => {
+  if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.engine))) {
+    router.replace({ name: "notFound" });
+  }
+});
+
+const { mutate: createEngine, loading: creating } = useMutation<CreateEngineMutation>(CREATE_ENGINE);
+const { mutate: updateEngine, loading: updating } = useMutation<UpdateEngineMutation>(UPDATE_ENGINE);
+const submitting = computed(() => creating.value || updating.value);
+
+async function handleSubmit() {
+  submitError.value = "";
+
+  const trimmedName = name.value.trim();
+  const trimmedWikidataId = wikidataId.value.trim();
+
+  if (!trimmedName) {
+    submitError.value = "Name is required.";
+    return;
+  }
+
+  if (!/^\d+$/.test(trimmedWikidataId) || Number(trimmedWikidataId) <= 0) {
+    submitError.value = "Wikidata ID must be a positive number.";
+    return;
+  }
+
+  try {
+    if (isEditing.value) {
+      const result = await updateEngine({
+        engineId: engineId.value,
+        name: trimmedName,
+        wikidataId: trimmedWikidataId
+      });
+      const engine = result?.updateEngine?.engine;
+      if (engine) {
+        showSnackbar(`${engine.name} has been updated.`);
+        router.push(`/engines/${engine.id}`);
+      }
+    } else {
+      const result = await createEngine({ name: trimmedName, wikidataId: trimmedWikidataId });
+      const engine = result?.createEngine?.engine;
+      if (engine) {
+        showSnackbar(`${engine.name} has been created.`);
+        router.push(`/engines/${engine.id}`);
+      }
+    }
+  } catch (e) {
+    submitError.value = extractGqlError(e);
+  }
+}
+</script>

--- a/frontend/src/pages/engines/EngineListPage.vue
+++ b/frontend/src/pages/engines/EngineListPage.vue
@@ -2,6 +2,10 @@
   <section class="section">
     <h1 class="title">Engines</h1>
 
+    <div v-if="authStore.isModerator" class="buttons">
+      <router-link to="/engines/new" class="button is-small is-primary">New Engine</router-link>
+    </div>
+
     <div v-if="loading && !data" class="has-text-centered">
       <p>Loading engines...</p>
     </div>
@@ -31,10 +35,13 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
+import { useAuthStore } from "@/stores/auth";
 import { useQuery } from "@/composables/useGraphQL";
 import { GET_ENGINES } from "@/graphql/queries/resources";
 import type { GetEnginesQuery } from "@/types/graphql";
 import PaginationNav from "@/components/PaginationNav.vue";
+
+const authStore = useAuthStore();
 
 const PAGE_SIZE = 25;
 const currentPage = ref(1);

--- a/frontend/src/pages/engines/EngineShowPage.vue
+++ b/frontend/src/pages/engines/EngineShowPage.vue
@@ -17,6 +17,11 @@
         >
       </p>
 
+      <div v-if="authStore.isModerator" class="buttons">
+        <router-link :to="`/engines/${data.engine.id}/edit`" class="button is-small">Edit</router-link>
+        <button class="button is-small is-danger is-light" @click="showDeleteConfirm = true">Delete</button>
+      </div>
+
       <h2 class="title is-4 mt-5">Games</h2>
 
       <div class="columns is-multiline">
@@ -24,20 +29,43 @@
           <GameCard :id="game.id" :name="game.name" :cover-url="game.coverUrl ?? null" />
         </div>
       </div>
+
+      <ConfirmDialog
+        v-model="showDeleteConfirm"
+        title="Delete engine?"
+        confirm-label="Delete engine"
+        loading-label="Deleting…"
+        :loading="deleting"
+        @confirm="confirmDelete"
+      >
+        <template #icon>
+          <CircleAlert :size="22" :stroke-width="1.8" />
+        </template>
+        <strong>{{ data.engine.name }}</strong> will be permanently deleted, and removed from every game that uses it.
+        This cannot be undone.
+      </ConfirmDialog>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { watch } from "vue";
+import { ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { useQuery } from "@/composables/useGraphQL";
+import { CircleAlert } from "@lucide/vue";
+import { useAuthStore } from "@/stores/auth";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
 import { GET_ENGINE } from "@/graphql/queries/resources";
-import type { GetEngineQuery } from "@/types/graphql";
+import { DELETE_ENGINE } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetEngineQuery, DeleteEngineMutation } from "@/types/graphql";
 import GameCard from "@/components/GameCard.vue";
+import ConfirmDialog from "@/components/ConfirmDialog.vue";
 
 const route = useRoute("engine");
 const router = useRouter();
+const authStore = useAuthStore();
+const { show: showSnackbar } = useSnackbar();
 
 const { data, loading, error } = useQuery<GetEngineQuery>(GET_ENGINE, {
   variables: { id: route.params.id }
@@ -48,4 +76,19 @@ watch([data, error, loading], () => {
     router.replace({ name: "notFound" });
   }
 });
+
+const showDeleteConfirm = ref(false);
+const { mutate: deleteEngine, loading: deleting } = useMutation<DeleteEngineMutation>(DELETE_ENGINE);
+
+async function confirmDelete() {
+  try {
+    await deleteEngine({ engineId: route.params.id });
+    showSnackbar(`${data.value?.engine?.name ?? "Engine"} has been deleted.`);
+    showDeleteConfirm.value = false;
+    router.replace({ name: "engines" });
+  } catch (e) {
+    showSnackbar(`Failed to delete engine: ${extractGqlError(e)}`, "error");
+    showDeleteConfirm.value = false;
+  }
+}
 </script>

--- a/frontend/src/pages/genres/GenreFormPage.vue
+++ b/frontend/src/pages/genres/GenreFormPage.vue
@@ -52,6 +52,16 @@ watch(
   { immediate: true }
 );
 
+// The "new" and "edit" routes resolve to this same component, so vue-router
+// reuses the instance when navigating between them. Clear any values carried
+// over from an edit when we land on "new".
+watch(isEditing, (editing) => {
+  if (editing) return;
+  name.value = "";
+  wikidataId.value = "";
+  submitError.value = "";
+});
+
 // Redirect to 404 when editing a genre that doesn't exist.
 watch([data, error, loading], () => {
   if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.genre))) {

--- a/frontend/src/pages/genres/GenreFormPage.vue
+++ b/frontend/src/pages/genres/GenreFormPage.vue
@@ -1,0 +1,106 @@
+<template>
+  <ResourceForm
+    v-model:name="name"
+    v-model:wikidata-id="wikidataId"
+    label="Genre"
+    plural-label="genres"
+    :is-editing="isEditing"
+    :loading="isEditing && loading && !data"
+    :submitting="submitting"
+    :submit-error="submitError"
+    :cancel-to="isEditing ? `/genres/${genreId}` : '/genres'"
+    @submit="handleSubmit"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
+import { GET_GENRE_FOR_EDIT } from "@/graphql/queries/resources";
+import { CREATE_GENRE, UPDATE_GENRE } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetGenreForEditQuery, CreateGenreMutation, UpdateGenreMutation } from "@/types/graphql";
+import ResourceForm from "@/components/ResourceForm.vue";
+
+// The edit route is used for typing because it is the superset of the two —
+// on the "new" route there is simply no `id` param.
+const route = useRoute("genreEdit");
+const router = useRouter();
+const { show: showSnackbar } = useSnackbar();
+
+const isEditing = computed(() => !!route.params.id);
+const genreId = computed(() => route.params.id);
+
+const name = ref("");
+const wikidataId = ref("");
+const submitError = ref("");
+
+const { data, loading, error } = useQuery<GetGenreForEditQuery>(GET_GENRE_FOR_EDIT, {
+  variables: () => ({ id: genreId.value }),
+  enabled: () => isEditing.value
+});
+
+watch(
+  () => data.value?.genre,
+  (genre) => {
+    if (!genre) return;
+    name.value = genre.name;
+    wikidataId.value = genre.wikidataId != null ? String(genre.wikidataId) : "";
+  },
+  { immediate: true }
+);
+
+// Redirect to 404 when editing a genre that doesn't exist.
+watch([data, error, loading], () => {
+  if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.genre))) {
+    router.replace({ name: "notFound" });
+  }
+});
+
+const { mutate: createGenre, loading: creating } = useMutation<CreateGenreMutation>(CREATE_GENRE);
+const { mutate: updateGenre, loading: updating } = useMutation<UpdateGenreMutation>(UPDATE_GENRE);
+const submitting = computed(() => creating.value || updating.value);
+
+async function handleSubmit() {
+  submitError.value = "";
+
+  const trimmedName = name.value.trim();
+  const trimmedWikidataId = wikidataId.value.trim();
+
+  if (!trimmedName) {
+    submitError.value = "Name is required.";
+    return;
+  }
+
+  if (!/^\d+$/.test(trimmedWikidataId) || Number(trimmedWikidataId) <= 0) {
+    submitError.value = "Wikidata ID must be a positive number.";
+    return;
+  }
+
+  try {
+    if (isEditing.value) {
+      const result = await updateGenre({
+        genreId: genreId.value,
+        name: trimmedName,
+        wikidataId: trimmedWikidataId
+      });
+      const genre = result?.updateGenre?.genre;
+      if (genre) {
+        showSnackbar(`${genre.name} has been updated.`);
+        router.push(`/genres/${genre.id}`);
+      }
+    } else {
+      const result = await createGenre({ name: trimmedName, wikidataId: trimmedWikidataId });
+      const genre = result?.createGenre?.genre;
+      if (genre) {
+        showSnackbar(`${genre.name} has been created.`);
+        router.push(`/genres/${genre.id}`);
+      }
+    }
+  } catch (e) {
+    submitError.value = extractGqlError(e);
+  }
+}
+</script>

--- a/frontend/src/pages/genres/GenreListPage.vue
+++ b/frontend/src/pages/genres/GenreListPage.vue
@@ -2,6 +2,10 @@
   <section class="section">
     <h1 class="title">Genres</h1>
 
+    <div v-if="authStore.isModerator" class="buttons">
+      <router-link to="/genres/new" class="button is-small is-primary">New Genre</router-link>
+    </div>
+
     <div v-if="loading && !data" class="has-text-centered">
       <p>Loading genres...</p>
     </div>
@@ -31,10 +35,13 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
+import { useAuthStore } from "@/stores/auth";
 import { useQuery } from "@/composables/useGraphQL";
 import { GET_GENRES } from "@/graphql/queries/resources";
 import type { GetGenresQuery } from "@/types/graphql";
 import PaginationNav from "@/components/PaginationNav.vue";
+
+const authStore = useAuthStore();
 
 const PAGE_SIZE = 25;
 const currentPage = ref(1);

--- a/frontend/src/pages/genres/GenreShowPage.vue
+++ b/frontend/src/pages/genres/GenreShowPage.vue
@@ -17,6 +17,11 @@
         >
       </p>
 
+      <div v-if="authStore.isModerator" class="buttons">
+        <router-link :to="`/genres/${data.genre.id}/edit`" class="button is-small">Edit</router-link>
+        <button class="button is-small is-danger is-light" @click="showDeleteConfirm = true">Delete</button>
+      </div>
+
       <h2 class="title is-4 mt-5">Games</h2>
 
       <div class="columns is-multiline">
@@ -24,20 +29,43 @@
           <GameCard :id="game.id" :name="game.name" :cover-url="game.coverUrl ?? null" />
         </div>
       </div>
+
+      <ConfirmDialog
+        v-model="showDeleteConfirm"
+        title="Delete genre?"
+        confirm-label="Delete genre"
+        loading-label="Deleting…"
+        :loading="deleting"
+        @confirm="confirmDelete"
+      >
+        <template #icon>
+          <CircleAlert :size="22" :stroke-width="1.8" />
+        </template>
+        <strong>{{ data.genre.name }}</strong> will be permanently deleted, and removed from every game in it. This
+        cannot be undone.
+      </ConfirmDialog>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { watch } from "vue";
+import { ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { useQuery } from "@/composables/useGraphQL";
+import { CircleAlert } from "@lucide/vue";
+import { useAuthStore } from "@/stores/auth";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
 import { GET_GENRE } from "@/graphql/queries/resources";
-import type { GetGenreQuery } from "@/types/graphql";
+import { DELETE_GENRE } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetGenreQuery, DeleteGenreMutation } from "@/types/graphql";
 import GameCard from "@/components/GameCard.vue";
+import ConfirmDialog from "@/components/ConfirmDialog.vue";
 
 const route = useRoute("genre");
 const router = useRouter();
+const authStore = useAuthStore();
+const { show: showSnackbar } = useSnackbar();
 
 const { data, loading, error } = useQuery<GetGenreQuery>(GET_GENRE, {
   variables: { id: route.params.id }
@@ -48,4 +76,19 @@ watch([data, error, loading], () => {
     router.replace({ name: "notFound" });
   }
 });
+
+const showDeleteConfirm = ref(false);
+const { mutate: deleteGenre, loading: deleting } = useMutation<DeleteGenreMutation>(DELETE_GENRE);
+
+async function confirmDelete() {
+  try {
+    await deleteGenre({ genreId: route.params.id });
+    showSnackbar(`${data.value?.genre?.name ?? "Genre"} has been deleted.`);
+    showDeleteConfirm.value = false;
+    router.replace({ name: "genres" });
+  } catch (e) {
+    showSnackbar(`Failed to delete genre: ${extractGqlError(e)}`, "error");
+    showDeleteConfirm.value = false;
+  }
+}
 </script>

--- a/frontend/src/pages/platforms/PlatformFormPage.vue
+++ b/frontend/src/pages/platforms/PlatformFormPage.vue
@@ -1,0 +1,106 @@
+<template>
+  <ResourceForm
+    v-model:name="name"
+    v-model:wikidata-id="wikidataId"
+    label="Platform"
+    plural-label="platforms"
+    :is-editing="isEditing"
+    :loading="isEditing && loading && !data"
+    :submitting="submitting"
+    :submit-error="submitError"
+    :cancel-to="isEditing ? `/platforms/${platformId}` : '/platforms'"
+    @submit="handleSubmit"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
+import { GET_PLATFORM_FOR_EDIT } from "@/graphql/queries/resources";
+import { CREATE_PLATFORM, UPDATE_PLATFORM } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetPlatformForEditQuery, CreatePlatformMutation, UpdatePlatformMutation } from "@/types/graphql";
+import ResourceForm from "@/components/ResourceForm.vue";
+
+// The edit route is used for typing because it is the superset of the two —
+// on the "new" route there is simply no `id` param.
+const route = useRoute("platformEdit");
+const router = useRouter();
+const { show: showSnackbar } = useSnackbar();
+
+const isEditing = computed(() => !!route.params.id);
+const platformId = computed(() => route.params.id);
+
+const name = ref("");
+const wikidataId = ref("");
+const submitError = ref("");
+
+const { data, loading, error } = useQuery<GetPlatformForEditQuery>(GET_PLATFORM_FOR_EDIT, {
+  variables: () => ({ id: platformId.value }),
+  enabled: () => isEditing.value
+});
+
+watch(
+  () => data.value?.platform,
+  (platform) => {
+    if (!platform) return;
+    name.value = platform.name;
+    wikidataId.value = platform.wikidataId != null ? String(platform.wikidataId) : "";
+  },
+  { immediate: true }
+);
+
+// Redirect to 404 when editing a platform that doesn't exist.
+watch([data, error, loading], () => {
+  if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.platform))) {
+    router.replace({ name: "notFound" });
+  }
+});
+
+const { mutate: createPlatform, loading: creating } = useMutation<CreatePlatformMutation>(CREATE_PLATFORM);
+const { mutate: updatePlatform, loading: updating } = useMutation<UpdatePlatformMutation>(UPDATE_PLATFORM);
+const submitting = computed(() => creating.value || updating.value);
+
+async function handleSubmit() {
+  submitError.value = "";
+
+  const trimmedName = name.value.trim();
+  const trimmedWikidataId = wikidataId.value.trim();
+
+  if (!trimmedName) {
+    submitError.value = "Name is required.";
+    return;
+  }
+
+  if (!/^\d+$/.test(trimmedWikidataId) || Number(trimmedWikidataId) <= 0) {
+    submitError.value = "Wikidata ID must be a positive number.";
+    return;
+  }
+
+  try {
+    if (isEditing.value) {
+      const result = await updatePlatform({
+        platformId: platformId.value,
+        name: trimmedName,
+        wikidataId: trimmedWikidataId
+      });
+      const platform = result?.updatePlatform?.platform;
+      if (platform) {
+        showSnackbar(`${platform.name} has been updated.`);
+        router.push(`/platforms/${platform.id}`);
+      }
+    } else {
+      const result = await createPlatform({ name: trimmedName, wikidataId: trimmedWikidataId });
+      const platform = result?.createPlatform?.platform;
+      if (platform) {
+        showSnackbar(`${platform.name} has been created.`);
+        router.push(`/platforms/${platform.id}`);
+      }
+    }
+  } catch (e) {
+    submitError.value = extractGqlError(e);
+  }
+}
+</script>

--- a/frontend/src/pages/platforms/PlatformFormPage.vue
+++ b/frontend/src/pages/platforms/PlatformFormPage.vue
@@ -52,6 +52,16 @@ watch(
   { immediate: true }
 );
 
+// The "new" and "edit" routes resolve to this same component, so vue-router
+// reuses the instance when navigating between them. Clear any values carried
+// over from an edit when we land on "new".
+watch(isEditing, (editing) => {
+  if (editing) return;
+  name.value = "";
+  wikidataId.value = "";
+  submitError.value = "";
+});
+
 // Redirect to 404 when editing a platform that doesn't exist.
 watch([data, error, loading], () => {
   if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.platform))) {

--- a/frontend/src/pages/platforms/PlatformListPage.vue
+++ b/frontend/src/pages/platforms/PlatformListPage.vue
@@ -2,6 +2,10 @@
   <section class="section">
     <h1 class="title">Platforms</h1>
 
+    <div v-if="authStore.isModerator" class="buttons">
+      <router-link to="/platforms/new" class="button is-small is-primary">New Platform</router-link>
+    </div>
+
     <div v-if="loading && !data" class="has-text-centered">
       <p>Loading platforms...</p>
     </div>
@@ -31,10 +35,13 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
+import { useAuthStore } from "@/stores/auth";
 import { useQuery } from "@/composables/useGraphQL";
 import { GET_PLATFORMS } from "@/graphql/queries/resources";
 import type { GetPlatformsQuery } from "@/types/graphql";
 import PaginationNav from "@/components/PaginationNav.vue";
+
+const authStore = useAuthStore();
 
 const PAGE_SIZE = 25;
 const currentPage = ref(1);

--- a/frontend/src/pages/platforms/PlatformShowPage.vue
+++ b/frontend/src/pages/platforms/PlatformShowPage.vue
@@ -20,6 +20,11 @@
         >
       </p>
 
+      <div v-if="authStore.isModerator" class="buttons">
+        <router-link :to="`/platforms/${data.platform.id}/edit`" class="button is-small">Edit</router-link>
+        <button class="button is-small is-danger is-light" @click="showDeleteConfirm = true">Delete</button>
+      </div>
+
       <h2 class="title is-4 mt-5">Games</h2>
 
       <div class="columns is-multiline">
@@ -27,20 +32,43 @@
           <GameCard :id="game.id" :name="game.name" :cover-url="game.coverUrl ?? null" />
         </div>
       </div>
+
+      <ConfirmDialog
+        v-model="showDeleteConfirm"
+        title="Delete platform?"
+        confirm-label="Delete platform"
+        loading-label="Deleting…"
+        :loading="deleting"
+        @confirm="confirmDelete"
+      >
+        <template #icon>
+          <CircleAlert :size="22" :stroke-width="1.8" />
+        </template>
+        <strong>{{ data.platform.name }}</strong> will be permanently deleted, and removed from every game that uses it.
+        This cannot be undone.
+      </ConfirmDialog>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { watch } from "vue";
+import { ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { useQuery } from "@/composables/useGraphQL";
+import { CircleAlert } from "@lucide/vue";
+import { useAuthStore } from "@/stores/auth";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
 import { GET_PLATFORM } from "@/graphql/queries/resources";
-import type { GetPlatformQuery } from "@/types/graphql";
+import { DELETE_PLATFORM } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetPlatformQuery, DeletePlatformMutation } from "@/types/graphql";
 import GameCard from "@/components/GameCard.vue";
+import ConfirmDialog from "@/components/ConfirmDialog.vue";
 
 const route = useRoute("platform");
 const router = useRouter();
+const authStore = useAuthStore();
+const { show: showSnackbar } = useSnackbar();
 
 const { data, loading, error } = useQuery<GetPlatformQuery>(GET_PLATFORM, {
   variables: { id: route.params.id }
@@ -51,4 +79,19 @@ watch([data, error, loading], () => {
     router.replace({ name: "notFound" });
   }
 });
+
+const showDeleteConfirm = ref(false);
+const { mutate: deletePlatform, loading: deleting } = useMutation<DeletePlatformMutation>(DELETE_PLATFORM);
+
+async function confirmDelete() {
+  try {
+    await deletePlatform({ platformId: route.params.id });
+    showSnackbar(`${data.value?.platform?.name ?? "Platform"} has been deleted.`);
+    showDeleteConfirm.value = false;
+    router.replace({ name: "platforms" });
+  } catch (e) {
+    showSnackbar(`Failed to delete platform: ${extractGqlError(e)}`, "error");
+    showDeleteConfirm.value = false;
+  }
+}
 </script>

--- a/frontend/src/pages/series/SeriesFormPage.vue
+++ b/frontend/src/pages/series/SeriesFormPage.vue
@@ -1,0 +1,106 @@
+<template>
+  <ResourceForm
+    v-model:name="name"
+    v-model:wikidata-id="wikidataId"
+    label="Series"
+    plural-label="series"
+    :is-editing="isEditing"
+    :loading="isEditing && loading && !data"
+    :submitting="submitting"
+    :submit-error="submitError"
+    :cancel-to="isEditing ? `/series/${seriesId}` : '/series'"
+    @submit="handleSubmit"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
+import { GET_SERIES_FOR_EDIT } from "@/graphql/queries/resources";
+import { CREATE_SERIES, UPDATE_SERIES } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetSeriesForEditQuery, CreateSeriesMutation, UpdateSeriesMutation } from "@/types/graphql";
+import ResourceForm from "@/components/ResourceForm.vue";
+
+// The edit route is used for typing because it is the superset of the two —
+// on the "new" route there is simply no `id` param.
+const route = useRoute("seriesEdit");
+const router = useRouter();
+const { show: showSnackbar } = useSnackbar();
+
+const isEditing = computed(() => !!route.params.id);
+const seriesId = computed(() => route.params.id);
+
+const name = ref("");
+const wikidataId = ref("");
+const submitError = ref("");
+
+const { data, loading, error } = useQuery<GetSeriesForEditQuery>(GET_SERIES_FOR_EDIT, {
+  variables: () => ({ id: seriesId.value }),
+  enabled: () => isEditing.value
+});
+
+watch(
+  () => data.value?.series,
+  (series) => {
+    if (!series) return;
+    name.value = series.name;
+    wikidataId.value = series.wikidataId != null ? String(series.wikidataId) : "";
+  },
+  { immediate: true }
+);
+
+// Redirect to 404 when editing a series that doesn't exist.
+watch([data, error, loading], () => {
+  if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.series))) {
+    router.replace({ name: "notFound" });
+  }
+});
+
+const { mutate: createSeries, loading: creating } = useMutation<CreateSeriesMutation>(CREATE_SERIES);
+const { mutate: updateSeries, loading: updating } = useMutation<UpdateSeriesMutation>(UPDATE_SERIES);
+const submitting = computed(() => creating.value || updating.value);
+
+async function handleSubmit() {
+  submitError.value = "";
+
+  const trimmedName = name.value.trim();
+  const trimmedWikidataId = wikidataId.value.trim();
+
+  if (!trimmedName) {
+    submitError.value = "Name is required.";
+    return;
+  }
+
+  if (!/^\d+$/.test(trimmedWikidataId) || Number(trimmedWikidataId) <= 0) {
+    submitError.value = "Wikidata ID must be a positive number.";
+    return;
+  }
+
+  try {
+    if (isEditing.value) {
+      const result = await updateSeries({
+        seriesId: seriesId.value,
+        name: trimmedName,
+        wikidataId: trimmedWikidataId
+      });
+      const series = result?.updateSeries?.series;
+      if (series) {
+        showSnackbar(`${series.name} has been updated.`);
+        router.push(`/series/${series.id}`);
+      }
+    } else {
+      const result = await createSeries({ name: trimmedName, wikidataId: trimmedWikidataId });
+      const series = result?.createSeries?.series;
+      if (series) {
+        showSnackbar(`${series.name} has been created.`);
+        router.push(`/series/${series.id}`);
+      }
+    }
+  } catch (e) {
+    submitError.value = extractGqlError(e);
+  }
+}
+</script>

--- a/frontend/src/pages/series/SeriesFormPage.vue
+++ b/frontend/src/pages/series/SeriesFormPage.vue
@@ -52,6 +52,16 @@ watch(
   { immediate: true }
 );
 
+// The "new" and "edit" routes resolve to this same component, so vue-router
+// reuses the instance when navigating between them. Clear any values carried
+// over from an edit when we land on "new".
+watch(isEditing, (editing) => {
+  if (editing) return;
+  name.value = "";
+  wikidataId.value = "";
+  submitError.value = "";
+});
+
 // Redirect to 404 when editing a series that doesn't exist.
 watch([data, error, loading], () => {
   if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.series))) {

--- a/frontend/src/pages/series/SeriesListPage.vue
+++ b/frontend/src/pages/series/SeriesListPage.vue
@@ -2,6 +2,10 @@
   <section class="section">
     <h1 class="title">Series</h1>
 
+    <div v-if="authStore.isModerator" class="buttons">
+      <router-link to="/series/new" class="button is-small is-primary">New Series</router-link>
+    </div>
+
     <div v-if="loading && !data" class="has-text-centered">
       <p>Loading series...</p>
     </div>
@@ -31,10 +35,13 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
+import { useAuthStore } from "@/stores/auth";
 import { useQuery } from "@/composables/useGraphQL";
 import { GET_SERIES_LIST } from "@/graphql/queries/resources";
 import type { GetSeriesListQuery } from "@/types/graphql";
 import PaginationNav from "@/components/PaginationNav.vue";
+
+const authStore = useAuthStore();
 
 const PAGE_SIZE = 25;
 const currentPage = ref(1);

--- a/frontend/src/pages/series/SeriesShowPage.vue
+++ b/frontend/src/pages/series/SeriesShowPage.vue
@@ -17,6 +17,11 @@
         >
       </p>
 
+      <div v-if="authStore.isModerator" class="buttons">
+        <router-link :to="`/series/${data.series.id}/edit`" class="button is-small">Edit</router-link>
+        <button class="button is-small is-danger is-light" @click="showDeleteConfirm = true">Delete</button>
+      </div>
+
       <h2 class="title is-4 mt-5">Games</h2>
 
       <div class="columns is-multiline">
@@ -24,20 +29,43 @@
           <GameCard :id="game.id" :name="game.name" :cover-url="game.coverUrl ?? null" />
         </div>
       </div>
+
+      <ConfirmDialog
+        v-model="showDeleteConfirm"
+        title="Delete series?"
+        confirm-label="Delete series"
+        loading-label="Deleting…"
+        :loading="deleting"
+        @confirm="confirmDelete"
+      >
+        <template #icon>
+          <CircleAlert :size="22" :stroke-width="1.8" />
+        </template>
+        <strong>{{ data.series.name }}</strong> will be permanently deleted, and removed from every game in it. This
+        cannot be undone.
+      </ConfirmDialog>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { watch } from "vue";
+import { ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { useQuery } from "@/composables/useGraphQL";
+import { CircleAlert } from "@lucide/vue";
+import { useAuthStore } from "@/stores/auth";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
 import { GET_SERIES } from "@/graphql/queries/resources";
-import type { GetSeriesQuery } from "@/types/graphql";
+import { DELETE_SERIES } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetSeriesQuery, DeleteSeriesMutation } from "@/types/graphql";
 import GameCard from "@/components/GameCard.vue";
+import ConfirmDialog from "@/components/ConfirmDialog.vue";
 
 const route = useRoute("series");
 const router = useRouter();
+const authStore = useAuthStore();
+const { show: showSnackbar } = useSnackbar();
 
 const { data, loading, error } = useQuery<GetSeriesQuery>(GET_SERIES, {
   variables: { id: route.params.id }
@@ -48,4 +76,19 @@ watch([data, error, loading], () => {
     router.replace({ name: "notFound" });
   }
 });
+
+const showDeleteConfirm = ref(false);
+const { mutate: deleteSeries, loading: deleting } = useMutation<DeleteSeriesMutation>(DELETE_SERIES);
+
+async function confirmDelete() {
+  try {
+    await deleteSeries({ seriesId: route.params.id });
+    showSnackbar(`${data.value?.series?.name ?? "Series"} has been deleted.`);
+    showDeleteConfirm.value = false;
+    router.replace({ name: "seriesList" });
+  } catch (e) {
+    showSnackbar(`Failed to delete series: ${extractGqlError(e)}`, "error");
+    showDeleteConfirm.value = false;
+  }
+}
 </script>

--- a/frontend/src/pages/stores/StoreFormPage.vue
+++ b/frontend/src/pages/stores/StoreFormPage.vue
@@ -50,6 +50,15 @@ watch(
   { immediate: true }
 );
 
+// The "new" and "edit" routes resolve to this same component, so vue-router
+// reuses the instance when navigating between them. Clear any values carried
+// over from an edit when we land on "new".
+watch(isEditing, (editing) => {
+  if (editing) return;
+  name.value = "";
+  submitError.value = "";
+});
+
 // Redirect to 404 when editing a store that doesn't exist.
 watch([data, error, loading], () => {
   if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.store))) {

--- a/frontend/src/pages/stores/StoreFormPage.vue
+++ b/frontend/src/pages/stores/StoreFormPage.vue
@@ -1,0 +1,94 @@
+<template>
+  <ResourceForm
+    v-model:name="name"
+    label="Store"
+    plural-label="stores"
+    :with-wikidata-id="false"
+    :is-editing="isEditing"
+    :loading="isEditing && loading && !data"
+    :submitting="submitting"
+    :submit-error="submitError"
+    :cancel-to="isEditing ? `/stores/${storeId}` : '/stores'"
+    @submit="handleSubmit"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
+import { GET_STORE_FOR_EDIT } from "@/graphql/queries/resources";
+import { CREATE_STORE, UPDATE_STORE } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetStoreForEditQuery, CreateStoreMutation, UpdateStoreMutation } from "@/types/graphql";
+import ResourceForm from "@/components/ResourceForm.vue";
+
+// The edit route is used for typing because it is the superset of the two —
+// on the "new" route there is simply no `id` param.
+const route = useRoute("storeEdit");
+const router = useRouter();
+const { show: showSnackbar } = useSnackbar();
+
+const isEditing = computed(() => !!route.params.id);
+const storeId = computed(() => route.params.id);
+
+const name = ref("");
+const submitError = ref("");
+
+const { data, loading, error } = useQuery<GetStoreForEditQuery>(GET_STORE_FOR_EDIT, {
+  variables: () => ({ id: storeId.value }),
+  enabled: () => isEditing.value
+});
+
+watch(
+  () => data.value?.store,
+  (store) => {
+    if (!store) return;
+    name.value = store.name;
+  },
+  { immediate: true }
+);
+
+// Redirect to 404 when editing a store that doesn't exist.
+watch([data, error, loading], () => {
+  if (isEditing.value && !loading.value && (error.value || (data.value && !data.value.store))) {
+    router.replace({ name: "notFound" });
+  }
+});
+
+const { mutate: createStore, loading: creating } = useMutation<CreateStoreMutation>(CREATE_STORE);
+const { mutate: updateStore, loading: updating } = useMutation<UpdateStoreMutation>(UPDATE_STORE);
+const submitting = computed(() => creating.value || updating.value);
+
+async function handleSubmit() {
+  submitError.value = "";
+
+  const trimmedName = name.value.trim();
+
+  if (!trimmedName) {
+    submitError.value = "Name is required.";
+    return;
+  }
+
+  try {
+    if (isEditing.value) {
+      const result = await updateStore({ storeId: storeId.value, name: trimmedName });
+      const store = result?.updateStore?.store;
+      if (store) {
+        showSnackbar(`${store.name} has been updated.`);
+        router.push(`/stores/${store.id}`);
+      }
+    } else {
+      const result = await createStore({ name: trimmedName });
+      const store = result?.createStore?.store;
+      if (store) {
+        showSnackbar(`${store.name} has been created.`);
+        router.push(`/stores/${store.id}`);
+      }
+    }
+  } catch (e) {
+    submitError.value = extractGqlError(e);
+  }
+}
+</script>

--- a/frontend/src/pages/stores/StoreListPage.vue
+++ b/frontend/src/pages/stores/StoreListPage.vue
@@ -2,6 +2,10 @@
   <section class="section">
     <h1 class="title">Stores</h1>
 
+    <div v-if="authStore.isModerator" class="buttons">
+      <router-link to="/stores/new" class="button is-small is-primary">New Store</router-link>
+    </div>
+
     <div v-if="loading && !data" class="has-text-centered">
       <p>Loading stores...</p>
     </div>
@@ -31,10 +35,13 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
+import { useAuthStore } from "@/stores/auth";
 import { useQuery } from "@/composables/useGraphQL";
 import { GET_STORES } from "@/graphql/queries/resources";
 import type { GetStoresQuery } from "@/types/graphql";
 import PaginationNav from "@/components/PaginationNav.vue";
+
+const authStore = useAuthStore();
 
 const PAGE_SIZE = 25;
 const currentPage = ref(1);

--- a/frontend/src/pages/stores/StoreShowPage.vue
+++ b/frontend/src/pages/stores/StoreShowPage.vue
@@ -8,21 +8,49 @@
       <p>Failed to load store: {{ error.message }}</p>
     </div>
 
-    <div v-if="data">
-      <h1 class="title">{{ data?.store?.name }}</h1>
+    <div v-if="data?.store">
+      <h1 class="title">{{ data.store.name }}</h1>
+
+      <div v-if="authStore.isModerator" class="buttons">
+        <router-link :to="`/stores/${data.store.id}/edit`" class="button is-small">Edit</router-link>
+        <button class="button is-small is-danger is-light" @click="showDeleteConfirm = true">Delete</button>
+      </div>
+
+      <ConfirmDialog
+        v-model="showDeleteConfirm"
+        title="Delete store?"
+        confirm-label="Delete store"
+        loading-label="Deleting…"
+        :loading="deleting"
+        @confirm="confirmDelete"
+      >
+        <template #icon>
+          <CircleAlert :size="22" :stroke-width="1.8" />
+        </template>
+        <strong>{{ data.store.name }}</strong> will be permanently deleted, and removed from every library entry that
+        uses it. This cannot be undone.
+      </ConfirmDialog>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { watch } from "vue";
+import { ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { useQuery } from "@/composables/useGraphQL";
+import { CircleAlert } from "@lucide/vue";
+import { useAuthStore } from "@/stores/auth";
+import { useQuery, useMutation } from "@/composables/useGraphQL";
+import { useSnackbar } from "@/composables/useSnackbar";
 import { GET_STORE } from "@/graphql/queries/resources";
-import type { GetStoreQuery } from "@/types/graphql";
+import { DELETE_STORE } from "@/graphql/mutations/resources";
+import { extractGqlError } from "@/utils/graphql-errors";
+import type { GetStoreQuery, DeleteStoreMutation } from "@/types/graphql";
+import ConfirmDialog from "@/components/ConfirmDialog.vue";
 
 const route = useRoute("store");
 const router = useRouter();
+const authStore = useAuthStore();
+const { show: showSnackbar } = useSnackbar();
 
 const { data, loading, error } = useQuery<GetStoreQuery>(GET_STORE, {
   variables: { id: route.params.id }
@@ -33,4 +61,19 @@ watch([data, error, loading], () => {
     router.replace({ name: "notFound" });
   }
 });
+
+const showDeleteConfirm = ref(false);
+const { mutate: deleteStore, loading: deleting } = useMutation<DeleteStoreMutation>(DELETE_STORE);
+
+async function confirmDelete() {
+  try {
+    await deleteStore({ storeId: route.params.id });
+    showSnackbar(`${data.value?.store?.name ?? "Store"} has been deleted.`);
+    showDeleteConfirm.value = false;
+    router.replace({ name: "stores" });
+  } catch (e) {
+    showSnackbar(`Failed to delete store: ${extractGqlError(e)}`, "error");
+    showDeleteConfirm.value = false;
+  }
+}
 </script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -105,9 +105,21 @@ const router = createRouter({
       component: () => import("@/pages/platforms/PlatformListPage.vue")
     },
     {
+      path: "/platforms/new",
+      name: "platformNew",
+      component: () => import("@/pages/platforms/PlatformFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
+    },
+    {
       path: "/platforms/:id",
       name: "platform",
       component: () => import("@/pages/platforms/PlatformShowPage.vue")
+    },
+    {
+      path: "/platforms/:id/edit",
+      name: "platformEdit",
+      component: () => import("@/pages/platforms/PlatformFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
     },
 
     // Companies
@@ -117,9 +129,21 @@ const router = createRouter({
       component: () => import("@/pages/companies/CompanyListPage.vue")
     },
     {
+      path: "/companies/new",
+      name: "companyNew",
+      component: () => import("@/pages/companies/CompanyFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
+    },
+    {
       path: "/companies/:id",
       name: "company",
       component: () => import("@/pages/companies/CompanyShowPage.vue")
+    },
+    {
+      path: "/companies/:id/edit",
+      name: "companyEdit",
+      component: () => import("@/pages/companies/CompanyFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
     },
 
     // Engines
@@ -129,9 +153,21 @@ const router = createRouter({
       component: () => import("@/pages/engines/EngineListPage.vue")
     },
     {
+      path: "/engines/new",
+      name: "engineNew",
+      component: () => import("@/pages/engines/EngineFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
+    },
+    {
       path: "/engines/:id",
       name: "engine",
       component: () => import("@/pages/engines/EngineShowPage.vue")
+    },
+    {
+      path: "/engines/:id/edit",
+      name: "engineEdit",
+      component: () => import("@/pages/engines/EngineFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
     },
 
     // Genres
@@ -141,9 +177,21 @@ const router = createRouter({
       component: () => import("@/pages/genres/GenreListPage.vue")
     },
     {
+      path: "/genres/new",
+      name: "genreNew",
+      component: () => import("@/pages/genres/GenreFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
+    },
+    {
       path: "/genres/:id",
       name: "genre",
       component: () => import("@/pages/genres/GenreShowPage.vue")
+    },
+    {
+      path: "/genres/:id/edit",
+      name: "genreEdit",
+      component: () => import("@/pages/genres/GenreFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
     },
 
     // Series
@@ -153,9 +201,21 @@ const router = createRouter({
       component: () => import("@/pages/series/SeriesListPage.vue")
     },
     {
+      path: "/series/new",
+      name: "seriesNew",
+      component: () => import("@/pages/series/SeriesFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
+    },
+    {
       path: "/series/:id",
       name: "series",
       component: () => import("@/pages/series/SeriesShowPage.vue")
+    },
+    {
+      path: "/series/:id/edit",
+      name: "seriesEdit",
+      component: () => import("@/pages/series/SeriesFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
     },
 
     // Stores
@@ -165,9 +225,21 @@ const router = createRouter({
       component: () => import("@/pages/stores/StoreListPage.vue")
     },
     {
+      path: "/stores/new",
+      name: "storeNew",
+      component: () => import("@/pages/stores/StoreFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
+    },
+    {
       path: "/stores/:id",
       name: "store",
       component: () => import("@/pages/stores/StoreShowPage.vue")
+    },
+    {
+      path: "/stores/:id/edit",
+      name: "storeEdit",
+      component: () => import("@/pages/stores/StoreFormPage.vue"),
+      meta: { requiresAuth: true, requiresModerator: true }
     },
 
     // Activity

--- a/frontend/src/typed-router.d.ts
+++ b/frontend/src/typed-router.d.ts
@@ -28,27 +28,39 @@ declare module "vue-router" {
 
       // Platforms
       platforms: RouteRecordInfo<"platforms", "/platforms", Record<never, never>, Record<never, never>>;
+      platformNew: RouteRecordInfo<"platformNew", "/platforms/new", Record<never, never>, Record<never, never>>;
       platform: RouteRecordInfo<"platform", "/platforms/:id", { id: string | number }, { id: string }>;
+      platformEdit: RouteRecordInfo<"platformEdit", "/platforms/:id/edit", { id: string | number }, { id: string }>;
 
       // Companies
       companies: RouteRecordInfo<"companies", "/companies", Record<never, never>, Record<never, never>>;
+      companyNew: RouteRecordInfo<"companyNew", "/companies/new", Record<never, never>, Record<never, never>>;
       company: RouteRecordInfo<"company", "/companies/:id", { id: string | number }, { id: string }>;
+      companyEdit: RouteRecordInfo<"companyEdit", "/companies/:id/edit", { id: string | number }, { id: string }>;
 
       // Engines
       engines: RouteRecordInfo<"engines", "/engines", Record<never, never>, Record<never, never>>;
+      engineNew: RouteRecordInfo<"engineNew", "/engines/new", Record<never, never>, Record<never, never>>;
       engine: RouteRecordInfo<"engine", "/engines/:id", { id: string | number }, { id: string }>;
+      engineEdit: RouteRecordInfo<"engineEdit", "/engines/:id/edit", { id: string | number }, { id: string }>;
 
       // Genres
       genres: RouteRecordInfo<"genres", "/genres", Record<never, never>, Record<never, never>>;
+      genreNew: RouteRecordInfo<"genreNew", "/genres/new", Record<never, never>, Record<never, never>>;
       genre: RouteRecordInfo<"genre", "/genres/:id", { id: string | number }, { id: string }>;
+      genreEdit: RouteRecordInfo<"genreEdit", "/genres/:id/edit", { id: string | number }, { id: string }>;
 
       // Series
       seriesList: RouteRecordInfo<"seriesList", "/series", Record<never, never>, Record<never, never>>;
+      seriesNew: RouteRecordInfo<"seriesNew", "/series/new", Record<never, never>, Record<never, never>>;
       series: RouteRecordInfo<"series", "/series/:id", { id: string | number }, { id: string }>;
+      seriesEdit: RouteRecordInfo<"seriesEdit", "/series/:id/edit", { id: string | number }, { id: string }>;
 
       // Stores
       stores: RouteRecordInfo<"stores", "/stores", Record<never, never>, Record<never, never>>;
+      storeNew: RouteRecordInfo<"storeNew", "/stores/new", Record<never, never>, Record<never, never>>;
       store: RouteRecordInfo<"store", "/stores/:id", { id: string | number }, { id: string }>;
+      storeEdit: RouteRecordInfo<"storeEdit", "/stores/:id/edit", { id: string | number }, { id: string }>;
 
       // Activity
       activity: RouteRecordInfo<"activity", "/activity", Record<never, never>, Record<never, never>>;

--- a/frontend/src/types/graphql.ts
+++ b/frontend/src/types/graphql.ts
@@ -316,6 +316,166 @@ export interface UpdateGameMutation {
   updateGame: { game: { id: string; name: string } } | null;
 }
 
+export type CreatePlatformMutationVariables = Exact<{
+  name: string;
+  wikidataId: string;
+}>;
+
+export interface CreatePlatformMutation {
+  createPlatform: { platform: { id: string; name: string } | null } | null;
+}
+
+export type UpdatePlatformMutationVariables = Exact<{
+  platformId: string;
+  name?: string | null | undefined;
+  wikidataId?: string | null | undefined;
+}>;
+
+export interface UpdatePlatformMutation {
+  updatePlatform: { platform: { id: string; name: string } } | null;
+}
+
+export type DeletePlatformMutationVariables = Exact<{
+  platformId: string;
+}>;
+
+export interface DeletePlatformMutation {
+  deletePlatform: { deleted: boolean | null } | null;
+}
+
+export type CreateCompanyMutationVariables = Exact<{
+  name: string;
+  wikidataId: string;
+}>;
+
+export interface CreateCompanyMutation {
+  createCompany: { company: { id: string; name: string } | null } | null;
+}
+
+export type UpdateCompanyMutationVariables = Exact<{
+  companyId: string;
+  name?: string | null | undefined;
+  wikidataId?: string | null | undefined;
+}>;
+
+export interface UpdateCompanyMutation {
+  updateCompany: { company: { id: string; name: string } } | null;
+}
+
+export type DeleteCompanyMutationVariables = Exact<{
+  companyId: string;
+}>;
+
+export interface DeleteCompanyMutation {
+  deleteCompany: { deleted: boolean | null } | null;
+}
+
+export type CreateEngineMutationVariables = Exact<{
+  name: string;
+  wikidataId: string;
+}>;
+
+export interface CreateEngineMutation {
+  createEngine: { engine: { id: string; name: string } | null } | null;
+}
+
+export type UpdateEngineMutationVariables = Exact<{
+  engineId: string;
+  name?: string | null | undefined;
+  wikidataId?: string | null | undefined;
+}>;
+
+export interface UpdateEngineMutation {
+  updateEngine: { engine: { id: string; name: string } } | null;
+}
+
+export type DeleteEngineMutationVariables = Exact<{
+  engineId: string;
+}>;
+
+export interface DeleteEngineMutation {
+  deleteEngine: { deleted: boolean | null } | null;
+}
+
+export type CreateGenreMutationVariables = Exact<{
+  name: string;
+  wikidataId: string;
+}>;
+
+export interface CreateGenreMutation {
+  createGenre: { genre: { id: string; name: string } | null } | null;
+}
+
+export type UpdateGenreMutationVariables = Exact<{
+  genreId: string;
+  name?: string | null | undefined;
+  wikidataId?: string | null | undefined;
+}>;
+
+export interface UpdateGenreMutation {
+  updateGenre: { genre: { id: string; name: string } } | null;
+}
+
+export type DeleteGenreMutationVariables = Exact<{
+  genreId: string;
+}>;
+
+export interface DeleteGenreMutation {
+  deleteGenre: { deleted: boolean | null } | null;
+}
+
+export type CreateSeriesMutationVariables = Exact<{
+  name: string;
+  wikidataId: string;
+}>;
+
+export interface CreateSeriesMutation {
+  createSeries: { series: { id: string; name: string } | null } | null;
+}
+
+export type UpdateSeriesMutationVariables = Exact<{
+  seriesId: string;
+  name?: string | null | undefined;
+  wikidataId?: string | null | undefined;
+}>;
+
+export interface UpdateSeriesMutation {
+  updateSeries: { series: { id: string; name: string } } | null;
+}
+
+export type DeleteSeriesMutationVariables = Exact<{
+  seriesId: string;
+}>;
+
+export interface DeleteSeriesMutation {
+  deleteSeries: { deleted: boolean | null } | null;
+}
+
+export type CreateStoreMutationVariables = Exact<{
+  name: string;
+}>;
+
+export interface CreateStoreMutation {
+  createStore: { store: { id: string; name: string } | null } | null;
+}
+
+export type UpdateStoreMutationVariables = Exact<{
+  storeId: string;
+  name?: string | null | undefined;
+}>;
+
+export interface UpdateStoreMutation {
+  updateStore: { store: { id: string; name: string } } | null;
+}
+
+export type DeleteStoreMutationVariables = Exact<{
+  storeId: string;
+}>;
+
+export interface DeleteStoreMutation {
+  deleteStore: { deleted: boolean | null } | null;
+}
+
 export type UpdateUserMutationVariables = Exact<{
   bio?: string | null | undefined;
   privacy?: UserPrivacy | null | undefined;
@@ -643,6 +803,14 @@ export interface GetPlatformQuery {
   } | null;
 }
 
+export type GetPlatformForEditQueryVariables = Exact<{
+  id: string;
+}>;
+
+export interface GetPlatformForEditQuery {
+  platform: { id: string; name: string; wikidataId: number | null } | null;
+}
+
 export type GetCompaniesQueryVariables = Exact<{
   first?: number | null | undefined;
   after?: string | null | undefined;
@@ -667,6 +835,14 @@ export interface GetCompanyQuery {
     developedGames: { nodes: Array<{ id: string; name: string; coverUrl: string | null }> };
     publishedGames: { nodes: Array<{ id: string; name: string; coverUrl: string | null }> };
   } | null;
+}
+
+export type GetCompanyForEditQueryVariables = Exact<{
+  id: string;
+}>;
+
+export interface GetCompanyForEditQuery {
+  company: { id: string; name: string; wikidataId: number | null } | null;
 }
 
 export type GetGenresQueryVariables = Exact<{
@@ -694,6 +870,14 @@ export interface GetGenreQuery {
   } | null;
 }
 
+export type GetGenreForEditQueryVariables = Exact<{
+  id: string;
+}>;
+
+export interface GetGenreForEditQuery {
+  genre: { id: string; name: string; wikidataId: number | null } | null;
+}
+
 export type GetEnginesQueryVariables = Exact<{
   first?: number | null | undefined;
   after?: string | null | undefined;
@@ -717,6 +901,14 @@ export interface GetEngineQuery {
     wikidataId: number | null;
     games: { nodes: Array<{ id: string; name: string; coverUrl: string | null }> };
   } | null;
+}
+
+export type GetEngineForEditQueryVariables = Exact<{
+  id: string;
+}>;
+
+export interface GetEngineForEditQuery {
+  engine: { id: string; name: string; wikidataId: number | null } | null;
 }
 
 export type GetSeriesListQueryVariables = Exact<{
@@ -744,6 +936,14 @@ export interface GetSeriesQuery {
   } | null;
 }
 
+export type GetSeriesForEditQueryVariables = Exact<{
+  id: string;
+}>;
+
+export interface GetSeriesForEditQuery {
+  series: { id: string; name: string; wikidataId: number | null } | null;
+}
+
 export type GetStoresQueryVariables = Exact<{
   first?: number | null | undefined;
   after?: string | null | undefined;
@@ -761,6 +961,14 @@ export type GetStoreQueryVariables = Exact<{
 }>;
 
 export interface GetStoreQuery {
+  store: { id: string; name: string } | null;
+}
+
+export type GetStoreForEditQueryVariables = Exact<{
+  id: string;
+}>;
+
+export interface GetStoreForEditQuery {
   store: { id: string; name: string } | null;
 }
 


### PR DESCRIPTION
## Summary

The GraphQL API has had create/update/delete mutations and Pundit policies for all six of these entity types for a while, but the SPA only ever rendered list and show pages for them. Games were the sole entity with a form page, so everything else could only be edited by hitting the API directly — 21 mutations with no frontend caller.

This adds new/edit routes and a delete affordance for each, all gated on moderator-or-admin.

## What's here

- **`ResourceForm.vue`** holds the shared markup, since all six resources are just a name plus a Wikidata ID. Stores have no `wikidata_id` column, so the component takes a `withWikidataId` prop to drop that field.
- **Six form pages**, each wiring up its own queries, mutations, and redirects, following the existing `GameFormPage` pattern (one component serving both the `/new` and `/:id/edit` routes).
- **Show pages** get Edit/Delete buttons, with delete behind the existing `ConfirmDialog` — the same one game deletion uses, so focus trapping, Escape-to-cancel, and focus restore come along with it. Each dialog names the record and spells out the cascade.
- **List pages** get a "New …" button for moderators.
- Lightweight `GET_*_FOR_EDIT` queries avoid pulling 30 games into a form that only needs a name and an ID.

## Notes

The mutations all require `first_party`. The SPA satisfies this because sign-in issues a JWT and `GraphqlController#first_party?` trusts a verified `@jwt_user` before it reaches the production check. Third-party OAuth clients still can't call these, which is the intended behavior.

The second commit fixes a bug found during review: the `new` and `edit` routes resolve to the same component module, so vue-router reuses the instance rather than remounting when navigating between them. That left the `new` form pre-filled with whatever was last edited. Verified with a scratch test (one instance created across both navigations, input state carried over) and fixed by resetting the fields when `isEditing` goes false. The same latent bug exists in `GameFormPage.vue` and is left alone here.

## Known gaps (pre-existing, not introduced here)

- `Store` declares `has_many :game_purchase_stores` without `dependent: :destroy`, so deleting an in-use store will error rather than cascade. It fails safe — the user gets an error snackbar — but store deletion won't actually work on stores that are in use.
- The delete dialogs warn that a delete cascades but don't say *how much*. Adding a `totalCount` to the show queries would make the blast radius visible.
- `/games/new` still has no link anywhere in the UI.

## Testing

`typecheck`, `lint`, `fmt:check`, and `build` all pass. Vitest: 55 passed across 8 files, including 10 new cases covering `ResourceForm` (create vs. edit rendering, field population, emitted updates, loading/error/submitting states, the no-Wikidata variant, and the non-moderator gate). No Ruby changed, so RSpec and Rubocop are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)