### PR TITLE
Fix quadratic complexity in the Steam import reconciliation

### DIFF
--- a/app/services/steam_import_service.rb
+++ b/app/services/steam_import_service.rb
@@ -30,7 +30,7 @@ class SteamImportService
 
     raise NoGamesError if games.nil?
 
-    blocklisted_steam_app_ids = SteamBlocklist.pluck(:steam_app_id)
+    blocklisted_steam_app_ids = SteamBlocklist.pluck(:steam_app_id).to_set
 
     # Filter out games with no icon, as they tend to be random server software and such.
     games.reject! { |game| game['img_icon_url'].blank? }
@@ -48,6 +48,12 @@ class SteamImportService
     end
     # Get a list of Steam IDs that weren't found in the vglist database.
     missing_ids = steam_ids.to_set - matching_app_and_game_ids.map(&:first).to_set
+    # Index the games by their Steam App ID so the unmatched games can be looked
+    # up in constant time rather than by scanning the whole array for each one.
+    # The first game wins for any duplicated app ID, matching `Array#find`.
+    games_by_app_id = games.each_with_object({}) do |game, hash|
+      hash[game['appid']] = game unless hash.key?(game['appid'])
+    end
 
     create_time = Time.current
 
@@ -85,7 +91,7 @@ class SteamImportService
     updated_purchases = GamePurchase.where(id: updated.pluck('id'))
 
     unmatched = missing_ids.to_a.filter_map do |id|
-      game = games.find { |g| g['appid'] == id }
+      game = games_by_app_id[id]
 
       next unless game
 

--- a/lib/tasks/import/steam.rake
+++ b/lib/tasks/import/steam.rake
@@ -37,10 +37,10 @@ namespace :import do
 
     # Games with no Steam App IDs.
     games_without_steam_ids = Game.left_outer_joins(:steam_app_ids).where(steam_app_ids: { id: nil })
-    blocklisted_steam_app_ids = SteamBlocklist.pluck(:steam_app_id)
+    # Sets give O(1) membership checks against the games from Wikidata.
+    blocklisted_steam_app_ids = SteamBlocklist.pluck(:steam_app_id).to_set
 
-    valid_wikidata_ids = games_without_steam_ids.pluck(:wikidata_id)
-    valid_wikidata_ids.compact!
+    valid_wikidata_ids = games_without_steam_ids.pluck(:wikidata_id).compact.to_set
 
     games_to_modify = games.select { |game| valid_wikidata_ids.include?(game[:wikidata_id].to_i) }
 

--- a/spec/services/steam_import_service_spec.rb
+++ b/spec/services/steam_import_service_spec.rb
@@ -56,5 +56,35 @@ RSpec.describe SteamImportService, type: :service do
     it 'works with update_hours true' do
       expect { SteamImportService.new(user: user, update_hours: true).call }.to change(GamePurchase, :count).by(1)
     end
+
+    context 'when some games are not in the vglist database' do
+      let(:response) do
+        {
+          'response': {
+            'game_count': 3,
+            'games': [
+              { 'appid': 10, 'name': "Counter-Strike", 'playtime_forever': 455, 'img_icon_url': "abc123" },
+              { 'appid': 20, 'name': "Team Fortress Classic", 'playtime_forever': 10, 'img_icon_url': "def456" },
+              { 'appid': 30, 'name': "Day of Defeat", 'playtime_forever': 0, 'img_icon_url': "ghi789" }
+            ]
+          }
+        }
+      end
+
+      it 'returns the unmatched games' do
+        result = SteamImportService.new(user: user, update_hours: false).call
+
+        expect(result.unmatched.map(&:steam_id)).to contain_exactly(20, 30)
+        expect(result.unmatched.map(&:name)).to contain_exactly("Team Fortress Classic", "Day of Defeat")
+      end
+
+      it 'excludes blocklisted games from the unmatched games' do
+        create(:steam_blocklist, steam_app_id: 20)
+
+        result = SteamImportService.new(user: user, update_hours: false).call
+
+        expect(result.unmatched.map(&:steam_id)).to contain_exactly(30)
+      end
+    end
   end
 end


### PR DESCRIPTION
The unmatched-game loop in `SteamImportService` did a full `games.find` scan for every missing Steam App ID, making reconciliation O(M x N) in the size of the imported library. Since `missing_ids` is nearly all of `games` on a database that doesn't yet know most Steam apps, M and N are effectively the same number.

The hash needed to avoid this was already being built two lines above for the matched direction (`matching_app_and_game_ids_hash`), so the quadratic scan looks incidental rather than intended.

### Changes

**`app/services/steam_import_service.rb`**
- Index `games` by app ID once, and replace the `games.find` with a hash lookup. `unless hash.key?` preserves `Array#find`'s first-wins behaviour for duplicate app IDs, and the index is keyed on the raw `game['appid']` so the lookup matches the `==` comparison it replaces.
- Make the blocklist a `Set`, since its `include?` ran inside the same loop.
- Adds specs for the unmatched path, which previously had no coverage at all — one for the unmatched games coming back correctly, one for blocklisted app IDs being excluded.

**`lib/tasks/import/steam.rake`**
- Same pattern in the `import:steam` task: the blocklist was scanned with `include?` once per Wikidata game, as was the `valid_wikidata_ids` list in the `select` that builds the work set. Both are now sets. `import:wikidata_import_games` already loads the same blocklist as a set for exactly this reason; this brings the Steam task in line.

### Measurements

Re-running the reconciliation loop's shape before and after:

| games | before | after |
|---|---|---|
| 4,000 | 0.221s | 0.002s |
| 8,000 | 0.887s | 0.003s |
| 16,000 | 3.604s | 0.007s |
| 32,000 | ~13s (extrapolated) | 0.016s |

Wall time quadrupled per doubling before; it's linear now.

### Testing

`bundle exec rspec spec/services/steam_import_service_spec.rb` — 4 examples, 0 failures. Rubocop clean on all three files.

I did not run the rake tasks — both hit the live Wikidata SPARQL endpoint. Those changes only swap the receiver of `include?`, which is semantically identical for these integer collections.

### Note on scope

This bounds the CPU cost per import but not who you can point an import at. The related concern that `connectSteam` accepts any public vanity URL with no ownership proof — which is what would let someone choose a 30,000-title library to import — is a separate issue and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)