### PR TITLE
Escape steam_username in the Steam ResolveVanityURL request

### DIFF
--- a/app/graphql/mutations/users/connect_steam.rb
+++ b/app/graphql/mutations/users/connect_steam.rb
@@ -12,9 +12,23 @@ class Mutations::Users::ConnectSteam < Mutations::BaseMutation
     user = User.find(user_id)
 
     # Resolve the numerical Steam ID based on the provided username.
-    uri = URI("https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/?key=#{ENV['STEAM_WEB_API_KEY']}&vanityurl=#{steam_username}")
+    #
+    # The username is user-provided, so it has to be escaped rather than
+    # interpolated into the query string, otherwise the user can append or
+    # override parameters on a request that carries our Steam Web API key.
+    uri = URI("https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/")
+    uri.query = URI.encode_www_form(
+      key: ENV['STEAM_WEB_API_KEY'],
+      vanityurl: steam_username
+    )
+
     response = Net::HTTP.get_response(uri)
-    json = JSON.parse(response.body)
+
+    begin
+      json = JSON.parse(response.body)
+    rescue JSON::ParserError
+      raise GraphQL::ExecutionError, 'The Steam API returned an unexpected response.'
+    end
 
     steam_id = json.dig("response", "steamid")
 
@@ -24,7 +38,7 @@ class Mutations::Users::ConnectSteam < Mutations::BaseMutation
     # If not, create it and pass in the steam_id and steam_profile_url.
     @steam_account = ExternalAccount.create_with(
       steam_id: steam_id,
-      steam_profile_url: "https://steamcommunity.com/id/#{steam_username}/"
+      steam_profile_url: "https://steamcommunity.com/id/#{ERB::Util.url_encode(steam_username)}/"
     ).find_or_create_by!(
       user_id: user.id,
       account_type: :steam

--- a/spec/requests/api/mutations/users/connect_steam_spec.rb
+++ b/spec/requests/api/mutations/users/connect_steam_spec.rb
@@ -77,6 +77,41 @@ RSpec.describe "ConnectSteam Mutation API", type: :request do
           )
         end.to change(ExternalAccount, :count).by(1)
       end
+
+      it "escapes the username rather than letting it inject query parameters" do
+        api_request(query_string, variables: { id: user.id, steam_username: 'foobar&key=attacker&format=xml' }, token: access_token)
+
+        expect(WebMock).to have_requested(:get, 'https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/')
+          .with(query: { 'key' => 'foo', 'vanityurl' => 'foobar&key=attacker&format=xml' })
+        expect(ExternalAccount.last.steam_profile_url).to eq('https://steamcommunity.com/id/foobar%26key%3Dattacker%26format%3Dxml/')
+      end
+
+      it "handles a non-ASCII username without raising" do
+        expect do
+          result = api_request(query_string, variables: { id: user.id, steam_username: 'connörshea' }, token: access_token)
+          expect(result.graphql_dig(:connect_steam)).to eq(
+            {
+              connected: true
+            }
+          )
+        end.to change(ExternalAccount, :count).by(1)
+
+        expect(WebMock).to have_requested(:get, 'https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/')
+          .with(query: { 'key' => 'foo', 'vanityurl' => 'connörshea' })
+      end
+
+      it "returns an error when the Steam API returns a non-JSON response" do
+        stub_request(:get, /api\.steampowered\.com/).to_return(
+          status: 200,
+          body: '<?xml version="1.0"?><response><steamid>123</steamid></response>',
+          headers: {}
+        )
+
+        expect do
+          result = api_request(query_string, variables: { id: user.id, steam_username: 'foobar' }, token: access_token)
+          expect(result.to_h['errors'].first['message']).to eq('The Steam API returned an unexpected response.')
+        end.not_to change(ExternalAccount, :count)
+      end
     end
   end
 end


### PR DESCRIPTION
The `connectSteam` mutation interpolated the user-supplied `steam_username` straight into the Steam Web API query string:

```ruby
uri = URI("https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/?key=#{ENV['STEAM_WEB_API_KEY']}&vanityurl=#{steam_username}")
```

`URI()` leaves `&` and `=` untouched, so any member could append or override parameters on an outbound request made with our `STEAM_WEB_API_KEY` — e.g. `foobar&format=xml` produced `...&vanityurl=foobar&format=xml`. The host and path are literal prefixes, so this isn't SSRF and the key can't be exfiltrated, but it also caused two unhandled exceptions that surface as 500s: a non-ASCII username (`connörshea`) raised `URI::InvalidURIError`, and a non-JSON response raised `JSON::ParserError`.

Changes:

- Build the query with `URI.encode_www_form`, matching the idiom already used in `lib/tasks/import/igdb.rake`. This also fixes the non-ASCII case — the username is percent-encoded instead of raising.
- Escape the username in the stored `steam_profile_url` with `ERB::Util.url_encode` so it can't carry path or query segments.
- Rescue `JSON::ParserError` into a `GraphQL::ExecutionError` instead of a 500.

Three specs added; all three fail against the unpatched mutation and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)