### PR TITLE
Require a first-party token to reset the API token

### DIFF
--- a/app/graphql/mutations/users/reset_api_token.rb
+++ b/app/graphql/mutations/users/reset_api_token.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Mutations::Users::ResetApiToken < Mutations::BaseMutation
-  description "Generate a new API token for the current user."
+  description "Generate a new API token for the current user. " \
+              "**Only available when using a first-party OAuth application.**"
 
   field :api_token, String, null: true, description: "The newly generated API token."
   field :errors, [String], null: false, description: "Error messages if token reset failed."
@@ -9,6 +10,12 @@ class Mutations::Users::ResetApiToken < Mutations::BaseMutation
   def resolve
     user = context[:current_user]
     raise GraphQL::ExecutionError, "You must be logged in to reset your API token." if user.nil?
+
+    # The plaintext token this returns is a long-lived credential that grants
+    # full, scope-less access to the account (see `token_auth` in
+    # BaseMutation#ready?), so it must never be handed to a third-party client
+    # holding nothing more than the 'write' scope.
+    require_permissions!(:first_party)
 
     token = user.reset_api_token
     if token

--- a/spec/requests/graphql/user_mutations_spec.rb
+++ b/spec/requests/graphql/user_mutations_spec.rb
@@ -73,6 +73,23 @@ RSpec.describe "GraphQL User Mutations", type: :request do
       json = JSON.parse(response.body)
       expect(json['errors'].first['message']).to include("logged in")
     end
+
+    it "returns an error when using a non-first-party API token", :aggregate_failures do
+      api_token = SecureRandom.alphanumeric(20)
+      api_token_user = create(:confirmed_user, encrypted_api_token: EncryptionService.encrypt(api_token))
+
+      post graphql_path, params: { query: query }, headers: {
+        'X-User-Email': api_token_user.email,
+        'X-User-Token': api_token
+      }
+
+      json = JSON.parse(response.body)
+      expect(json['errors'].first['message']).to include("first-party")
+      expect(json.dig('data', 'resetApiToken')).to be_nil
+      # The existing token must survive a rejected reset, otherwise this is a
+      # denial-of-service against the user's other integrations.
+      expect(api_token_user.reload.verify_api_token!(api_token)).to be true
+    end
   end
 
   describe "updateEmail mutation" do


### PR DESCRIPTION
## Problem

`Mutations::Users::ResetApiToken` had no `authorized?` hook and no `require_permissions!(:first_party)` call. `BaseMutation#ready?` only checks for the `write` scope, so **any third-party OAuth client holding `write` could call `resetApiToken` and read the user's plaintext legacy API token straight out of the response.**

That token is a genuine privilege escalation, not a lateral move:

- API-token auth sets `token_auth: true` in `graphql_controller.rb`, and `BaseMutation#ready?` **skips the scope check entirely** for token auth — so a `write`-scoped third-party token converts into a scope-less credential.
- The token lives outside Doorkeeper, so it survives OAuth revocation.
- The reset also silently invalidates the user's existing token, breaking their other integrations.

Every comparable user mutation (`deleteUser`, `banUser`, `resetUserLibrary`, `exportLibrary`, `removeUserAvatar`, …) already gates on `:first_party`; this one was the outlier.

## Fix

Gate the mutation inside `resolve` after the login check, following the `exportLibrary` pattern for no-argument, current-user-only mutations that return sensitive data. Also updated the description to carry the standard `**Only available when using a first-party OAuth application.**` note.

The SPA is unaffected — it authenticates with JWTs, and `first_party?` returns `true` whenever `@jwt_user` is present.

## Test plan

- [x] New regression spec asserts a non-first-party API token is rejected **and** that the user's existing token still verifies afterward (the DoS half of the bug).
- [x] `bundle exec rspec spec/requests/graphql/user_mutations_spec.rb` — 20 examples, 0 failures
- [x] `bundle exec rubocop` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)