### PR TITLE
Require a first-party token for the remaining account-settings mutations

### DIFF
--- a/app/graphql/mutations/users/update_email.rb
+++ b/app/graphql/mutations/users/update_email.rb
@@ -2,7 +2,8 @@
 
 class Mutations::Users::UpdateEmail < Mutations::BaseMutation
   description "Update the current user's email address. Requires current password for verification. " \
-              "The new email must be confirmed before it takes effect."
+              "The new email must be confirmed before it takes effect. " \
+              "**Only available when using a first-party OAuth application.**"
 
   argument :new_email, String, required: true, description: "The new email address."
   argument :current_password, String, required: true, description: "The user's current password for verification."
@@ -13,6 +14,12 @@ class Mutations::Users::UpdateEmail < Mutations::BaseMutation
   def resolve(new_email:, current_password:)
     user = context[:current_user]
     raise GraphQL::ExecutionError, "You must be logged in to update your email." if user.nil?
+
+    # The email address is the account's recovery channel, so changing it is an
+    # auth-factor change. The password check below is the primary control; this
+    # keeps a third-party client that has obtained the password some other way
+    # from using a 'write' token to complete an account takeover.
+    require_permissions!(:first_party)
 
     return { user: nil, errors: ["Current password is incorrect."] } unless user.valid_password?(current_password)
 

--- a/app/graphql/mutations/users/update_password.rb
+++ b/app/graphql/mutations/users/update_password.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Mutations::Users::UpdatePassword < Mutations::BaseMutation
-  description "Update the current user's password. Requires current password for verification."
+  description "Update the current user's password. Requires current password for verification. " \
+              "**Only available when using a first-party OAuth application.**"
 
   argument :current_password, String, required: true, description: "The user's current password for verification."
   argument :new_password, String, required: true, description: "The new password (minimum 8 characters)."
@@ -13,6 +14,12 @@ class Mutations::Users::UpdatePassword < Mutations::BaseMutation
   def resolve(current_password:, new_password:, new_password_confirmation:)
     user = context[:current_user]
     raise GraphQL::ExecutionError, "You must be logged in to update your password." if user.nil?
+
+    # Changing the password is an auth-factor change, and `revoke_all!` below
+    # only invalidates JWTs — a third-party OAuth token keeps working across
+    # the change. A 'write' scope shouldn't be enough to rotate the credential
+    # that every other session depends on.
+    require_permissions!(:first_party)
 
     return { user: nil, errors: ["Current password is incorrect."] } unless user.valid_password?(current_password)
 

--- a/app/graphql/mutations/users/update_user.rb
+++ b/app/graphql/mutations/users/update_user.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Mutations::Users::UpdateUser < Mutations::BaseMutation
-  description "Update the current user's profile."
+  description "Update the current user's profile. Changing `privacy` is " \
+              "**only available when using a first-party OAuth application.**"
 
   argument :bio, String, required: false, description: "User profile description."
-  argument :privacy, Types::Enums::UserPrivacyType, required: false, description: "Account privacy setting."
+  argument :privacy, Types::Enums::UserPrivacyType, required: false, description: "Account privacy setting. **Only available when using a first-party OAuth application.**"
   argument :hide_days_played, Boolean, required: false, description: "Whether to hide days played on profile."
 
   field :user, Types::UserType, null: true, description: "The updated user."
@@ -16,6 +17,13 @@ class Mutations::Users::UpdateUser < Mutations::BaseMutation
 
     # Only update attributes that were provided
     update_params = args.compact
+
+    # `privacy` decides whether the account's library and activity are visible
+    # to the world, so it's a security setting rather than a profile field.
+    # `bio` and `hideDaysPlayed` are ordinary profile writes that third-party
+    # clients can legitimately make, so only gate the mutation when privacy is
+    # actually being changed.
+    require_permissions!(:first_party) if update_params.key?(:privacy)
 
     if user.update(update_params)
       { user: user, errors: [] }

--- a/spec/requests/graphql/user_mutations_spec.rb
+++ b/spec/requests/graphql/user_mutations_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe "GraphQL User Mutations", type: :request do
   let(:jwt_token) { JwtService.encode(user) }
   let(:auth_headers) { { 'Authorization': "Bearer #{jwt_token}" } }
 
+  # Legacy API-token auth never counts as first-party (see `first_party?` in
+  # GraphqlController), so it stands in for any non-first-party credential.
+  let(:api_token) { SecureRandom.alphanumeric(20) }
+  let(:api_token_user) { create(:confirmed_user, encrypted_api_token: EncryptionService.encrypt(api_token)) }
+  let(:api_token_headers) do
+    { 'X-User-Email': api_token_user.email, 'X-User-Token': api_token }
+  end
+
   describe "updateUser mutation" do
     let(:query) do
       <<~GQL
@@ -42,6 +50,54 @@ RSpec.describe "GraphQL User Mutations", type: :request do
       json = JSON.parse(response.body)
       expect(json['errors'].first['message']).to include("logged in")
     end
+
+    it "updates the bio when using a non-first-party API token", :aggregate_failures do
+      post graphql_path, params: {
+        query: query,
+        variables: { bio: "Third-party bio" }.to_json
+      }, headers: api_token_headers
+
+      json = JSON.parse(response.body)
+      expect(json.dig('data', 'updateUser', 'errors')).to be_empty
+      expect(api_token_user.reload.bio).to eq("Third-party bio")
+    end
+
+    context "when changing privacy" do
+      let(:privacy_query) do
+        <<~GQL
+          mutation UpdateUser($privacy: UserPrivacy) {
+            updateUser(privacy: $privacy) {
+              user { id privacy }
+              errors
+            }
+          }
+        GQL
+      end
+
+      it "updates privacy with a first-party token", :aggregate_failures do
+        post graphql_path, params: {
+          query: privacy_query,
+          variables: { privacy: "PRIVATE_ACCOUNT" }.to_json
+        }, headers: auth_headers
+
+        json = JSON.parse(response.body)
+        expect(json.dig('data', 'updateUser', 'errors')).to be_empty
+        expect(user.reload.privacy).to eq("private_account")
+      end
+
+      it "returns an error when using a non-first-party API token", :aggregate_failures do
+        api_token_user.update!(privacy: :private_account)
+
+        post graphql_path, params: {
+          query: privacy_query,
+          variables: { privacy: "PUBLIC_ACCOUNT" }.to_json
+        }, headers: api_token_headers
+
+        json = JSON.parse(response.body)
+        expect(json['errors'].first['message']).to include("first-party")
+        expect(api_token_user.reload.privacy).to eq("private_account")
+      end
+    end
   end
 
   describe "resetApiToken mutation" do
@@ -75,13 +131,7 @@ RSpec.describe "GraphQL User Mutations", type: :request do
     end
 
     it "returns an error when using a non-first-party API token", :aggregate_failures do
-      api_token = SecureRandom.alphanumeric(20)
-      api_token_user = create(:confirmed_user, encrypted_api_token: EncryptionService.encrypt(api_token))
-
-      post graphql_path, params: { query: query }, headers: {
-        'X-User-Email': api_token_user.email,
-        'X-User-Token': api_token
-      }
+      post graphql_path, params: { query: query }, headers: api_token_headers
 
       json = JSON.parse(response.body)
       expect(json['errors'].first['message']).to include("first-party")
@@ -153,6 +203,18 @@ RSpec.describe "GraphQL User Mutations", type: :request do
 
       json = JSON.parse(response.body)
       expect(json['errors'].first['message']).to include("logged in")
+    end
+
+    it "returns an error when using a non-first-party API token", :aggregate_failures do
+      post graphql_path, params: {
+        query: query,
+        variables: { newEmail: "attacker@example.com", currentPassword: "password" }.to_json
+      }, headers: api_token_headers
+
+      json = JSON.parse(response.body)
+      expect(json['errors'].first['message']).to include("first-party")
+      # Rejected even though the correct password was supplied.
+      expect(api_token_user.reload.unconfirmed_email).to be_nil
     end
   end
 
@@ -248,6 +310,22 @@ RSpec.describe "GraphQL User Mutations", type: :request do
       expect(json['errors'].first['message']).to include("logged in")
     end
 
+    it "returns an error when using a non-first-party API token", :aggregate_failures do
+      post graphql_path, params: {
+        query: query,
+        variables: {
+          currentPassword: "password",
+          newPassword: "newpassword123",
+          newPasswordConfirmation: "newpassword123"
+        }.to_json
+      }, headers: api_token_headers
+
+      json = JSON.parse(response.body)
+      expect(json['errors'].first['message']).to include("first-party")
+      # Rejected even though the correct password was supplied.
+      expect(api_token_user.reload.valid_password?("password")).to be true
+    end
+
     it "revokes previously issued JWTs after a successful password update", :aggregate_failures do
       # Capture the token as it stood before the password change, then make
       # sure a fresh token works (sanity check) before asserting that the
@@ -338,13 +416,7 @@ RSpec.describe "GraphQL User Mutations", type: :request do
     end
 
     it "returns an error when using a non-first-party API token" do
-      api_token = SecureRandom.alphanumeric(20)
-      api_token_user = create(:confirmed_user, encrypted_api_token: EncryptionService.encrypt(api_token))
-
-      post graphql_path, params: { query: query }, headers: {
-        'X-User-Email': api_token_user.email,
-        'X-User-Token': api_token
-      }
+      post graphql_path, params: { query: query }, headers: api_token_headers
 
       json = JSON.parse(response.body)
       expect(json['errors'].first['message']).to include("first-party")


### PR DESCRIPTION
Follow-up to #4651. Every mutation in the SPA's `users-settings.ts` is an account-settings operation, and all but three already required a first-party token. This gates the stragglers.

## `updateUser` — the real gap

`privacy` decides whether an account's library and activity are world-visible (see the `public_account` filter in `ActivityResolver`), and it had **no password check and no first-party gate** — so any third-party client holding `write` could flip a private account public. This is the closest analogue to the `resetApiToken` issue: a security-relevant setting change reachable by a bare `write` token with no second factor.

`bio` and `hideDaysPlayed` are ordinary profile writes that third-party clients can legitimately make, so the gate applies **only when `privacy` is among the supplied arguments** rather than to the whole mutation. There's a spec covering that split.

## `updateEmail` / `updatePassword` — defense in depth

Both verify the current password, so a token alone can't reach them. The case this closes is a third-party app that has collected the password out of band (the "re-enter your password to continue" pattern): with a `write` token it could then change the recovery email *and* the password, which is permanent account takeover. Note that `revoke_all!` in `updatePassword` only invalidates JWTs — the attacker's Doorkeeper token would survive a change that logs the victim out everywhere else.

## Test plan

- [x] Three new specs, one per mutation, asserting rejection **and** that the underlying state is unchanged (email/password/privacy).
- [x] Each new spec confirmed to **fail with the gate removed** (`git stash push -- app/` → 3 failures, all the new ones).
- [x] New positive spec: `bio` updates still succeed with a non-first-party token, so the surgical `updateUser` gate doesn't over-block.
- [x] Refactored the repeated API-token header setup into a shared `let` (5 copies → 1).
- [x] Full suite: `bundle exec rake parallel:spec` — 986 examples, 0 failures
- [x] `bundle exec rubocop app/graphql spec/requests/graphql` — 147 files, no offenses
- [x] `pnpm --dir=frontend run lint:schema` — 0 errors

The SPA is unaffected — it authenticates with JWTs, which are always first-party.

🤖 Generated with [Claude Code](https://claude.com/claude-code)