### PR TITLE
Bound the globalSearch searchableTypes list

### DIFF
--- a/app/graphql/resolvers/global_search_resolver.rb
+++ b/app/graphql/resolvers/global_search_resolver.rb
@@ -12,10 +12,18 @@ module Resolvers
       reason to send a request for every letter a user types.
     MARKDOWN
 
+    # Every searchable type, used as the default when the client doesn't
+    # specify any. Also the upper bound on the length of `searchable_types`,
+    # since asking for more than one of each type is meaningless.
+    DEFAULT_SEARCHABLE_TYPES = %w[Game Series Company Platform Engine Genre User].freeze
+
     argument :query, String, required: true, description: 'The query to search for records with.'
     argument :searchable_types, [Types::Enums::SearchableEnum], required: false do
-      description 'The types of records that multisearch should return. By default, it will return all types of searchable records.'
-      validates length: { minimum: 1 }
+      description 'The types of records that multisearch should return. By default, it will return all types of searchable records. Duplicate types are ignored.'
+      # `resolve` runs one full-text query per type, so cap the list at the
+      # number of types that exist. Duplicates within that cap are deduped
+      # below, so a request can never issue more than one query per type.
+      validates length: { minimum: 1, maximum: DEFAULT_SEARCHABLE_TYPES.length }
     end
 
     # Limit results per type to ensure type diversity. Without this,
@@ -23,8 +31,8 @@ module Resolvers
     # out all other types.
     MAX_RESULTS_PER_TYPE = 25
 
-    def resolve(query:, searchable_types: %w[Game Series Company Platform Engine Genre User])
-      results = searchable_types.flat_map do |type|
+    def resolve(query:, searchable_types: DEFAULT_SEARCHABLE_TYPES)
+      results = searchable_types.uniq.flat_map do |type|
         PgSearch.multisearch(query)
                 .where(searchable_type: type)
                 .limit(MAX_RESULTS_PER_TYPE)

--- a/spec/requests/api/global_search_spec.rb
+++ b/spec/requests/api/global_search_spec.rb
@@ -168,6 +168,59 @@ RSpec.describe "Global Search API", type: :request do
         expect(nodes.length).to eq(1)
         expect(nodes.first[:searchableId]).to eq(platform.id.to_s)
       end
+
+      it "only searches each type once when a type is repeated" do
+        query_string = <<-GRAPHQL
+          query($query: String!, $types: [SearchableEnum!]) {
+            globalSearch(query: $query, searchableTypes: $types) {
+              nodes {
+                ... on GameSearchResult {
+                  searchableId
+                }
+              }
+            }
+          }
+        GRAPHQL
+
+        allow(PgSearch).to receive(:multisearch).and_call_original
+
+        result = api_request(query_string, variables: { query: 'Searchable', types: ['GAME', 'GAME', 'GAME'] }, token: access_token)
+        nodes = result.graphql_dig(:global_search, :nodes)
+
+        expect(PgSearch).to have_received(:multisearch).once
+        expect(nodes.length).to eq(1)
+        expect(nodes.first[:searchableId]).to eq(game.id.to_s)
+      end
+
+      it "rejects a list with more entries than there are searchable types" do
+        query_string = <<-GRAPHQL
+          query($query: String!, $types: [SearchableEnum!]) {
+            globalSearch(query: $query, searchableTypes: $types) {
+              nodes {
+                __typename
+              }
+            }
+          }
+        GRAPHQL
+
+        types = ['GAME'] * (Resolvers::GlobalSearchResolver::DEFAULT_SEARCHABLE_TYPES.length + 1)
+
+        allow(PgSearch).to receive(:multisearch).and_call_original
+
+        result = api_request(query_string, variables: { query: 'Searchable', types: types }, token: access_token)
+
+        expect(PgSearch).not_to have_received(:multisearch)
+        expect(api_result_errors(result)).to include(
+          "searchableTypes is too long (maximum is #{Resolvers::GlobalSearchResolver::DEFAULT_SEARCHABLE_TYPES.length})"
+        )
+      end
+    end
+
+    context 'with the default searchable types' do
+      it "matches the values of the SearchableEnum" do
+        expect(Resolvers::GlobalSearchResolver::DEFAULT_SEARCHABLE_TYPES)
+          .to match_array(Types::Enums::SearchableEnum.values.each_value.map(&:value))
+      end
     end
 
     context 'with per-type result limits' do


### PR DESCRIPTION
`searchable_types` on `Resolvers::GlobalSearchResolver` validated a minimum length of 1 but no maximum, and `resolve` issued one `PgSearch.multisearch` full-text query per element of the list. GraphQL doesn't de-duplicate list arguments, so a single anonymous `POST /graphql` could repeat an enum value arbitrarily many times and multiply itself into that many scans of `pg_search_documents` — a 600 KB request body produces 100,000 queries with no validation error.

Nothing upstream bounds it: `max_depth` counts selection nesting, `max_complexity` scores fields rather than argument arity, and the field's `max_page_size: 200` caps what's *returned*, after the work is already done.

Two changes, so neither is solely load-bearing:

- `validates length: { minimum: 1, maximum: DEFAULT_SEARCHABLE_TYPES.length }` rejects an oversized list before any query runs.
- `searchable_types.uniq.flat_map` dedupes, so even a valid list issues at most one full-text query per type.

The previously inline default list is now the `DEFAULT_SEARCHABLE_TYPES` constant, which does double duty as the bound.

## Tests

- `[GAME, GAME, GAME]` calls `PgSearch.multisearch` exactly once and still returns the game.
- An 8-element list errors with `searchableTypes is too long (maximum is 7)` and never reaches `multisearch`.
- A guard that `DEFAULT_SEARCHABLE_TYPES` matches `SearchableEnum`'s values, so the cap can't silently drift when a searchable type is added.

`bundle exec rspec spec/requests/api/global_search_spec.rb` — 13 examples, 0 failures. `bundle exec rubocop --cache false` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)