### PR TITLE
Don't render edit forms with the previously loaded record

### DIFF
--- a/frontend/src/composables/useGraphQL.test.ts
+++ b/frontend/src/composables/useGraphQL.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { defineComponent, nextTick, ref } from "vue";
+import { defineComponent, nextTick, ref, type Ref } from "vue";
 import { mount } from "@vue/test-utils";
 import { GET_PLATFORM_FOR_EDIT } from "@/graphql/queries/resources";
 import { useQuery } from "./useGraphQL";
@@ -32,9 +32,11 @@ type ThingData = { platform: { id: string } };
 
 /**
  * Mounts a component around `useQuery` so `onMounted` fires and the reactive
- * variables watcher is active, and hands back the id ref to drive it.
+ * variables watcher is active, and hands back the id ref to drive it. Pass an
+ * `enabled` ref to also drive the enabled flag; leaving it off exercises the
+ * always-enabled path where the option is omitted entirely.
  */
-function mountQuery() {
+function mountQuery({ enabled }: { enabled?: Ref<boolean> } = {}) {
   const id = ref("1");
   // Held in a plain binding rather than a ref — a ref would deeply unwrap the
   // refs the composable returns, leaving `.value` undefined.
@@ -44,7 +46,8 @@ function mountQuery() {
     defineComponent({
       setup() {
         composable = useQuery<ThingData>(GET_PLATFORM_FOR_EDIT, {
-          variables: () => ({ id: id.value })
+          variables: () => ({ id: id.value }),
+          enabled: enabled ? () => enabled.value : undefined
         });
         return () => null;
       }
@@ -124,6 +127,62 @@ describe("useQuery", () => {
 
     expect(query().error.value).toBeNull();
     expect(query().data.value).toEqual({ platform: { id: "2" } });
+  });
+
+  it("discards a response that arrives after the query is disabled", async () => {
+    const first = deferred<ThingData>();
+    mockRequest.mockReturnValueOnce(first.promise);
+
+    const enabled = ref(true);
+    const { query } = mountQuery({ enabled });
+    await nextTick();
+
+    // Standing in for navigating from an edit route to a new one in a reused
+    // component: the query is disabled while its request is still in flight.
+    enabled.value = false;
+    await nextTick();
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+
+    first.resolve({ platform: { id: "1" } });
+    await nextTick();
+
+    // Applying it would repopulate form fields the page just cleared.
+    expect(query().data.value).toBeNull();
+    expect(query().loading.value).toBeFalsy();
+  });
+
+  it("discards an error that arrives after the query is disabled", async () => {
+    const first = deferred<ThingData>();
+    mockRequest.mockReturnValueOnce(first.promise);
+
+    const enabled = ref(true);
+    const { query } = mountQuery({ enabled });
+    await nextTick();
+
+    enabled.value = false;
+    await nextTick();
+
+    first.reject(new Error("stale request failed"));
+    await nextTick();
+
+    expect(query().error.value).toBeNull();
+    expect(query().loading.value).toBeFalsy();
+  });
+
+  it("runs again when the query is re-enabled", async () => {
+    mockRequest.mockResolvedValue({ platform: { id: "1" } });
+
+    const enabled = ref(false);
+    const { query } = mountQuery({ enabled });
+    await nextTick();
+    expect(mockRequest).not.toHaveBeenCalled();
+
+    enabled.value = true;
+    await nextTick();
+    await nextTick();
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(query().data.value).toEqual({ platform: { id: "1" } });
   });
 
   it("still surfaces data and errors from the newest request", async () => {

--- a/frontend/src/composables/useGraphQL.test.ts
+++ b/frontend/src/composables/useGraphQL.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { defineComponent, nextTick, ref } from "vue";
+import { mount } from "@vue/test-utils";
+import { GET_PLATFORM_FOR_EDIT } from "@/graphql/queries/resources";
+import { useQuery } from "./useGraphQL";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────
+
+const { mockRequest } = vi.hoisted(() => ({
+  mockRequest: vi.fn<(...args: unknown[]) => Promise<unknown>>()
+}));
+
+vi.mock("@/graphql/client", () => ({
+  gqlClient: { request: mockRequest }
+}));
+
+/**
+ * A deferred promise, so a test can control exactly when (and in what order)
+ * each in-flight request resolves.
+ */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+type ThingData = { platform: { id: string } };
+
+/**
+ * Mounts a component around `useQuery` so `onMounted` fires and the reactive
+ * variables watcher is active, and hands back the id ref to drive it.
+ */
+function mountQuery() {
+  const id = ref("1");
+  // Held in a plain binding rather than a ref — a ref would deeply unwrap the
+  // refs the composable returns, leaving `.value` undefined.
+  let composable: ReturnType<typeof useQuery<ThingData>> | null = null;
+
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        composable = useQuery<ThingData>(GET_PLATFORM_FOR_EDIT, {
+          variables: () => ({ id: id.value })
+        });
+        return () => null;
+      }
+    })
+  );
+
+  return { id, wrapper, query: () => composable! };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("useQuery", () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it("discards a response that has been superseded by a newer request", async () => {
+    const first = deferred<ThingData>();
+    const second = deferred<ThingData>();
+    mockRequest.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const { id, query } = mountQuery();
+    await nextTick();
+
+    // Change the variable so a second request goes out while the first is
+    // still in flight.
+    id.value = "2";
+    await nextTick();
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+
+    // The newer request answers first, then the stale one arrives late.
+    second.resolve({ platform: { id: "2" } });
+    await nextTick();
+    first.resolve({ platform: { id: "1" } });
+    await nextTick();
+
+    expect(query().data.value).toEqual({ platform: { id: "2" } });
+  });
+
+  it("keeps loading true until the newest request settles", async () => {
+    const first = deferred<ThingData>();
+    const second = deferred<ThingData>();
+    mockRequest.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const { id, query } = mountQuery();
+    await nextTick();
+
+    id.value = "2";
+    await nextTick();
+
+    // The superseded request settling must not clear the loading flag, or the
+    // UI would show a form/page as ready while the real request is pending.
+    first.resolve({ platform: { id: "1" } });
+    await nextTick();
+    expect(query().loading.value).toBeTruthy();
+
+    second.resolve({ platform: { id: "2" } });
+    await nextTick();
+    expect(query().loading.value).toBeFalsy();
+  });
+
+  it("ignores an error from a superseded request", async () => {
+    const first = deferred<ThingData>();
+    const second = deferred<ThingData>();
+    mockRequest.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const { id, query } = mountQuery();
+    await nextTick();
+
+    id.value = "2";
+    await nextTick();
+
+    second.resolve({ platform: { id: "2" } });
+    await nextTick();
+    first.reject(new Error("stale request failed"));
+    await nextTick();
+
+    expect(query().error.value).toBeNull();
+    expect(query().data.value).toEqual({ platform: { id: "2" } });
+  });
+
+  it("still surfaces data and errors from the newest request", async () => {
+    mockRequest.mockRejectedValueOnce(new Error("boom"));
+
+    const { query } = mountQuery();
+    await nextTick();
+    await nextTick();
+
+    expect(query().error.value?.message).toBe("boom");
+    expect(query().loading.value).toBeFalsy();
+  });
+});

--- a/frontend/src/composables/useGraphQL.ts
+++ b/frontend/src/composables/useGraphQL.ts
@@ -37,8 +37,17 @@ export function useQuery<TData = Record<string, unknown>, TVariables = Record<st
   // last wins — which may be the older one.
   let latestRequestId = 0;
 
+  // A disabled query must not write state, and `enabled` can flip to false
+  // while a request is in flight (e.g. navigating from an edit route to a new
+  // one in a component vue-router reuses). Bailing out of `execute` doesn't
+  // touch `latestRequestId`, so the in-flight request would otherwise still
+  // count as the newest and apply its result.
+  function isEnabled() {
+    return options?.enabled === undefined || resolveValue(options.enabled);
+  }
+
   async function execute() {
-    if (options?.enabled !== undefined && !resolveValue(options.enabled)) return;
+    if (!isEnabled()) return;
 
     const requestId = ++latestRequestId;
     loading.value = true;
@@ -47,10 +56,10 @@ export function useQuery<TData = Record<string, unknown>, TVariables = Record<st
     try {
       const variables = options?.variables ? resolveValue(options.variables) : undefined;
       const result = await gqlClient.request<TData>(query, variables as Record<string, unknown>);
-      if (requestId !== latestRequestId) return;
+      if (requestId !== latestRequestId || !isEnabled()) return;
       data.value = result;
     } catch (e) {
-      if (requestId !== latestRequestId) return;
+      if (requestId !== latestRequestId || !isEnabled()) return;
       error.value = e instanceof Error ? e : new Error(String(e));
     } finally {
       // Only the newest request owns the loading flag, so a superseded
@@ -66,14 +75,14 @@ export function useQuery<TData = Record<string, unknown>, TVariables = Record<st
     loading.value = true;
     try {
       const nextData = await gqlClient.request<TData>(query, variables);
-      if (requestId !== latestRequestId) return;
+      if (requestId !== latestRequestId || !isEnabled()) return;
       if (data.value) {
         data.value = merge(data.value, nextData);
       } else {
         data.value = nextData;
       }
     } catch (e) {
-      if (requestId !== latestRequestId) return;
+      if (requestId !== latestRequestId || !isEnabled()) return;
       error.value = e instanceof Error ? e : new Error(String(e));
     } finally {
       if (requestId === latestRequestId) loading.value = false;

--- a/frontend/src/composables/useGraphQL.ts
+++ b/frontend/src/composables/useGraphQL.ts
@@ -31,35 +31,52 @@ export function useQuery<TData = Record<string, unknown>, TVariables = Record<st
   const loading = ref(false);
   const error = ref<Error | null>(null);
 
+  // Requests are numbered so a response that has been superseded by a newer
+  // one can be discarded. Without this, two in-flight requests (e.g. after a
+  // reactive variable changes twice) race, and whichever the server answers
+  // last wins — which may be the older one.
+  let latestRequestId = 0;
+
   async function execute() {
     if (options?.enabled !== undefined && !resolveValue(options.enabled)) return;
 
+    const requestId = ++latestRequestId;
     loading.value = true;
     error.value = null;
 
     try {
       const variables = options?.variables ? resolveValue(options.variables) : undefined;
-      data.value = await gqlClient.request<TData>(query, variables as Record<string, unknown>);
+      const result = await gqlClient.request<TData>(query, variables as Record<string, unknown>);
+      if (requestId !== latestRequestId) return;
+      data.value = result;
     } catch (e) {
+      if (requestId !== latestRequestId) return;
       error.value = e instanceof Error ? e : new Error(String(e));
     } finally {
-      loading.value = false;
+      // Only the newest request owns the loading flag, so a superseded
+      // response can't clear it while its replacement is still in flight.
+      if (requestId === latestRequestId) loading.value = false;
     }
   }
 
   async function fetchMore(variables: Record<string, unknown>, merge: (prev: TData, next: TData) => TData) {
+    // Shares the counter with `execute` so that loading another page and
+    // re-running the base query can't interleave into a mangled result.
+    const requestId = ++latestRequestId;
     loading.value = true;
     try {
       const nextData = await gqlClient.request<TData>(query, variables);
+      if (requestId !== latestRequestId) return;
       if (data.value) {
         data.value = merge(data.value, nextData);
       } else {
         data.value = nextData;
       }
     } catch (e) {
+      if (requestId !== latestRequestId) return;
       error.value = e instanceof Error ? e : new Error(String(e));
     } finally {
-      loading.value = false;
+      if (requestId === latestRequestId) loading.value = false;
     }
   }
 

--- a/frontend/src/pages/companies/CompanyFormPage.vue
+++ b/frontend/src/pages/companies/CompanyFormPage.vue
@@ -5,7 +5,7 @@
     label="Company"
     plural-label="companies"
     :is-editing="isEditing"
-    :loading="isEditing && loading && !data"
+    :loading="isEditing && loading"
     :submitting="submitting"
     :submit-error="submitError"
     :cancel-to="isEditing ? `/companies/${companyId}` : '/companies'"

--- a/frontend/src/pages/engines/EngineFormPage.vue
+++ b/frontend/src/pages/engines/EngineFormPage.vue
@@ -5,7 +5,7 @@
     label="Engine"
     plural-label="engines"
     :is-editing="isEditing"
-    :loading="isEditing && loading && !data"
+    :loading="isEditing && loading"
     :submitting="submitting"
     :submit-error="submitError"
     :cancel-to="isEditing ? `/engines/${engineId}` : '/engines'"

--- a/frontend/src/pages/games/GameFormPage.vue
+++ b/frontend/src/pages/games/GameFormPage.vue
@@ -9,7 +9,7 @@
         <template v-else>
           <h1 class="title">{{ isEditing ? "Edit Game" : "New Game" }}</h1>
 
-          <div v-if="isEditing && gameLoading && !gameData" class="has-text-centered py-5">
+          <div v-if="isEditing && gameLoading" class="has-text-centered py-5">
             <p>Loading game...</p>
           </div>
 
@@ -17,7 +17,10 @@
             <p>Failed to load game: {{ gameError.message }}</p>
           </div>
 
-          <form v-if="!isEditing || gameData" @submit.prevent="handleSubmit">
+          <!-- `gameData` still holds the previously loaded game while a refetch
+               for a new id is in flight, so gate on `gameLoading` too or the
+               form renders with the wrong record's values. -->
+          <form v-if="!isEditing || (gameData && !gameLoading)" @submit.prevent="handleSubmit">
             <!-- Name -->
             <div class="field">
               <label class="label" for="game-name">Name <span class="has-text-danger">*</span></label>

--- a/frontend/src/pages/genres/GenreFormPage.vue
+++ b/frontend/src/pages/genres/GenreFormPage.vue
@@ -5,7 +5,7 @@
     label="Genre"
     plural-label="genres"
     :is-editing="isEditing"
-    :loading="isEditing && loading && !data"
+    :loading="isEditing && loading"
     :submitting="submitting"
     :submit-error="submitError"
     :cancel-to="isEditing ? `/genres/${genreId}` : '/genres'"

--- a/frontend/src/pages/platforms/PlatformFormPage.vue
+++ b/frontend/src/pages/platforms/PlatformFormPage.vue
@@ -5,7 +5,7 @@
     label="Platform"
     plural-label="platforms"
     :is-editing="isEditing"
-    :loading="isEditing && loading && !data"
+    :loading="isEditing && loading"
     :submitting="submitting"
     :submit-error="submitError"
     :cancel-to="isEditing ? `/platforms/${platformId}` : '/platforms'"

--- a/frontend/src/pages/series/SeriesFormPage.vue
+++ b/frontend/src/pages/series/SeriesFormPage.vue
@@ -5,7 +5,7 @@
     label="Series"
     plural-label="series"
     :is-editing="isEditing"
-    :loading="isEditing && loading && !data"
+    :loading="isEditing && loading"
     :submitting="submitting"
     :submit-error="submitError"
     :cancel-to="isEditing ? `/series/${seriesId}` : '/series'"

--- a/frontend/src/pages/stores/StoreFormPage.vue
+++ b/frontend/src/pages/stores/StoreFormPage.vue
@@ -5,7 +5,7 @@
     plural-label="stores"
     :with-wikidata-id="false"
     :is-editing="isEditing"
-    :loading="isEditing && loading && !data"
+    :loading="isEditing && loading"
     :submitting="submitting"
     :submit-error="submitError"
     :cancel-to="isEditing ? `/stores/${storeId}` : '/stores'"


### PR DESCRIPTION
Follows up on [Copilot's review of #4650](https://github.com/connorshea/vglist/pull/4650#pullrequestreview-4890633852).

## The bug

`useQuery` only assigns `data` once a request resolves and never clears it, so during a refetch triggered by a variables change it still holds the *previously loaded* record. The form pages gated their loading state on `isEditing && loading && !data`, and that `!data` term is false during a refetch — so navigating straight from one `/:id/edit` route to another renders the form with the wrong record's values.

That window isn't only cosmetic. Submit takes the id from the route but the name from the form state, so saving during it calls `updatePlatform(platformId: 2, name: <platform 1's name>)` and **silently renames the wrong record**.

Reaching it takes a direct edit→edit navigation, which nothing in the UI links, so in practice it needs browser history navigation. Low odds, but the failure mode is bad enough to be worth closing.

## Changes

**1. `useQuery` request sequencing.** Requests are now numbered, and responses, errors, and loading-flag clears from any superseded request are discarded. Without this, two in-flight requests race and whichever the server answers last wins — which may be the older one, leaving stale data on screen with *no* loading indicator at all. Copilot's suggested fix alone doesn't close this. Applies to `fetchMore` too, which shares the counter, and covers all 22 reactive-variable call sites rather than just the forms.

**2. The seven form pages** drop the `!data` term, so the loader shows during any refetch while editing.

**3. `GameFormPage` needed a second fix.** Its form is an independent `v-if="!isEditing || gameData"` rather than a `v-else` of the loader, so the loader and the stale form would otherwise render *simultaneously* — the one-line fix that works for the other six isn't enough here. It had the same latent bug as the six pages in #4650 but wasn't in that diff, so it wasn't flagged.

## Deliberately not changed

The ~20 list and show pages using the same `loading && !data` idiom. Keeping results on screen while paginating is reasonable there, and they're display-only, so there's no wrong-write risk. The sequencing fix covers their race either way.

## Test plan

- [x] New `useGraphQL.test.ts`: 4 cases covering out-of-order responses, the loading flag across a superseded request, superseded errors, and a regression guard that real errors still surface.
- [x] The 3 sequencing cases confirmed to **fail without the fix** (`git stash push -- useGraphQL.ts` → exactly those 3 fail).
- [x] `pnpm test` — 59 passed across 9 files
- [x] `typecheck`, `lint`, `fmt:check`, `build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)