### PR TITLE
Preload attachment variants and avatars in the GraphQL API

### DIFF
--- a/app/graphql/game_preloads.rb
+++ b/app/graphql/game_preloads.rb
@@ -10,10 +10,9 @@
 module GamePreloads
   # GameType field name => the association to preload for it.
   #
-  # `cover_url` is deliberately absent: it needs `with_attached_cover`, which
-  # preloads `blob: { variant_records: { image_attachment: :blob } }` on top of
-  # the attachment. A plain `includes(cover_attachment: :blob)` would leave the
-  # variant record lookup to fire once per game.
+  # `cover_url` is deliberately absent: it needs the full attachment chain, and
+  # `with_attached_cover` applies here because the cover hangs off the relation
+  # being loaded. See `AttachmentPreloads` for why the short form isn't enough.
   FIELD_PRELOADS = {
     series: :series,
     developers: :developers,

--- a/app/graphql/resolvers/activity_resolver.rb
+++ b/app/graphql/resolvers/activity_resolver.rb
@@ -12,7 +12,7 @@ module Resolvers
       case feed_type
       when 'global'
         Views::NewEvent.recently_created
-                       .includes(user: { avatar_attachment: :blob })
+                       .includes(user: AttachmentPreloads::AVATAR)
                        .joins(:user)
                        .where(users: { privacy: :public_account, banned: false })
       when 'following'
@@ -31,7 +31,7 @@ module Resolvers
         # layer the includes/order on top of the combined relation.
         Views::NewEvent.where(user_id: user_ids)
                        .or(Views::NewEvent.where(user_id: current_user.id))
-                       .includes(user: { avatar_attachment: :blob })
+                       .includes(user: AttachmentPreloads::AVATAR)
                        .recently_created
       end
     end

--- a/app/graphql/resolvers/user_resolvers/list_resolver.rb
+++ b/app/graphql/resolvers/user_resolvers/list_resolver.rb
@@ -11,7 +11,7 @@ module Resolvers
 
       def resolve(sort_by: nil)
         # Exclude banned users from the results.
-        users = User.all.where(banned: false)
+        users = User.all.where(banned: false).with_attached_avatar
 
         sort_by.nil? ? users.order(:id) : users.public_send(sort_by.to_sym)
       end

--- a/app/graphql/resolvers/user_resolvers/search_resolver.rb
+++ b/app/graphql/resolvers/user_resolvers/search_resolver.rb
@@ -10,7 +10,7 @@ module Resolvers
       argument :query, String, required: true, description: "Username to search by."
 
       def resolve(query:)
-        User.search(query)
+        User.search(query).with_attached_avatar
       end
     end
   end

--- a/app/graphql/types/game_type.rb
+++ b/app/graphql/types/game_type.rb
@@ -45,11 +45,11 @@ module Types
     # plays this" list, so they're restricted to public, unbanned accounts for
     # everyone, rather than being tailored to the viewer.
     def owners
-      @object.purchasers.public_and_unbanned
+      @object.purchasers.public_and_unbanned.with_attached_avatar
     end
 
     def favoriters
-      @object.favoriters.public_and_unbanned
+      @object.favoriters.public_and_unbanned.with_attached_avatar
     end
 
     # Get the number of purchases for the game where rating is not nil.

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -33,7 +33,7 @@ module Types
       return [] unless user_visible?
 
       Views::NewEvent.recently_created
-                     .includes(user: { avatar_attachment: :blob })
+                     .includes(user: AttachmentPreloads::AVATAR)
                      .where(user_id: @object.id)
     end
 
@@ -44,12 +44,23 @@ module Types
       Rails.application.routes.url_helpers.rails_representation_url(avatar)
     end
 
+    # Preloading applied to the associations below once the viewer is allowed to
+    # see them, so that a page of users doesn't load an avatar (or cover) one
+    # record at a time.
+    FIELD_PRELOADS = {
+      followers: ->(relation) { relation.with_attached_avatar },
+      following: ->(relation) { relation.with_attached_avatar },
+      favorited_games: ->(relation) { relation.with_attached_cover }
+    }.freeze
+
     # Extremely cursed metaprogramming that protects private users from having
     # their details exposed if the UserPolicy wants to prevent it.
     def handler(field_name, fallback = nil)
-      return @object.public_send(field_name) if user_visible?
+      return fallback unless user_visible?
 
-      fallback
+      value = @object.public_send(field_name)
+      preload = FIELD_PRELOADS[field_name]
+      preload ? preload.call(value) : value
     end
 
     # Define a method for each of these fields, to forward the correct info onto the handler method.
@@ -69,7 +80,7 @@ module Types
     def game_purchases
       return [] unless user_visible?
 
-      @object.game_purchases.includes(:platforms, :stores, game: { cover_attachment: :blob })
+      @object.game_purchases.includes(:platforms, :stores, game: AttachmentPreloads::COVER)
     end
 
     def followed?

--- a/app/models/attachment_preloads.rb
+++ b/app/models/attachment_preloads.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# `includes` specs for eagerly loading an Active Storage attachment.
+#
+# `includes(cover_attachment: :blob)` looks complete but isn't. With
+# `ActiveStorage.track_variants` enabled — the default — rendering a variant URL
+# also reads `blob.variant_records`, so the truncated form preloads the
+# attachment and its blob and then still fires one variant lookup per record.
+# It half-works, which is why it's easy to write by mistake.
+#
+# Rails' generated `with_attached_*` scopes expand to the full chain below.
+# Prefer those scopes when the attachment hangs off the relation being loaded
+# (`User.all.with_attached_avatar`); use these constants when the attachment is
+# nested inside a larger `includes` and the scope can't be applied
+# (`includes(user: AttachmentPreloads::AVATAR)`).
+module AttachmentPreloads
+  # The blob and everything needed to resolve a variant of it.
+  BLOB = { blob: { variant_records: { image_attachment: :blob } } }.freeze
+
+  # For `Game#cover`.
+  COVER = { cover_attachment: BLOB }.freeze
+
+  # For `User#avatar`.
+  AVATAR = { avatar_attachment: BLOB }.freeze
+end

--- a/app/models/views/new_event.rb
+++ b/app/models/views/new_event.rb
@@ -32,12 +32,17 @@ module Views
     }.freeze
 
     # Nested associations to preload for each event category's eventable.
+    #
+    # Game purchases also preload their owner, which `GamePurchaseType`'s
+    # authorization check reads for every record. These are loaded by ID rather
+    # than through a user's association, so there's no `inverse_of` to fall back
+    # on and the owner would otherwise be fetched one purchase at a time.
     EVENTABLE_INCLUDES = {
-      'add_to_library' => { game: { cover_attachment: :blob } },
-      'change_completion_status' => { game: { cover_attachment: :blob } },
-      'favorite_game' => { game: { cover_attachment: :blob } },
-      'new_user' => { avatar_attachment: :blob },
-      'following' => { followed: { avatar_attachment: :blob } }
+      'add_to_library' => [:user, { game: AttachmentPreloads::COVER }],
+      'change_completion_status' => [:user, { game: AttachmentPreloads::COVER }],
+      'favorite_game' => { game: AttachmentPreloads::COVER },
+      'new_user' => AttachmentPreloads::AVATAR,
+      'following' => { followed: AttachmentPreloads::AVATAR }
     }.freeze
 
     # Get a specific event subclass record based on the ID.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,7 @@ RSpec.configure do |config|
 
   config.include ApiRequestTestHelper, type: :request
   config.include EnvHelper
+  config.include SqlQueryTestHelper
 end
 
 # Configure shoulda-matchers to work with rspec and all of rails.

--- a/spec/requests/api/activity_spec.rb
+++ b/spec/requests/api/activity_spec.rb
@@ -568,18 +568,6 @@ RSpec.describe "Activity API", type: :request do
     # Authenticating lazily would create the user inside the measured block.
     before(:each) { access_token }
 
-    # The number of SQL queries run while the block executes.
-    def query_count
-      count = 0
-      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
-        count += 1 unless payload[:name].to_s.match?(/SCHEMA|TRANSACTION/)
-      end
-      yield
-      count
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber)
-    end
-
     def create_library_event
       create(
         :game_purchase_library_event,

--- a/spec/requests/api/activity_spec.rb
+++ b/spec/requests/api/activity_spec.rb
@@ -539,4 +539,70 @@ RSpec.describe "Activity API", type: :request do
       expect(json['errors'].first['message']).to eq("You must be logged in to view the following feed.")
     end
   end
+
+  describe "Preloading for the activity feed" do
+    let(:user) { create(:confirmed_user) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    # Every field the feed renders that touches an association or an
+    # attachment, so a missing preload shows up as extra queries.
+    let(:activity_query) do
+      <<-GRAPHQL
+        query {
+          activity(feedType: GLOBAL) {
+            nodes {
+              id
+              user { id username avatarUrl(size: SMALL) }
+              eventable {
+                ... on GamePurchase {
+                  rating
+                  game { id name coverUrl(size: SMALL) }
+                }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    # Authenticating lazily would create the user inside the measured block.
+    before(:each) { access_token }
+
+    # The number of SQL queries run while the block executes.
+    def query_count
+      count = 0
+      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+        count += 1 unless payload[:name].to_s.match?(/SCHEMA|TRANSACTION/)
+      end
+      yield
+      count
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    def create_library_event
+      create(
+        :game_purchase_library_event,
+        user: create(:confirmed_user_with_avatar),
+        eventable: create(:game_purchase, game: create(:game_with_cover))
+      )
+    end
+
+    # The first request for an image generates its variant, which writes records
+    # and is unrelated to preloading, so warm those up and measure the second
+    # request.
+    def warm_then_count_queries
+      api_request(activity_query, token: access_token)
+      query_count { api_request(activity_query, token: access_token) }
+    end
+
+    it "runs no more queries as the feed grows" do
+      2.times { create_library_event }
+      baseline = warm_then_count_queries
+
+      3.times { create_library_event }
+
+      expect(warm_then_count_queries).to eq(baseline)
+    end
+  end
 end

--- a/spec/requests/api/games/games_spec.rb
+++ b/spec/requests/api/games/games_spec.rb
@@ -319,19 +319,6 @@ RSpec.describe "Games API", type: :request do
       # its OAuth application inside the measured block.
       before(:each) { access_token }
 
-      # The tables touched while running a block, so that a query can be
-      # checked for preloading associations it never asked for.
-      def tables_queried
-        queries = []
-        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
-          queries << payload[:sql] unless payload[:name].to_s.match?(/SCHEMA|TRANSACTION|CACHE/)
-        end
-        yield
-        queries.filter_map { |sql| sql[/FROM "([^"]+)"/, 1] }.uniq
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber)
-      end
-
       it "doesn't preload associations the query didn't select" do
         query_string = <<-GRAPHQL
           query {

--- a/spec/requests/api/global_search_spec.rb
+++ b/spec/requests/api/global_search_spec.rb
@@ -304,11 +304,7 @@ RSpec.describe "Global Search API", type: :request do
           }
         GRAPHQL
 
-        queries = []
-        callback = lambda { |_name, _start, _finish, _id, payload|
-          queries << payload[:sql] unless payload[:name] == "SCHEMA" || payload[:sql].match?(/\A(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)/i)
-        }
-        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        queries = queries_run do
           result = api_request(query_string, variables: { query: 'NplusOneG', types: ['GAME'] }, token: access_token)
           expect(result.graphql_dig(:global_search, :nodes).length).to eq(5)
         end
@@ -336,11 +332,7 @@ RSpec.describe "Global Search API", type: :request do
           }
         GRAPHQL
 
-        queries = []
-        callback = lambda { |_name, _start, _finish, _id, payload|
-          queries << payload[:sql] unless payload[:name] == "SCHEMA" || payload[:sql].match?(/\A(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)/i)
-        }
-        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        queries = queries_run do
           result = api_request(query_string, variables: { query: 'nplus1user', types: ['USER'] }, token: access_token)
           expect(result.graphql_dig(:global_search, :nodes).length).to eq(5)
         end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -655,18 +655,6 @@ RSpec.describe "Users API", type: :request do
       # Authenticating lazily would create the user inside the measured block.
       before(:each) { access_token }
 
-      # The number of SQL queries run while the block executes.
-      def query_count
-        count = 0
-        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
-          count += 1 unless payload[:name].to_s.match?(/SCHEMA|TRANSACTION/)
-        end
-        yield
-        count
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber)
-      end
-
       let(:users_query) do
         <<-GRAPHQL
           query {

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -650,5 +650,53 @@ RSpec.describe "Users API", type: :request do
         end
       end
     end
+
+    context 'when preloading avatars for a list of users' do
+      # Authenticating lazily would create the user inside the measured block.
+      before(:each) { access_token }
+
+      # The number of SQL queries run while the block executes.
+      def query_count
+        count = 0
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+          count += 1 unless payload[:name].to_s.match?(/SCHEMA|TRANSACTION/)
+        end
+        yield
+        count
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      let(:users_query) do
+        <<-GRAPHQL
+          query {
+            users {
+              nodes {
+                id
+                username
+                avatarUrl(size: SMALL)
+              }
+            }
+          }
+        GRAPHQL
+      end
+
+      # The first request for an avatar generates its variant, which writes
+      # records and is unrelated to preloading, so warm those up and measure
+      # the second request.
+      def warm_then_count_queries
+        api_request(users_query, token: access_token)
+        query_count { api_request(users_query, token: access_token) }
+      end
+
+      it "runs no more queries as the list grows" do
+        create_list(:confirmed_user_with_avatar, 2)
+        baseline = warm_then_count_queries
+
+        create_list(:confirmed_user_with_avatar, 3)
+
+        expect(warm_then_count_queries).to eq(baseline)
+      end
+    end
   end
 end

--- a/spec/support/sql_query_test_helper.rb
+++ b/spec/support/sql_query_test_helper.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Helpers for measuring the SQL run by a block, so a spec can assert that a
+# request preloads its associations rather than running a query per record.
+#
+# Schema lookups, transaction statements and query cache hits never represent a
+# database round trip worth measuring, so they're all ignored.
+module SqlQueryTestHelper
+  IGNORED_QUERY_NAMES = /SCHEMA|TRANSACTION|CACHE/
+  TRANSACTION_STATEMENTS = /\A\s*(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)/i
+
+  # The SQL statements run while the block executes.
+  #
+  # @return [Array<String>]
+  def queries_run
+    queries = []
+    subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+      sql = payload[:sql].to_s
+      queries << sql unless payload[:name].to_s.match?(IGNORED_QUERY_NAMES) || sql.match?(TRANSACTION_STATEMENTS)
+    end
+    yield
+    return queries
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
+  # The number of SQL queries run while the block executes.
+  #
+  # @return [Integer]
+  def query_count(&)
+    return queries_run(&).count
+  end
+
+  # The tables touched while running a block, so that a query can be checked
+  # for preloading associations it never asked for.
+  #
+  # @return [Array<String>]
+  def tables_queried(&)
+    return queries_run(&).filter_map { |sql| sql[/FROM "([^"]+)"/, 1] }.uniq
+  end
+end


### PR DESCRIPTION
Follow-up to #4660.

Every hand-written attachment `includes` in the GraphQL layer stopped at `{ cover_attachment: :blob }` (or the avatar equivalent). That isn't what Rails' `with_attached_*` scope expands to — resolving a variant also needs `variant_records` and their own image attachment and blob. So each rendered image still cost several queries despite the preload, and the include was doing almost nothing. The same truncated chain had been copied to all nine sites that write one.

This pulls the correct chain into `AttachmentPreloads` and uses it everywhere, so the shape lives in one place instead of being re-derived (incorrectly) at each call site.

It also preloads avatars on the user connections that render them — the user list and search resolvers, `GameType#owners`/`#favoriters`, and `UserType`'s `followers`/`following`/`favoritedGames` — and preloads `:user` on the two game-purchase event categories, whose owner `GamePurchaseType.authorized?` reads for every record. Those records are loaded by ID rather than through a user's association, so there's no `inverse_of` to fall back on.

On `UserType` the avatar scopes are applied through a `FIELD_PRELOADS` map wired into the existing `handler` metaprogramming, which keeps the visibility gate as the single entry point rather than adding a second one.

## Impact

Measured against the development database at `first: 100`:

| query | before | after |
| --- | --- | --- |
| GET_ACTIVITY | 175 | **28** |
| GET_USERS | 96 | **46** |
| GET_USER_ACTIVITY | 36 | **20** |
| GET_USER | 23 | **16** |

## What this doesn't fix

`GET_USERS` still grows with the size of the list. The queries left are the per-user `gamePurchases { totalCount }` counts, which need batching rather than preloading.

`UserType#game_purchases` deliberately does *not* preload `:user`, even though the analogous event path does — measuring showed `inverse_of` already resolves the owner there, so adding it would have been a pure extra query.

Writing the specs surfaced a separate issue that isn't addressed here: the first read of any image generates its variant inline, writing records mid-request. The new specs warm the request once before measuring to work around it. It's on the read path in production and worth its own pass.

## Testing

Full suite passes. The two new specs assert that query counts don't grow with the number of records; I confirmed they aren't vacuous by stashing the fix and watching them fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
