### PR TITLE
Filter the activity feed by profile visibility

### DIFF
--- a/app/graphql/resolvers/activity_resolver.rb
+++ b/app/graphql/resolvers/activity_resolver.rb
@@ -14,17 +14,23 @@ module Resolvers
         Views::NewEvent.recently_created
                        .includes(user: { avatar_attachment: :blob })
                        .joins(:user)
-                       .where(users: { privacy: :public_account })
+                       .where(users: { privacy: :public_account, banned: false })
       when 'following'
-        raise GraphQL::ExecutionError, "You must be logged in to view the following feed." if @context[:current_user].nil?
+        current_user = @context[:current_user]
+        raise GraphQL::ExecutionError, "You must be logged in to view the following feed." if current_user.nil?
 
-        user_ids = @context[:current_user].following.select(:id)
+        # Following a user doesn't grant permanent visibility: the followed
+        # user can go private or get banned afterwards without the
+        # relationship being removed. Filter the followed users through the
+        # same visibility rule the UserPolicy applies, so the feed can't leak
+        # events the policy would withhold.
+        user_ids = current_user.following.visible_to(current_user).select(:id)
         # Build the OR relation first with matching structure on both sides
         # (no includes/order), otherwise ActiveRecord raises ArgumentError:
         # "Relation passed to #or must be structurally compatible". Then
         # layer the includes/order on top of the combined relation.
         Views::NewEvent.where(user_id: user_ids)
-                       .or(Views::NewEvent.where(user_id: @context[:current_user].id))
+                       .or(Views::NewEvent.where(user_id: current_user.id))
                        .includes(user: { avatar_attachment: :blob })
                        .recently_created
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,6 +107,27 @@ class User < ApplicationRecord
       .order(Arel.sql('count(relationships.followed_id) desc nulls last'))
   }
 
+  # Users whose profiles the given viewer is allowed to see. This must stay in
+  # sync with UserPolicy#user_profile_is_visible?, and exists so that queries
+  # returning many users' records (e.g. the activity feed) can apply the same
+  # rule in SQL instead of re-deriving it.
+  scope :visible_to, ->(viewer) {
+    next all if viewer&.admin?
+
+    visible = where(privacy: :public_account, banned: false)
+    next visible if viewer.nil?
+
+    # A viewer can always see themselves, and can see users that follow them
+    # (unless those users have been banned), even if those accounts are private.
+    #
+    # The follower check reads follower_id off `relationships` directly rather
+    # than going through the `followers` association, which would join `users`
+    # a second time; that join makes the planner seq scan the whole users table
+    # instead of probing it by primary key.
+    visible.or(where(id: viewer.id))
+           .or(where(banned: false, id: viewer.passive_relationships.select(:follower_id)))
+  }
+
   # Users have roles that can be used to define what actions they're allowed
   # to perform. Default should be 'member'.
   enum :role, { member: 0, moderator: 1, admin: 2 }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -240,6 +240,54 @@ RSpec.describe User, type: :model do
         expect(User.most_games).to eq([user1, user3, user2])
       end
     end
+
+    context 'with visible_to' do
+      let(:viewer) { create(:user) }
+      let(:public_user) { create(:user) }
+      let(:private_user) { create(:user, :private_account) }
+      let(:banned_user) { create(:user, :banned) }
+
+      it "includes public, unbanned users" do
+        expect(User.visible_to(viewer)).to include(public_user)
+      end
+
+      it "excludes private users" do
+        expect(User.visible_to(viewer)).not_to include(private_user)
+      end
+
+      it "excludes banned users" do
+        expect(User.visible_to(viewer)).not_to include(banned_user)
+      end
+
+      it "includes the viewer themselves, even when private" do
+        viewer.update!(privacy: :private_account)
+        expect(User.visible_to(viewer)).to include(viewer)
+      end
+
+      it "includes private users that follow the viewer" do
+        create(:relationship, follower: private_user, followed: viewer)
+        expect(User.visible_to(viewer)).to include(private_user)
+      end
+
+      it "excludes banned users that follow the viewer" do
+        create(:relationship, follower: banned_user, followed: viewer)
+        expect(User.visible_to(viewer)).not_to include(banned_user)
+      end
+
+      it "excludes private users that the viewer follows" do
+        create(:relationship, follower: viewer, followed: private_user)
+        expect(User.visible_to(viewer)).not_to include(private_user)
+      end
+
+      it "includes everyone for an admin viewer" do
+        expect(User.visible_to(create(:admin))).to include(private_user, banned_user)
+      end
+
+      it "only includes public, unbanned users when there's no viewer" do
+        expect(User.visible_to(nil)).to include(public_user)
+        expect(User.visible_to(nil)).not_to include(private_user, banned_user)
+      end
+    end
   end
 
   describe 'Destructions' do

--- a/spec/requests/api/activity_spec.rb
+++ b/spec/requests/api/activity_spec.rb
@@ -409,6 +409,118 @@ RSpec.describe "Activity API", type: :request do
       expect(usernames).not_to include(private_user.username)
     end
 
+    it "excludes banned users from global activity feed" do
+      banned_user = create(:banned_user)
+      create(:game_purchase, user: banned_user)
+
+      query_string = <<-GRAPHQL
+        query {
+          activity(feedType: GLOBAL) {
+            nodes {
+              user { username }
+            }
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, token: access_token)
+      nodes = result.graphql_dig(:activity, :nodes)
+      usernames = nodes.map { |n| n.dig(:user, :username) }
+
+      expect(usernames).not_to include(banned_user.username)
+    end
+
+    it "excludes a followed user who has since gone private from the following feed" do
+      create(:relationship, follower: user, followed: user2)
+      create(:game_purchase, user: user2)
+      # The follow was created while user2's account was still public, and it
+      # isn't removed when they switch to a private account.
+      user2.update!(privacy: :private_account)
+
+      query_string = <<-GRAPHQL
+        query {
+          activity(feedType: FOLLOWING) {
+            nodes {
+              user { username }
+            }
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, token: access_token)
+      usernames = result.graphql_dig(:activity, :nodes).map { |n| n.dig(:user, :username) }
+
+      expect(usernames).not_to include(user2.username)
+    end
+
+    it "excludes a followed user who has since been banned from the following feed" do
+      create(:relationship, follower: user, followed: user2)
+      create(:game_purchase, user: user2)
+      user2.update!(banned: true)
+
+      query_string = <<-GRAPHQL
+        query {
+          activity(feedType: FOLLOWING) {
+            nodes {
+              user { username }
+            }
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, token: access_token)
+      usernames = result.graphql_dig(:activity, :nodes).map { |n| n.dig(:user, :username) }
+
+      expect(usernames).not_to include(user2.username)
+    end
+
+    it "includes a followed private user that follows the current user back in the following feed" do
+      # UserPolicy#user_profile_is_visible? lets a viewer see a private profile
+      # if that user follows the viewer, so the feed must match.
+      create(:relationship, follower: user, followed: user2)
+      create(:relationship, follower: user2, followed: user)
+      create(:game_purchase, user: user2)
+      user2.update!(privacy: :private_account)
+
+      query_string = <<-GRAPHQL
+        query {
+          activity(feedType: FOLLOWING) {
+            nodes {
+              user { username }
+            }
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, token: access_token)
+      usernames = result.graphql_dig(:activity, :nodes).map { |n| n.dig(:user, :username) }
+
+      expect(usernames).to include(user2.username)
+    end
+
+    it "includes a followed private user's events when the current user is an admin" do
+      admin = create(:confirmed_admin)
+      admin_token = create(:access_token, resource_owner_id: admin.id, application: build(:application, owner: admin))
+      create(:relationship, follower: admin, followed: user2)
+      create(:game_purchase, user: user2)
+      user2.update!(privacy: :private_account)
+
+      query_string = <<-GRAPHQL
+        query {
+          activity(feedType: FOLLOWING) {
+            nodes {
+              user { username }
+            }
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, token: admin_token)
+      usernames = result.graphql_dig(:activity, :nodes).map { |n| n.dig(:user, :username) }
+
+      expect(usernames).to include(user2.username)
+    end
+
     it "returns an error when querying following feed without authentication" do
       query_string = <<-GRAPHQL
         query {


### PR DESCRIPTION
The `following` activity feed built its relation solely from the current user's follow set, and nothing removes a `relationships` row when the followed user goes private or gets banned. A follow created while an account was still public therefore kept leaking that account's events afterwards, even though `UserPolicy#activity?` and `Types::UserType#activity` both refuse the same target.

The `global` feed had a smaller version of the same gap: it filtered on `privacy: :public_account` but not on `banned`, so a banned user whose account was still public stayed in the feed.

### Changes

- New `User.visible_to(viewer)` scope expressing `UserPolicy#user_profile_is_visible?` in SQL: public + unbanned, plus the viewer themselves, plus unbanned users who follow the viewer, and everything for an admin viewer.
- `ActivityResolver` runs the followed-user ids through that scope, and adds `banned: false` to the global branch. The caller's own events are still unioned in unconditionally, and the `.or` structure the existing regression test guards is unchanged.

### Performance

The scope reads `follower_id` off `relationships` directly rather than through the `followers` association. The `followers` version joins `users` a second time, which makes the planner seq scan the whole users table instead of probing it by primary key — measured on a synthetic 50k users / 1M relationships / 500k events dataset, that was 82k shared buffers in the subplan vs 5.5k.

As shipped, the query costs ~1.3% more buffers than before (5,507 vs 5,437): the `users` join was already there, since `following` is a `has_many :through`, so the fix only adds predicates to a row Postgres was already fetching by primary key, plus one uncorrelated subplan on `index_relationships_on_followed_id`.

### Tests

Five request specs (followed-then-private excluded, followed-then-banned excluded, banned excluded from global, mutual-follow private user still included, admin still sees everything) and nine model specs for the scope. The three "excludes" specs were verified to fail against the previous resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)