### PR TITLE
Hide private and banned users from a game's owners and favoriters

### DIFF
--- a/app/graphql/types/game_type.rb
+++ b/app/graphql/types/game_type.rb
@@ -27,7 +27,7 @@ module Types
     field :engines, EngineType.connection_type, null: false, description: "Game engines that the game runs on."
     field :genres, GenreType.connection_type, null: false, description: "Genres of the game."
     field :platforms, PlatformType.connection_type, null: false, description: "Platforms the game is available on."
-    field :owners, UserType.connection_type, null: false, method: :purchasers, description: "Users who have this game in their libraries."
+    field :owners, UserType.connection_type, null: false, description: "Users who have this game in their libraries."
     field :favoriters, UserType.connection_type, null: false, description: "Users who have favorited this game."
 
     field :cover_url, String, null: true, description: "URL for the game's cover image. `null` means the game has no associated cover." do
@@ -37,6 +37,20 @@ module Types
     field :is_favorited, Boolean, null: true, resolver_method: :favorited?, description: "Whether the game is in the current user's favorites, or `null` if there is no logged-in user."
     field :is_in_library, Boolean, null: true, resolver_method: :in_library?, description: "Whether the game is in the current user's library, or `null` if there is no logged-in user."
     field :game_purchase_id, ID, null: true, description: 'The ID of the GamePurchase record if the game is in the current user\'s library, or `null` otherwise.'
+
+    # These two connections are the inverse of `User#gamePurchases` and
+    # `User#favoritedGames`, which UserType hides for private and banned users.
+    # Without the same filter here they can be used to answer "does this
+    # private/banned user own or like this game?". These are a public "who else
+    # plays this" list, so they're restricted to public, unbanned accounts for
+    # everyone, rather than being tailored to the viewer.
+    def owners
+      @object.purchasers.public_and_unbanned
+    end
+
+    def favoriters
+      @object.favoriters.public_and_unbanned
+    end
 
     # Get the number of purchases for the game where rating is not nil.
     def rating_count

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,6 +107,11 @@ class User < ApplicationRecord
       .order(Arel.sql('count(relationships.followed_id) desc nulls last'))
   }
 
+  # Users whose profiles anyone can see, i.e. the first clause of
+  # UserPolicy#user_profile_is_visible?. Use this for listings that are the same
+  # for every viewer; use `visible_to` when the viewer's own carve-outs apply.
+  scope :public_and_unbanned, -> { where(privacy: :public_account, banned: false) }
+
   # Users whose profiles the given viewer is allowed to see. This must stay in
   # sync with UserPolicy#user_profile_is_visible?, and exists so that queries
   # returning many users' records (e.g. the activity feed) can apply the same
@@ -114,7 +119,7 @@ class User < ApplicationRecord
   scope :visible_to, ->(viewer) {
     next all if viewer&.admin?
 
-    visible = where(privacy: :public_account, banned: false)
+    visible = public_and_unbanned
     next visible if viewer.nil?
 
     # A viewer can always see themselves, and can see users that follow them

--- a/spec/requests/api/games/game_spec.rb
+++ b/spec/requests/api/games/game_spec.rb
@@ -317,6 +317,49 @@ RSpec.describe "Game query API", type: :request do
       end
     end
 
+    context 'with owners and favoriters that the current user cannot see' do
+      let(:private_user) { create(:private_user) }
+      let(:banned_user) { create(:banned_user) }
+      let(:admin) { create(:confirmed_admin) }
+      let(:admin_application) { build(:application, owner: admin) }
+      let(:admin_access_token) { create(:access_token, resource_owner_id: admin.id, application: admin_application) }
+      let(:query_string) do
+        <<-GRAPHQL
+          query($id: ID!) {
+            game(id: $id) {
+              owners { totalCount nodes { id } }
+              favoriters { totalCount nodes { id } }
+            }
+          }
+        GRAPHQL
+      end
+
+      before(:each) do
+        [private_user, banned_user, user].each do |u|
+          create(:game_purchase, user: u, game: game)
+          create(:favorite_game, user: u, game: game)
+        end
+      end
+
+      it "hides private and banned users from the owners and favoriters connections" do
+        result = api_request(query_string, variables: { id: game.id }, token: access_token)
+
+        expect(result.graphql_dig(:game, :owners)).to eq(
+          { totalCount: 1, nodes: [{ id: user.id.to_s }] }
+        )
+        expect(result.graphql_dig(:game, :favoriters)).to eq(
+          { totalCount: 1, nodes: [{ id: user.id.to_s }] }
+        )
+      end
+
+      it "hides them from admins too, since these connections aren't viewer-specific" do
+        result = api_request(query_string, variables: { id: game.id }, token: admin_access_token)
+
+        expect(result.graphql_dig(:game, :owners, :total_count)).to eq(1)
+        expect(result.graphql_dig(:game, :favoriters, :total_count)).to eq(1)
+      end
+    end
+
     context 'with the current user having favorited the game' do
       let(:favorite_game) { create(:favorite_game, game: game, user: user) }
       let(:query_string) do


### PR DESCRIPTION
`GameType#owners` and `#favoriters` returned every user with a matching library or favorite row, unfiltered. That's the exact inverse of `UserType#gamePurchases` / `#favoritedGames`, which are gated behind `UserPolicy#show?` — so `user(id: X) { gamePurchases }` returned `[]` for a private or banned account, while `game(id: Y) { owners }` answered "does X own Y?" for any Y, to an anonymous caller. #4642 swept this class of gap on `UserType` but didn't touch these two fields, and the only spec covering them used a default (public) user.

These connections back the avatar stack in `GameSidebar.vue` — a public "who else plays this" list that isn't tailored to the viewer — so they're filtered to public, unbanned accounts for *everyone* rather than running the viewer-specific `visible_to` rule. There's no real value in an admin (or a private user themselves) seeing banned accounts in that stack.

- Adds a `User.public_and_unbanned` scope, extracted from the first clause of `visible_to`.
- `owners` / `favoriters` now apply it, which also drops the hidden users from `totalCount`.
- Request specs cover the private/banned exclusion, including for admins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)