### PR TITLE
Use import.meta.dirname in the Vite configs

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,11 +18,11 @@ export default defineConfig(({ mode }) => {
   return {
     // Serve files from the root public/ directory (favicons, manifest, etc.)
     // so they're available at / in both dev and production builds.
-    publicDir: resolve(__dirname, "../public"),
+    publicDir: resolve(import.meta.dirname, "../public"),
     plugins: [vue()],
     resolve: {
       alias: {
-        "@": resolve(__dirname, "src")
+        "@": resolve(import.meta.dirname, "src")
       }
     },
     server: {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      "@": resolve(__dirname, "src")
+      "@": resolve(import.meta.dirname, "src")
     }
   },
   test: {


### PR DESCRIPTION
## Problem

Every `pnpm --dir=frontend test` run printed:

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vitest.config.ts:9:20). Use `import.meta.dirname` instead
```

Vitest already loads the config through the native loader, where the config is a real ES module and `__dirname` doesn't exist. It currently works only because the config gets bundled first; once `configLoader: 'native'` becomes the default, it breaks rather than warns.

## Fix

Swap `__dirname` for `import.meta.dirname`. `vite.config.ts` uses it the same way in two places — the `@` alias and `publicDir` — so it's fixed there too rather than left to break later.

`import.meta.dirname` has been available since Node 20.11; CI pins Node 24.

## Testing

- `pnpm --dir=frontend test` — 62 tests pass, and the warning is gone.
- `pnpm --dir=frontend run build` (vue-tsc + vite build) succeeds, and the root `public/` files still land in `dist/`, confirming `publicDir` and the `@` alias resolve to the same paths as before.
- oxlint and oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)