### PR TITLE
Fix quadratic complexity in the Wikidata and IGDB import tasks

### DIFF
--- a/lib/tasks/import/igdb.rake
+++ b/lib/tasks/import/igdb.rake
@@ -85,7 +85,11 @@ namespace :import do
     # Limit logging in production to allow the progress bar to work.
     Rails.logger.level = 2 if Rails.env.production?
 
-    igdb_games = []
+    # IGDB results indexed by slug, so the per-game lookup below is a constant
+    # time hit rather than a scan of every result fetched so far. The first
+    # result wins for any duplicated slug, matching the `Array#find` it
+    # replaces.
+    igdb_games_by_slug = {}
 
     puts "Getting game information from IGDB..."
 
@@ -121,8 +125,11 @@ namespace :import do
         end
       end
 
-      igdb_games.concat(igdb_response)
-      igdb_games.compact!
+      igdb_response.compact.each do |igdb_game|
+        slug = igdb_game['slug']
+        igdb_games_by_slug[slug] = igdb_game unless igdb_games_by_slug.key?(slug)
+      end
+
       # Sleep to prevent the rate limiter from killing us.
       sleep 1
     end
@@ -136,8 +143,8 @@ namespace :import do
     cover_added_count = 0
 
     games.each do |game|
-      # Find the IGDB cover URL from igdb_games for this game record.
-      igdb_game = igdb_games.find { |g| g['slug'] == game[:igdb_id] }
+      # Find the IGDB cover URL from the IGDB results for this game record.
+      igdb_game = igdb_games_by_slug[game[:igdb_id]]
 
       if igdb_game.nil?
         progress_bar.log "#{game[:name].ljust(40)} | No cover found for the game's IGDB ID."

--- a/lib/tasks/import/update.rake
+++ b/lib/tasks/import/update.rake
@@ -42,8 +42,9 @@ namespace :import do
     task series: :environment do
       puts "Adding game series' from Wikidata to games."
 
-      # Get all games with no series that have Wikidata IDs.
-      games_with_no_series = Game.where(series_id: nil).where.not(wikidata_id: nil).pluck(:wikidata_id)
+      # Get all games with no series that have Wikidata IDs. A set, because
+      # this is membership-tested once per Wikidata row below.
+      games_with_no_series = Game.where(series_id: nil).where.not(wikidata_id: nil).pluck(:wikidata_id).to_set
 
       rows = get_rows(games_with_series_query).map(&:to_h)
 
@@ -193,8 +194,9 @@ namespace :import do
 
     puts "Adding game #{property_name.pluralize} from Wikidata to games."
 
-    # Get all games that have Wikidata IDs.
-    games = Game.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    # Get all games that have Wikidata IDs. A set, because this is
+    # membership-tested once per Wikidata row below.
+    games = Game.where.not(wikidata_id: nil).pluck(:wikidata_id).to_set
 
     # This has to use send because methods in Rake tasks are private by default.
     rows = get_rows(send("games_with_#{property_name.pluralize}_query")).map(&:to_h)

--- a/lib/tasks/import/wikidata_import.rake
+++ b/lib/tasks/import/wikidata_import.rake
@@ -25,7 +25,7 @@ namespace 'import:wikidata' do
     companies.uniq! { |company| company&.dig(:wikidata_id) }
 
     # Filter companies that are already represented in the vglist database.
-    wikidata_ids_in_db = Company.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    wikidata_ids_in_db = Company.where.not(wikidata_id: nil).pluck(:wikidata_id).to_set
     companies = companies.reject { |company| wikidata_ids_in_db.include?(company[:wikidata_id].delete('Q').to_i) }
 
     puts
@@ -77,7 +77,7 @@ namespace 'import:wikidata' do
     platforms.uniq! { |platform| platform&.dig(:wikidata_id) }
 
     # Filter platforms that are already represented in the vglist database.
-    wikidata_ids_in_db = Platform.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    wikidata_ids_in_db = Platform.where.not(wikidata_id: nil).pluck(:wikidata_id).to_set
     platforms = platforms.reject { |platform| wikidata_ids_in_db.include?(platform[:wikidata_id].delete('Q').to_i) }
 
     puts
@@ -129,7 +129,7 @@ namespace 'import:wikidata' do
     genres.uniq! { |genre| genre&.dig(:wikidata_id) }
 
     # Filter genres that are already represented in the vglist database.
-    wikidata_ids_in_db = Genre.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    wikidata_ids_in_db = Genre.where.not(wikidata_id: nil).pluck(:wikidata_id).to_set
     genres = genres.reject { |genre| wikidata_ids_in_db.include?(genre[:wikidata_id].delete('Q').to_i) }
 
     progress_bar_for_filter.finish unless progress_bar_for_filter.finished?
@@ -182,7 +182,7 @@ namespace 'import:wikidata' do
     series.uniq! { |s| s&.dig(:wikidata_id) }
 
     # Filter series that are already represented in the vglist database.
-    wikidata_ids_in_db = Series.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    wikidata_ids_in_db = Series.where.not(wikidata_id: nil).pluck(:wikidata_id).to_set
     series = series.reject { |srs| wikidata_ids_in_db.include?(srs[:wikidata_id].delete('Q').to_i) }
 
     puts
@@ -235,7 +235,7 @@ namespace 'import:wikidata' do
     engines.uniq! { |engine| engine&.dig(:wikidata_id) }
 
     # Filter engines that are already represented in the vglist database.
-    wikidata_ids_in_db = Engine.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    wikidata_ids_in_db = Engine.where.not(wikidata_id: nil).pluck(:wikidata_id).to_set
     engines = engines.reject { |engine| wikidata_ids_in_db.include?(engine[:wikidata_id].delete('Q').to_i) }
 
     puts


### PR DESCRIPTION
Follow-up to #4654, which fixed the same class of problem in the Steam import. Found four more instances of it in the import rake tasks.

Several tasks membership-test a plucked ID array once per Wikidata row, making them O(M × N) over collections that are both tens of thousands of rows.

### `import:update` (`update.rake`)

`add_props_to_games` plucks every game's `wikidata_id` into a plain array and then scans it for each row of the SPARQL response. This is the worst of the group — it's the largest collection *and* the highest multiplicity, since `add_props_to_games` runs six times per `import:update` (platforms, genres, engines, developers, publishers, series). `import:update:series` has the same shape against a smaller array.

### `import:wikidata:*` (`wikidata_import.rake`)

Five identical instances — companies, platforms, genres, series, engines — each plucking existing IDs into an array and then `reject`ing against it with `include?`. Companies is the biggest, since its rows are the developers and publishers queries concatenated.

`wikidata_import_games.rake` already loads the equivalent collections as sets, with a comment explaining exactly why; this brings the rest in line.

### `import:igdb:covers` (`igdb.rake`)

A different flavour of the same problem: the task accumulated every batch of API results into one growing array, then scanned the whole thing once per game to find the matching slug. Now indexed by slug as the batches arrive. Note this task is wall-clock-dominated by its `sleep 1` per batch, so the win here is CPU only.

## On correctness

The seven `Array` → `Set` conversions are behaviour-preserving: each converted variable is used *only* for the membership test, and `wikidata_id` is a `bigint` on both sides of every comparison (all comparands go through `.to_i`), so the `==` vs `eql?` distinction between `Array#include?` and `Set#include?` has nothing to bite on — that gap needs a float.

The IGDB change is the only real restructuring. `unless hash.key?(slug)` preserves `Array#find`'s first-wins behaviour for duplicate slugs, matching the guard used in #4654.

## Testing

Rubocop is clean and `spec/tasks/import_covers_spec.rb` passes (it loads every rake file, so it covers the load path).

Worth flagging: `import:igdb:covers` has no test coverage — the existing task spec only covers the PCGamingWiki cover task — so the IGDB change is verified by inspection rather than by a test. Stubbing Twitch auth plus the IGDB API to cover it is a reasonable follow-up if we want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
